### PR TITLE
Adding a remote referencing a ~/.ssh/config shortcut creates a screwy URL

### DIFF
--- a/test/hub_test.rb
+++ b/test/hub_test.rb
@@ -170,6 +170,10 @@ class HubTest < Test::Unit::TestCase
     assert_forwarded "remote add origin /path"
   end
 
+  def test_remote_from_ssh_config
+    assert_forwarded "remote add origin server:/git/repo.git"
+  end
+
   def test_private_remote_origin_as_normal
     assert_forwarded "remote add origin git@github.com:defunkt/resque.git"
   end


### PR DESCRIPTION
Git likes these, Hub does not. Here's a failing test case.
