### PR TITLE
extend compare-command so two dots also define a range

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -417,6 +417,7 @@ module Hub
           end
         else
           range = args.pop
+          range.sub!('..', '...') if range =~ /[0-9a-f]{6}\.\.[0-9a-f]{6}/
           user = args.pop || repo_user
         end
         { :user => user, :web => "/compare/#{range}" }

--- a/man/hub.1.ronn
+++ b/man/hub.1.ronn
@@ -92,7 +92,9 @@ alias command displays information on configuring your environment:
     Open a GitHub compare view page in the system's default web browser.
     <START> to <END> are branch names, tag names, or commit SHA1s specifying
     the range of history to compare. If <START> is omitted, GitHub will
-    compare against the base branch (the default is "master").
+    compare against the base branch (the default is "master"). You can also
+    copy the notification from the `git pull`- and `git push`-output and it
+    will format it for github.
 
   * `git submodule add` [`-p`] <OPTIONS> [<USER>/]<REPOSITORY> <DIRECTORY>:  
     Submodule repository "git://github.com/<USER>/<REPOSITORY>.git" into
@@ -246,6 +248,9 @@ authentication?
 
     $ git compare 1.0...1.1
     > open https://github.com/CURRENT_REPO/compare/1.0...1.1
+
+    $ git compare 7a50012..ed17344
+    > open https://github.com/CURRENT_REPO/compare/7a50012...ed17344
 
     $ git compare -u fix
     > (https://github.com/CURRENT_REPO/compare/fix)

--- a/test/hub_test.rb
+++ b/test/hub_test.rb
@@ -634,6 +634,11 @@ config
       "open https://github.com/defunkt/hub/compare/1.0...fix"
   end
 
+  def test_hub_compare_range_from_git_push
+    assert_command "compare 7a50012..ed17344",
+      "open https://github.com/defunkt/hub/compare/7a50012...ed17344"
+  end
+
   def test_hub_compare_on_wiki
     stub_repo_url 'git://github.com/defunkt/hub.wiki.git'
     assert_command "compare 1.0...fix",


### PR DESCRIPTION
This enables the user to directly copy the notification about changes in branches from the output of git pull (and git fetch, git push, etc) without the need of manually adding a dot in the commandline.

While this is a small addition and mostly scratches my own itch, I've run into this so often that I think its useful for other people, too.
