### PR TITLE
Preserve attributes on `rake install`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,7 @@ task :install => :standalone do
   prefix = ENV['PREFIX'] || ENV['prefix'] || '/usr/local'
 
   FileUtils.mkdir_p "#{prefix}/bin"
-  FileUtils.cp "hub", "#{prefix}/bin"
+  FileUtils.cp "hub", "#{prefix}/bin", :preserve => true
 
   FileUtils.mkdir_p "#{prefix}/share/man/man1"
   FileUtils.cp "man/hub.1", "#{prefix}/share/man/man1"


### PR DESCRIPTION
At least on my setup (Ubuntu 10.04, rvm ruby 1.9.2) doing `FileUtils.cp` does not preserve the execution attribute.
