### PR TITLE
Allow Enterprise access over regular HTTP

### DIFF
--- a/lib/hub/context.rb
+++ b/lib/hub/context.rb
@@ -189,7 +189,7 @@ module Hub
       end
     end
 
-    class GithubProject < Struct.new(:local_repo, :owner, :name, :host)
+    class GithubProject < Struct.new(:local_repo, :owner, :name, :host, :scheme)
       def self.from_url(url, local_repo)
         if local_repo.known_hosts.include? url.host
           _, owner, name = url.path.split('/', 4)
@@ -199,6 +199,7 @@ module Hub
 
       def initialize(*args)
         super
+        self.scheme = (local_repo && local_repo.git_config('hub.protocol')) || 'https'
         self.host ||= local_repo.default_host
       end
 
@@ -234,7 +235,7 @@ module Hub
             path = '/wiki' + path
           end
         end
-        "https://#{host}/" + project_name + path.to_s
+        "#{scheme}://#{host}/" + project_name + path.to_s
       end
 
       def git_url(options = {})
@@ -245,7 +246,7 @@ module Hub
       end
 
       def api_url(type, resource, action)
-        URI("https://#{host}/api/v2/#{type}/#{resource}/#{action}")
+        URI("#{scheme}://#{host}/api/v2/#{type}/#{resource}/#{action}")
       end
 
       def api_show_url(type)

--- a/test/hub_test.rb
+++ b/test/hub_test.rb
@@ -993,6 +993,21 @@ class HubTest < Test::Unit::TestCase
       "checkout -f https://github.com/defunkt/hub/pull/73/files -q"
   end
 
+  def test_checkout_pullrequest_enterprise_http
+    stub_hub_host('git.my.org')
+    stub_repo_url('git@git.my.org:defunkt/hub.git')
+    stub_github_user('myfiname', 'git.my.org')
+    stub_github_token('789xyz', 'git.my.org')
+    stub_http_is_preferred
+
+    stub_request(:get, "http://#{auth('myfiname', '789xyz')}git.my.org/api/v2/json/pulls/defunkt/hub/73").
+      to_return(:body => mock_pull_response('blueyed:feature'))
+
+    assert_commands 'git remote add -f -t feature blueyed git@git.my.org:blueyed/hub.git',
+      'git checkout -f --track -B blueyed-feature blueyed/feature -q',
+      "checkout -f http://git.my.org/defunkt/hub/pull/73/files -q"
+  end
+
   def test_checkout_private_pullrequest
     stub_request(:get, "https://#{auth}github.com/api/v2/json/pulls/defunkt/hub/73").
       to_return(:body => mock_pull_response('blueyed:feature', :private))
@@ -1386,6 +1401,10 @@ config
 
     def stub_https_is_preferred
       stub_config_value 'hub.protocol', 'https'
+    end
+
+    def stub_http_is_preferred
+      stub_config_value 'hub.protocol', 'http'
     end
 
     def stub_hub_host(names)


### PR DESCRIPTION
Now only HTTPS scheme is allow to checkout pull request. We use GitHub Enterprise with non-SSL environment. This patch allows hub to checkout pull reuqest with HTTP.
