### PR TITLE
Better remotes management with `hub fork`

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -232,7 +232,8 @@ module Hub
 
     # $ hub fork
     # ... hardcore forking action ...
-    # > git remote add -f YOUR_USER git@github.com:YOUR_USER/CURRENT_REPO.git
+    # > git config remote.origin.url git@github.com:YOUR_USER/CURRENT_REPO.git
+    # > git remote add -f upstream git@github.com:ORIGINAL_USER/CURRENT_REPO.git
     def fork(args)
       # can't do anything without token and original owner name
       if github_user && github_token && repo_owner
@@ -245,9 +246,11 @@ module Hub
         if args.include?('--no-remote')
           exit
         else
-          url = github_url(:private => true)
-          args.replace %W"remote add -f #{github_user} #{url}"
-          args.after { puts "new remote: #{github_user}" }
+          old_url = origin_url
+          new_url = github_url(:private => true)
+
+          args.replace %W"config remote.origin.url #{new_url}"
+          args.after "git remote add -f upstream #{old_url}"
         end
       end
     end

--- a/lib/hub/context.rb
+++ b/lib/hub/context.rb
@@ -138,5 +138,9 @@ module Hub
         url % [user, repo]
       end
     end
+
+    def origin_url
+      GIT_CONFIG['config remote.origin.url']
+    end
   end
 end

--- a/man/hub.1
+++ b/man/hub.1
@@ -1,7 +1,7 @@
-.\" generated with Ronn/v0.5
-.\" http://github.com/rtomayko/ronn/
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "HUB" "1" "August 2010" "DEFUNKT" "Git Manual"
+.TH "HUB" "1" "October 2010" "DEFUNKT" "Git Manual"
 .
 .SH "NAME"
 \fBhub\fR \- git + hub = github
@@ -25,19 +25,19 @@
 \fBgit remote set\-url\fR [\fB\-p\fR] \fIOPTIONS\fR \fIREMOTE\-NAME\fR \fIUSER\fR[/\fIREPOSITORY\fR]
 .
 .br
-\fBgit fetch\fR \fIUSER\-1\fR,[\fIUSER\-2\fR,...]
+\fBgit fetch\fR \fIUSER\-1\fR,[\fIUSER\-2\fR,\.\.\.]
 .
 .br
 \fBgit cherry\-pick\fR \fIGITHUB\-REF\fR
 .
 .br
-\fBgit push\fR \fIREMOTE\-1\fR,\fIREMOTE\-2\fR,...,\fIREMOTE\-N\fR \fIREF\fR
+\fBgit push\fR \fIREMOTE\-1\fR,\fIREMOTE\-2\fR,\.\.\.,\fIREMOTE\-N\fR \fIREF\fR
 .
 .br
 \fBgit browse\fR [\fB\-p\fR] [\fB\-u\fR] [[\fIUSER\fR\fB/\fR]\fIREPOSITORY\fR] [SUBPAGE]
 .
 .br
-\fBgit compare\fR [\fB\-p\fR] [\fB\-u\fR] [\fIUSER\fR] [\fISTART\fR...]\fIEND\fR
+\fBgit compare\fR [\fB\-p\fR] [\fB\-u\fR] [\fIUSER\fR] [\fISTART\fR\.\.\.]\fIEND\fR
 .
 .br
 \fBgit submodule add\fR [\fB\-p\fR] \fIOPTIONS\fR [\fIUSER\fR/]\fIREPOSITORY\fR \fIDIRECTORY\fR
@@ -46,98 +46,55 @@
 \fBgit fork\fR [\fB\-\-no\-remote\fR]
 .
 .SH "DESCRIPTION"
-\fBhub\fR enhances various \fBgit\fR commands with GitHub remote expansion. The
-alias command displays information on configuring your environment:
+\fBhub\fR enhances various \fBgit\fR commands with GitHub remote expansion\. The alias command displays information on configuring your environment:
 .
 .IP "\(bu" 4
-\fBhub alias\fR [\fB\-s\fR] \fISHELL\fR:
-Writes shell aliasing code for \fISHELL\fR (\fBbash\fR, \fBsh\fR, \fBzsh\fR, \fBcsh\fR) to standard output. With the \fB\-s\fR option, the output of
-this command can be evaluated directly within the shell:
+\fBhub alias\fR [\fB\-s\fR] \fISHELL\fR: Writes shell aliasing code for \fISHELL\fR (\fBbash\fR, \fBsh\fR, \fBzsh\fR, \fBcsh\fR) to standard output\. With the \fB\-s\fR option, the output of this command can be evaluated directly within the shell:
 .
 .br
 \fBeval $(hub alias \-s bash)\fR
 .
 .IP "\(bu" 4
-\fBgit init\fR \fB\-g\fR \fIOPTIONS\fR:
-Create a git repository as with git\-init(1) and add remote \fBorigin\fR at
-"git@github.com:\fIUSER\fR/\fIREPOSITORY\fR.git"; \fIUSER\fR is your GitHub username and \fIREPOSITORY\fR is the current working directory's basename.
+\fBgit init\fR \fB\-g\fR \fIOPTIONS\fR: Create a git repository as with git\-init(1) and add remote \fBorigin\fR at "git@github\.com:\fIUSER\fR/\fIREPOSITORY\fR\.git"; \fIUSER\fR is your GitHub username and \fIREPOSITORY\fR is the current working directory\'s basename\.
 .
 .IP "\(bu" 4
-\fBgit create\fR [\fB\-p\fR] [\fB\-d <DESCRIPTION>\fR] [\fB\-h <HOMEPAGE>\fR]:
-Create a new public github repository from the current git
-repository and add remote \fBorigin\fR at
-"git@github.com:\fIUSER\fR/\fIREPOSITORY\fR.git"; \fIUSER\fR is your GitHub
-username and \fIREPOSITORY\fR is the current working directory's
-basename. With \fB\-p\fR, create a private repository. \fB\-d\fR and \fB\-h\fR
-set the repository's description and homepage, respectively.
+\fBgit create\fR [\fB\-p\fR] [\fB\-d <DESCRIPTION>\fR] [\fB\-h <HOMEPAGE>\fR]: Create a new public github repository from the current git repository and add remote \fBorigin\fR at "git@github\.com:\fIUSER\fR/\fIREPOSITORY\fR\.git"; \fIUSER\fR is your GitHub username and \fIREPOSITORY\fR is the current working directory\'s basename\. With \fB\-p\fR, create a private repository\. \fB\-d\fR and \fB\-h\fR set the repository\'s description and homepage, respectively\.
 .
 .IP "\(bu" 4
-\fBgit clone\fR [\fB\-p\fR] \fIOPTIONS\fR [\fIUSER\fR\fB/\fR]\fIREPOSITORY\fR \fIDIRECTORY\fR:
-Clone repository "git://github.com/\fIUSER\fR/\fIREPOSITORY\fR.git" into \fIDIRECTORY\fR as with git\-clone(1). When \fIUSER\fR/ is omitted, assumes
-your GitHub login. With \fB\-p\fR, use private remote
-"git@github.com:\fIUSER\fR/\fIREPOSITORY\fR.git".
+\fBgit clone\fR [\fB\-p\fR] \fIOPTIONS\fR [\fIUSER\fR\fB/\fR]\fIREPOSITORY\fR \fIDIRECTORY\fR: Clone repository "git://github\.com/\fIUSER\fR/\fIREPOSITORY\fR\.git" into \fIDIRECTORY\fR as with git\-clone(1)\. When \fIUSER\fR/ is omitted, assumes your GitHub login\. With \fB\-p\fR, use private remote "git@github\.com:\fIUSER\fR/\fIREPOSITORY\fR\.git"\.
 .
 .IP "\(bu" 4
-\fBgit remote add\fR [\fB\-p\fR] \fIOPTIONS\fR \fIUSER\fR[\fB/\fR\fIREPOSITORY\fR]:
-Add remote "git://github.com/\fIUSER\fR/\fIREPOSITORY\fR.git" as with
-git\-remote(1). When /\fIREPOSITORY\fR is omitted, the basename of the
-current working directory is used. With \fB\-p\fR, use private remote
-"git@github.com:\fIUSER\fR/\fIREPOSITORY\fR.git". If \fIUSER\fR is "origin"
-then uses your GitHub login.
+\fBgit remote add\fR [\fB\-p\fR] \fIOPTIONS\fR \fIUSER\fR[\fB/\fR\fIREPOSITORY\fR]: Add remote "git://github\.com/\fIUSER\fR/\fIREPOSITORY\fR\.git" as with git\-remote(1)\. When /\fIREPOSITORY\fR is omitted, the basename of the current working directory is used\. With \fB\-p\fR, use private remote "git@github\.com:\fIUSER\fR/\fIREPOSITORY\fR\.git"\. If \fIUSER\fR is "origin" then uses your GitHub login\.
 .
 .IP "\(bu" 4
 \fBgit remote set\-url\fR [\fB\-p\fR] \fIOPTIONS\fR \fIREMOTE\-NAME\fR \fIUSER\fR[/\fIREPOSITORY\fR]
 .
 .br
-Sets the url of remote \fIREMOTE\-NAME\fR using the same rules as \fBgit remote add\fR.
+Sets the url of remote \fIREMOTE\-NAME\fR using the same rules as \fBgit remote add\fR\.
 .
 .IP "\(bu" 4
-\fBgit fetch\fR \fIUSER\-1\fR,[\fIUSER\-2\fR,...]:
-Adds missing remote(s) with \fBgit remote add\fR prior to fetching. New
-remotes are only added if they correspond to valid forks on GitHub.
+\fBgit fetch\fR \fIUSER\-1\fR,[\fIUSER\-2\fR,\.\.\.]: Adds missing remote(s) with \fBgit remote add\fR prior to fetching\. New remotes are only added if they correspond to valid forks on GitHub\.
 .
 .IP "\(bu" 4
-\fBgit cherry\-pick\fR \fIGITHUB\-REF\fR:
-Cherry\-pick a commit from a fork using either full URL to the commit
-or GitHub\-flavored Markdown notation, which is \fBuser@sha\fR. If the remote
-doesn't yet exist, it will be added. A \fBgit fetch <user>\fR is issued
-prior to the cherry\-pick attempt.
+\fBgit cherry\-pick\fR \fIGITHUB\-REF\fR: Cherry\-pick a commit from a fork using either full URL to the commit or GitHub\-flavored Markdown notation, which is \fBuser@sha\fR\. If the remote doesn\'t yet exist, it will be added\. A \fBgit fetch <user>\fR is issued prior to the cherry\-pick attempt\.
 .
 .IP "\(bu" 4
-\fBgit push\fR \fIREMOTE\-1\fR,\fIREMOTE\-2\fR,...,\fIREMOTE\-N\fR \fIREF\fR:
-Push \fIREF\fR to each of \fIREMOTE\-1\fR through \fIREMOTE\-N\fR by executing
-multiple \fBgit push\fR commands.
+\fBgit push\fR \fIREMOTE\-1\fR,\fIREMOTE\-2\fR,\.\.\.,\fIREMOTE\-N\fR \fIREF\fR: Push \fIREF\fR to each of \fIREMOTE\-1\fR through \fIREMOTE\-N\fR by executing multiple \fBgit push\fR commands\.
 .
 .IP "\(bu" 4
-\fBgit browse\fR [\fB\-p\fR] [\fB\-u\fR] [[\fIUSER\fR\fB/\fR]\fIREPOSITORY\fR] [SUBPAGE]:
-Open repository's GitHub page in the system's default web browser
-using \fBopen(1)\fR or the \fBBROWSER\fR env variable. Use \fB\-p\fR to open a
-page with https. If the repository isn't specified, \fBbrowse\fR opens
-the page of the repository found in the current directory. If SUBPAGE
-is specified, the browser will open on the specified subpage: one of
-"wiki", "commits", "issues" or other (the default is "tree").
+\fBgit browse\fR [\fB\-p\fR] [\fB\-u\fR] [[\fIUSER\fR\fB/\fR]\fIREPOSITORY\fR] [SUBPAGE]: Open repository\'s GitHub page in the system\'s default web browser using \fBopen(1)\fR or the \fBBROWSER\fR env variable\. Use \fB\-p\fR to open a page with https\. If the repository isn\'t specified, \fBbrowse\fR opens the page of the repository found in the current directory\. If SUBPAGE is specified, the browser will open on the specified subpage: one of "wiki", "commits", "issues" or other (the default is "tree")\.
 .
 .IP "\(bu" 4
-\fBgit compare\fR [\fB\-p\fR] [\fB\-u\fR] [\fIUSER\fR] [\fISTART\fR...]\fIEND\fR:
-Open a GitHub compare view page in the system's default web browser. \fISTART\fR to \fIEND\fR are branch names, tag names, or commit SHA1s specifying
-the range of history to compare. If \fISTART\fR is omitted, GitHub will
-compare against the base branch (the default is "master").
+\fBgit compare\fR [\fB\-p\fR] [\fB\-u\fR] [\fIUSER\fR] [\fISTART\fR\.\.\.]\fIEND\fR: Open a GitHub compare view page in the system\'s default web browser\. \fISTART\fR to \fIEND\fR are branch names, tag names, or commit SHA1s specifying the range of history to compare\. If \fISTART\fR is omitted, GitHub will compare against the base branch (the default is "master")\.
 .
 .IP "\(bu" 4
-\fBgit submodule add\fR [\fB\-p\fR] \fIOPTIONS\fR [\fIUSER\fR/]\fIREPOSITORY\fR \fIDIRECTORY\fR:
-Submodule repository "git://github.com/\fIUSER\fR/\fIREPOSITORY\fR.git" into \fIDIRECTORY\fR as with git\-submodule(1). When \fIUSER\fR/ is omitted, assumes
-your GitHub login. With \fB\-p\fR, use private remote
-"git@github.com:\fIUSER\fR/\fIREPOSITORY\fR.git".
+\fBgit submodule add\fR [\fB\-p\fR] \fIOPTIONS\fR [\fIUSER\fR/]\fIREPOSITORY\fR \fIDIRECTORY\fR: Submodule repository "git://github\.com/\fIUSER\fR/\fIREPOSITORY\fR\.git" into \fIDIRECTORY\fR as with git\-submodule(1)\. When \fIUSER\fR/ is omitted, assumes your GitHub login\. With \fB\-p\fR, use private remote "git@github\.com:\fIUSER\fR/\fIREPOSITORY\fR\.git"\.
 .
 .IP "\(bu" 4
-\fBgit fork\fR [\fB\-\-no\-remote\fR]:
-Forks the original project (referenced by "origin" remote) on GitHub and
-adds a new remote for it under your username. Requires \fBgithub.token\fR to
-be set (see CONFIGURATION).
+\fBgit fork\fR [\fB\-\-no\-remote\fR]: Forks the original project (referenced by "origin" remote) on GitHub, changes "origin" to point at the fork and adds a new remote for the old origin under "upstream"\. Requires \fBgithub\.token\fR to be set (see CONFIGURATION)\.
 .
 .IP "\(bu" 4
-\fBgit help\fR:
-Display enhanced git\-help(1).
+\fBgit help\fR: Display enhanced git\-help(1)\.
 .
 .IP "" 0
 .
@@ -148,7 +105,7 @@ Use git\-config(1) to display the currently configured GitHub username:
 .
 .nf
 
-$ git config \-\-global github.user
+$ git config \-\-global github\.user
 .
 .fi
 .
@@ -161,26 +118,24 @@ Or, set the GitHub username and token with:
 .
 .nf
 
-$ git config \-\-global github.user <username>
-$ git config \-\-global github.token <token>
+$ git config \-\-global github\.user <username>
+$ git config \-\-global github\.token <token>
 .
 .fi
 .
 .IP "" 0
 .
 .P
-See \fIhttp://github.com/guides/local\-github\-config\fR for more
-information.
+See \fIhttp://github\.com/guides/local\-github\-config\fR for more information\.
 .
 .P
-You can also tell \fBhub\fR to use \fBhttp://\fR rather than \fBgit://\fR when
-cloning:
+You can also tell \fBhub\fR to use \fBhttp://\fR rather than \fBgit://\fR when cloning:
 .
 .IP "" 4
 .
 .nf
 
-$ git config \-\-global \-\-bool hub.http\-clone true
+$ git config \-\-global \-\-bool hub\.http\-clone true
 .
 .fi
 .
@@ -193,16 +148,16 @@ $ git config \-\-global \-\-bool hub.http\-clone true
 .nf
 
 $ git clone schacon/ticgit
-> git clone git://github.com/schacon/ticgit.git
+> git clone git://github\.com/schacon/ticgit\.git
 
 $ git clone \-p schacon/ticgit
-> git clone git@github.com:schacon/ticgit.git
+> git clone git@github\.com:schacon/ticgit\.git
 
 $ git clone resque
-> git clone git://github.com/YOUR_USER/resque.git
+> git clone git://github\.com/YOUR_USER/resque\.git
 
 $ git clone \-p resque
-> git clone git@github.com:YOUR_USER/resque.git
+> git clone git@github\.com:YOUR_USER/resque\.git
 .
 .fi
 .
@@ -211,13 +166,13 @@ $ git clone \-p resque
 .nf
 
 $ git remote add rtomayko
-> git remote add rtomayko git://github.com/rtomayko/CURRENT_REPO.git
+> git remote add rtomayko git://github\.com/rtomayko/CURRENT_REPO\.git
 
 $ git remote add \-p rtomayko
-> git remote add rtomayko git@github.com:rtomayko/CURRENT_REPO.git
+> git remote add rtomayko git@github\.com:rtomayko/CURRENT_REPO\.git
 
 $ git remote add origin
-> git remote add origin git://github.com/YOUR_USER/CURRENT_REPO.git
+> git remote add origin git://github\.com/YOUR_USER/CURRENT_REPO\.git
 .
 .fi
 .
@@ -226,12 +181,12 @@ $ git remote add origin
 .nf
 
 $ git fetch mislav
-> git remote add mislav git://github.com/mislav/REPO.git
+> git remote add mislav git://github\.com/mislav/REPO\.git
 > git fetch mislav
 
 $ git fetch mislav,xoebus
-> git remote add mislav ...
-> git remote add xoebus ...
+> git remote add mislav \.\.\.
+> git remote add xoebus \.\.\.
 > git fetch \-\-multiple mislav xoebus
 .
 .fi
@@ -240,12 +195,12 @@ $ git fetch mislav,xoebus
 .
 .nf
 
-$ git cherry\-pick http://github.com/mislav/REPO/commit/SHA
-> git remote add \-f mislav git://github.com/mislav/REPO.git
+$ git cherry\-pick http://github\.com/mislav/REPO/commit/SHA
+> git remote add \-f mislav git://github\.com/mislav/REPO\.git
 > git cherry\-pick SHA
 
 $ git cherry\-pick mislav@SHA
-> git remote add \-f mislav git://github.com/mislav/CURRENT_REPO.git
+> git remote add \-f mislav git://github\.com/mislav/CURRENT_REPO\.git
 > git cherry\-pick SHA
 
 $ git cherry\-pick mislav@SHA
@@ -259,8 +214,8 @@ $ git cherry\-pick mislav@SHA
 .nf
 
 $ git fork
-... hardcore forking action ...
-> git remote add YOUR_USER git@github.com:YOUR_USER/CURRENT_REPO.git
+\.\.\. hardcore forking action \.\.\.
+> git remote add YOUR_USER git@github\.com:YOUR_USER/CURRENT_REPO\.git
 .
 .fi
 .
@@ -270,7 +225,7 @@ $ git fork
 
 $ git init \-g
 > git init
-> git remote add origin git@github.com:YOUR_USER/REPO.git
+> git remote add origin git@github\.com:YOUR_USER/REPO\.git
 .
 .fi
 .
@@ -279,8 +234,8 @@ $ git init \-g
 .nf
 
 $ git create
-... hardcore creating action ...
-> git remote add origin git@github.com:YOUR_USER/CURRENT_REPO.git
+\.\.\. hardcore creating action \.\.\.
+> git remote add origin git@github\.com:YOUR_USER/CURRENT_REPO\.git
 .
 .fi
 .
@@ -300,25 +255,25 @@ $ git push origin,staging,qa bert_timeout
 .nf
 
 $ git browse
-> open http://github.com/CURRENT_REPO
+> open http://github\.com/CURRENT_REPO
 
 $ git browse \-\- issues
-> open http://github.com/CURRENT_REPO/issues
+> open http://github\.com/CURRENT_REPO/issues
 
 $ git browse schacon/ticgit
-> open http://github.com/schacon/ticgit
+> open http://github\.com/schacon/ticgit
 
 $ git browse \-p schacon/ticgit
-> open https://github.com/schacon/ticgit
+> open https://github\.com/schacon/ticgit
 
 $ git browse resque
-> open http://github.com/YOUR_USER/resque
+> open http://github\.com/YOUR_USER/resque
 
 $ git browse resque network
-> open http://github.com/YOUR_USER/resque/network
+> open http://github\.com/YOUR_USER/resque/network
 
 $ git browse \-p resque
-> open https://github.com/YOUR_USER/resque
+> open https://github\.com/YOUR_USER/resque
 .
 .fi
 .
@@ -327,16 +282,16 @@ $ git browse \-p resque
 .nf
 
 $ git compare refactor
-> open http://github.com/CURRENT_REPO/compare/refactor
+> open http://github\.com/CURRENT_REPO/compare/refactor
 
-$ git compare 1.0...1.1
-> open http://github.com/CURRENT_REPO/compare/1.0...1.1
+$ git compare 1\.0\.\.\.1\.1
+> open http://github\.com/CURRENT_REPO/compare/1\.0\.\.\.1\.1
 
 $ git compare \-u fix
-> (http://github.com/CURRENT_REPO/compare/fix)
+> (http://github\.com/CURRENT_REPO/compare/fix)
 
 $ git compare other\-user patch
-> open http://github.com/other\-user/REPO/compare/patch
+> open http://github\.com/other\-user/REPO/compare/patch
 .
 .fi
 .
@@ -352,10 +307,10 @@ $ git help hub
 .fi
 .
 .SH "BUGS"
-\fIhttp://github.com/defunkt/hub/issues\fR
+\fIhttp://github\.com/defunkt/hub/issues\fR
 .
 .SH "AUTHOR"
-Chris Wanstrath :: chris@ozmm.org :: @defunkt
+Chris Wanstrath :: chris@ozmm\.org :: @defunkt
 .
 .SH "SEE ALSO"
-git(1), git\-clone(1), git\-remote(1), git\-init(1), \fIhttp://github.com\fR, \fIhttp://github.com/defunkt/hub\fR
+git(1), git\-clone(1), git\-remote(1), git\-init(1), \fIhttp://github\.com\fR, \fIhttp://github\.com/defunkt/hub\fR

--- a/man/hub.1.html
+++ b/man/hub.1.html
@@ -2,127 +2,57 @@
 <html>
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.5 (http://github.com/rtomayko/ronn)'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
   <title>hub(1) - git + hub = github</title>
   <style type='text/css' media='all'>
-  /* STRUCTURE, INDENT, MARGINS */
-  
-  body                                { margin:0}
-  #man                                { max-width:92ex; padding:0 2ex 1ex 2ex}
-  
-  #man p, #man pre,
-  #man ul, #man ol, #man dl           { margin:0 0 20px 0}
-  #man h2                             { margin:10px 0 0 0}
-  
-  #man > p, #man > pre,
-  #man > ul, #man > ol, #man > dl     { margin-left:8ex}
-  #man h3                             { margin:0 0 0 4ex}
-  
-  #man dt                             { margin:0; clear:left}
-  #man dt.flush                       { float:left; width:8ex}
-  #man dd                             { margin:0 0 0 9ex}
-  #man h1, #man h2, #man h3, #man h4  { clear:left}
-  
-  #man pre                            { margin-bottom:20px}
-  #man pre+h2, #man pre+h3            { margin-top:22px}
-  #man h2+pre, #man h3+pre            { margin-top:5px}
-  
-  #man img                            { display:block;margin:auto}
-  #man h1.man-title                   { display:none}
-  
-  /* FONTS */
-  
-  #man, #man code, #man pre,
-  #man tt, #man kbd, #man samp,
-  #man h3, #man h4 {
-      font-family:monospace;
-      font-size:14px;
-      line-height:1.42857142857143;
-  }
-  #man h2, #man ol.man, #man .man-navigation a {
-    font-size:16px;
-    line-height:1.25
-  }
-  #man h1 {
-    font-size:20px;
-    line-height:2;
-  }
-  
-  /* TEXT STYLES */
-  
-  #man {
-    text-align:justify;
-    background:#fff;
-  }
-  #man, #man code, #man pre, #man pre code,
-  #man tt, #man kbd, #man samp            { color:#131211}
-  #man h1, #man h2, #man h3, #man h4      { color:#030201}
-  #man ol.man, #man ol.man li             { color:#636261}
-  
-  #man code, #man strong, #man b {
-      font-weight:bold;
-      color:#131211;
-  }
-  
-  #man em, #man var, #man u {
-      font-style:italic;
-      color:#434241;
-      text-decoration:none;
-  }
-  
-  #man pre {
-      background:#edeceb;
-      padding:5px 1ex;
-      border-left:1ex solid #ddd;
-  }
-  #man pre code {
-      font-weight:normal;
-      background:inherit;
-  }
-  
-  /* DOCUMENT HEADER AND FOOTER AREAS */
-  
-  #man ol.man, #man ol.man li {
-      margin:3px 0 10px 0;
-      padding:0;
-      float:left;
-      width:33%;
-      list-style-type:none;
-      text-transform:uppercase;
-      color:#999;
-      letter-spacing:1px;
-  }
-  #man ol.man                  { width:100%}
-  #man ol.man li.tl            { text-align:left}
-  #man ol.man li.tc            { text-align:center; letter-spacing:4px}
-  #man ol.man li.tr            { text-align:right; float:right}
-  
-  /* SECTION TOC NAVIGATION */
-  
-  #man div.man-navigation {
-      position:fixed;
-      top:0;
-      left:106ex;
-      height:100%;
-      width:100%;
-      padding:1ex 0 0 2ex;
-      border-left:0.25ex solid #DCDCDC;
-      background-color: #F5F5F5;
-  }
-  #man div.man-navigation a { display:block; margin-bottom:1.5ex}
-  </style>
-  <style type='text/css' media='print'>
-  #man { max-width:none}
-  #man div.man-navigation { display:none}
-  #man a[href]:not([href^="#"]):not([data-bare-link]):after {
-    content:" " attr(href);
-  }
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
   </style>
 </head>
-<body id='manpage'>
-  <div id='man'>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
 
-  <div class='man-navigation'>
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
     <a href="#NAME">NAME</a>
     <a href="#SYNOPSIS">SYNOPSIS</a>
     <a href="#DESCRIPTION">DESCRIPTION</a>
@@ -133,16 +63,16 @@
     <a href="#SEE-ALSO">SEE ALSO</a>
     </div>
 
-  <h1 class='man-title'>hub(1)</h1>
-
-  <ol class='man head'>
+  <ol class='man-decor man-head man head'>
     <li class='tl'>hub(1)</li>
     <li class='tc'>Git Manual</li>
     <li class='tr'>hub(1)</li>
   </ol>
 
-  <h2 id='NAME'>NAME</h2>
-<p><code>hub</code> - git + hub = github</p>
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>hub</code> - <span class="man-whatis">git + hub = github</span>
+</p>
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
@@ -174,7 +104,7 @@ Writes shell aliasing code for <var>SHELL</var> (<code>bash</code>, <code>sh</co
 this command can be evaluated directly within the shell:<br />
 <code>eval $(hub alias -s bash)</code></p></li>
 <li><p><code>git init</code> <code>-g</code> <var>OPTIONS</var>:
-Create a git repository as with git-init(1) and add remote <code>origin</code> at
+Create a git repository as with <span class="man-ref">git-init<span class="s">(1)</span></span> and add remote <code>origin</code> at
 "git@github.com:<var>USER</var>/<var>REPOSITORY</var>.git"; <var>USER</var> is your GitHub username and
 <var>REPOSITORY</var> is the current working directory's basename.</p></li>
 <li><p><code>git create</code> [<code>-p</code>] [<code>-d &lt;DESCRIPTION></code>] [<code>-h &lt;HOMEPAGE></code>]:
@@ -186,12 +116,12 @@ basename. With <code>-p</code>, create a private repository. <code>-d</code> and
 set the repository's description and homepage, respectively.</p></li>
 <li><p><code>git clone</code> [<code>-p</code>] <var>OPTIONS</var> [<var>USER</var><code>/</code>]<var>REPOSITORY</var> <var>DIRECTORY</var>:
 Clone repository "git://github.com/<var>USER</var>/<var>REPOSITORY</var>.git" into
-<var>DIRECTORY</var> as with git-clone(1). When <var>USER</var>/ is omitted, assumes
+<var>DIRECTORY</var> as with <span class="man-ref">git-clone<span class="s">(1)</span></span>. When <var>USER</var>/ is omitted, assumes
 your GitHub login. With <code>-p</code>, use private remote
 "git@github.com:<var>USER</var>/<var>REPOSITORY</var>.git".</p></li>
 <li><p><code>git remote add</code> [<code>-p</code>] <var>OPTIONS</var> <var>USER</var>[<code>/</code><var>REPOSITORY</var>]:
 Add remote "git://github.com/<var>USER</var>/<var>REPOSITORY</var>.git" as with
-git-remote(1). When /<var>REPOSITORY</var> is omitted, the basename of the
+<span class="man-ref">git-remote<span class="s">(1)</span></span>. When /<var>REPOSITORY</var> is omitted, the basename of the
 current working directory is used. With <code>-p</code>, use private remote
 "git@github.com:<var>USER</var>/<var>REPOSITORY</var>.git". If <var>USER</var> is "origin"
 then uses your GitHub login.</p></li>
@@ -223,21 +153,22 @@ the range of history to compare. If <var>START</var> is omitted, GitHub will
 compare against the base branch (the default is "master").</p></li>
 <li><p><code>git submodule add</code> [<code>-p</code>] <var>OPTIONS</var> [<var>USER</var>/]<var>REPOSITORY</var> <var>DIRECTORY</var>:
 Submodule repository "git://github.com/<var>USER</var>/<var>REPOSITORY</var>.git" into
-<var>DIRECTORY</var> as with git-submodule(1). When <var>USER</var>/ is omitted, assumes
+<var>DIRECTORY</var> as with <span class="man-ref">git-submodule<span class="s">(1)</span></span>. When <var>USER</var>/ is omitted, assumes
 your GitHub login. With <code>-p</code>, use private remote
 "git@github.com:<var>USER</var>/<var>REPOSITORY</var>.git".</p></li>
 <li><p><code>git fork</code> [<code>--no-remote</code>]:
-Forks the original project (referenced by "origin" remote) on GitHub and
-adds a new remote for it under your username. Requires <code>github.token</code> to
-be set (see CONFIGURATION).</p></li>
+Forks the original project (referenced by "origin" remote) on GitHub,
+changes "origin" to point at the fork and adds a new remote for the old
+origin under "upstream". Requires <code>github.token</code> to be set (see
+CONFIGURATION).</p></li>
 <li><p><code>git help</code>:
-Display enhanced git-help(1).</p></li>
+Display enhanced <span class="man-ref">git-help<span class="s">(1)</span></span>.</p></li>
 </ul>
 
 
 <h2 id="CONFIGURATION">CONFIGURATION</h2>
 
-<p>Use git-config(1) to display the currently configured GitHub username:</p>
+<p>Use <span class="man-ref">git-config<span class="s">(1)</span></span> to display the currently configured GitHub username:</p>
 
 <pre><code>$ git config --global github.user
 </code></pre>
@@ -399,14 +330,14 @@ $ git help hub
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
-<p>git(1), git-clone(1), git-remote(1), git-init(1),
+<p><span class="man-ref">git<span class="s">(1)</span></span>, <span class="man-ref">git-clone<span class="s">(1)</span></span>, <span class="man-ref">git-remote<span class="s">(1)</span></span>, <span class="man-ref">git-init<span class="s">(1)</span></span>,
 <a href="http://github.com" data-bare-link="true">http://github.com</a>,
 <a href="http://github.com/defunkt/hub" data-bare-link="true">http://github.com/defunkt/hub</a></p>
 
 
-  <ol class='man foot'>
+  <ol class='man-decor man-foot man foot'>
     <li class='tl'>DEFUNKT</li>
-    <li class='tc'>August 2010</li>
+    <li class='tc'>October 2010</li>
     <li class='tr'>hub(1)</li>
   </ol>
 

--- a/man/hub.1.ronn
+++ b/man/hub.1.ronn
@@ -95,9 +95,10 @@ alias command displays information on configuring your environment:
     "git@github.com:<USER>/<REPOSITORY>.git".
 
   * `git fork` [`--no-remote`]:
-    Forks the original project (referenced by "origin" remote) on GitHub and
-    adds a new remote for it under your username. Requires `github.token` to
-    be set (see CONFIGURATION).
+    Forks the original project (referenced by "origin" remote) on GitHub,
+    changes "origin" to point at the fork and adds a new remote for the old
+    origin under "upstream". Requires `github.token` to be set (see
+    CONFIGURATION).
 
   * `git help`:
     Display enhanced git-help(1).


### PR DESCRIPTION
I've changed `hub fork` to work more like fork in github-gem. Like github-gem, it changes the "origin" to point to the new fork. Unlike github-gem, it adds an additional remote "upstream" that points at the original origin. 

I think this more closely mirrors the common case. Very rarely do you have write access to the repository that you're forking from, so you want to be able to have `git push` and `git pull` work on your fork, which means changing origin. Additionally, the change mirrors the forking workflow laid out here: http://help.github.com/forking/.

It's just a first pass, so things may need some cleaning up, but I'm interested to hear your thoughts.
