### PR TITLE
Default the remote to the user repo after forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ superpowers:
     $ git fork
     [ repo forked on GitHub ]
     > git remote add -f YOUR_USER git@github.com:YOUR_USER/CURRENT_REPO.git
+    > git config branch.master.remote YOUR_USER
 
 ### git pull-request
 

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -438,7 +438,8 @@ module Hub
       else
         url = forked_project.git_url(:private => true, :https => https_protocol?)
         args.replace %W"remote add -f #{forked_project.owner} #{url}"
-        args.after 'echo', ['new remote:', forked_project.owner]
+        args.after ['config', 'branch.master.remote', forked_project.owner]
+        args.after 'echo', ['new default remote:', forked_project.owner]
       end
     rescue HTTPExceptions
       display_http_exception("creating fork", $!.response)

--- a/test/hub_test.rb
+++ b/test/hub_test.rb
@@ -748,7 +748,8 @@ class HubTest < Test::Unit::TestCase
       with { |req| req.headers['Content-Length'] == 0 }
 
     expected = "remote add -f tpw git@github.com:tpw/hub.git\n"
-    expected << "new remote: tpw\n"
+    expected << "config branch.master.remote tpw\n"
+    expected << "new default remote: tpw\n"
     assert_output expected, "fork"
   end
 
@@ -769,7 +770,8 @@ class HubTest < Test::Unit::TestCase
     stub_request(:post, "https://#{auth('myfiname', '789xyz')}git.my.org/api/v2/yaml/repos/fork/defunkt/hub")
 
     expected = "remote add -f myfiname git@git.my.org:myfiname/hub.git\n"
-    expected << "new remote: myfiname\n"
+    expected << "config branch.master.remote myfiname\n"
+    expected << "new default remote: myfiname\n"
     assert_output expected, "fork"
   end
 
@@ -794,7 +796,8 @@ class HubTest < Test::Unit::TestCase
 
     expected = "tpw/hub already exists on github.com\n"
     expected << "remote add -f tpw git@github.com:tpw/hub.git\n"
-    expected << "new remote: tpw\n"
+    expected << "config branch.master.remote tpw\n"
+    expected << "new default remote: tpw\n"
     assert_equal expected, hub("fork") { ENV['GIT'] = 'echo' }
   end
 
@@ -804,7 +807,8 @@ class HubTest < Test::Unit::TestCase
 
     expected = "tpw/hub already exists on github.com\n"
     expected << "remote add -f tpw https://github.com/tpw/hub.git\n"
-    expected << "new remote: tpw\n"
+    expected << "config branch.master.remote tpw\n"
+    expected << "new default remote: tpw\n"
     assert_equal expected, hub("fork") { ENV['GIT'] = 'echo' }
   end
 


### PR DESCRIPTION
That would saves me to manually type it each time I fork a repo.

That's very nice to know if master have unpushed commits when using holman/dotfiles prompt. See [pull request](https://github.com/holman/dotfiles/pull/22)
