### PR TITLE
Support for execution of commands in config

### DIFF
--- a/lib/hub/context.rb
+++ b/lib/hub/context.rb
@@ -23,6 +23,11 @@ module Hub
     # Caches output when shelling out to git
     GIT_CONFIG = ShellOutCache.new(ENV['GIT'] || 'git') do |cache, cmd|
       result = %x{#{cache.to_exec(cmd).shelljoin}}.chomp
+      # If the value starts with a bang, it is a command to be executed
+      if result[0,1] == '!'
+        cmd = result[1, result.length]
+        result = %x{#{cmd}}.chomp
+      end
       cache[cmd] = $?.success? && !result.empty? ? result : nil
     end
 


### PR DESCRIPTION
This is useful for e.g. github.token, where you might want to use an
external command for decryption.

I am not sure about doing this properly at all, but it works for me.
