### PR TITLE
Fix URL for installing hub standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Install
 
 `hub` is most easily installed as a standalone script:
 
-    curl -s http://defunkt.github.com/hub/standalone > ~/bin/hub &&
+    curl -s http://chriswanstrath.com/hub/standalone > ~/bin/hub &&
     chmod 755 ~/bin/hub
 
 Assuming `~/bin/` is in your `$PATH`, you're ready to roll:


### PR DESCRIPTION
Hey,
Please see the attached commit. This also closes the existing issue GH-56 using github magic.
Otherwise ~/bin/hub is a 301 html page.

Cheers
Phil
