### PR TITLE
for windows.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,8 @@ require 'rake/testtask'
 #
 
 def command?(command)
-  `which #{command} 2>/dev/null`
+  RUBY_PLATFORM.downcase =~ /mswin(?!ce)|mingw|bccwin/ ?
+    `which #{command} 2>NUL` : `which #{command} 2>/dev/null`
   $?.success?
 end
 

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -743,6 +743,7 @@ help
     # http://nex-3.com/posts/73-git-style-automatic-paging-in-ruby
     def page_stdout
       return unless $stdout.tty?
+      return RUBY_PLATFORM.downcase =~ /mswin(?!ce)|mingw|bccwin/
 
       read, write = IO.pipe
 


### PR DESCRIPTION
- use `NUL` instead of `/dev/null`
- don't call fork() on windows.
