### PR TITLE
Branch names with slashes confuse hub browse

### DIFF
--- a/test/hub_test.rb
+++ b/test/hub_test.rb
@@ -1040,6 +1040,18 @@ config
       "open https://github.com/mislav/hub/commits/experimental"
   end
 
+  def test_hub_browse_on_branch_named_with_slashes
+    stub_branch('refs/heads/feature/foo')
+    stub_tracking('feature/foo', 'mislav', 'feature/foo')
+
+    assert_command 'browse',
+      'open https://github.com/mislav/hub/tree/feature/foo'
+    assert_command 'browse -- tree',
+      'open https://github.com/mislav/hub/tree/feature/foo'
+    assert_command 'browse -- commits',
+      'open https://github.com/mislav/hub/commits/feature/foo'
+  end
+
   def test_hub_browse_current
     assert_command "browse", "open https://github.com/defunkt/hub"
     assert_command "browse --", "open https://github.com/defunkt/hub"


### PR DESCRIPTION
I added a breaking test trying to use `browse` with a branch called `feature/foo`. I see that the bug may be related to the way `Branch#short_name` is implemented.

``` ruby
def short_name
  name.split('/').last
end
```

It seems, that `name.split('\').last` isn't sufficient for obtaining current branch name. I'm not sure what would be the right way to do it though. Perhaps, `sub`-out `/^refs\/(?:heads|remotes|tags)\//` from the ref path? Thoughts?
