### PR TITLE
Add GitHub Commands section to improved_help_text

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -758,6 +758,13 @@ Advanced Commands:
    bisect     Find by binary search the change that introduced a bug
    grep       Print files with lines matching a pattern in your codebase
 
+Github Commands:
+   pull-request   Open a pull request on GitHub
+   fork           Make a fork of a remote repository on GitHub and add as remote
+   create         Create this repository on GitHub and add GitHub as origin
+   browse         Open a GitHub page in the default browser
+   compare        Open a compare page on GitHub
+
 See 'git help <command>' for more information on a specific command.
 help
     end


### PR DESCRIPTION
The help text for hub is much better than for git, but it doesn't currently
cover the hub commands for interacting with GitHub such as pull-request, create,
or fork (most ofthe `CUSTOM_COMMANDS` defined in lib/hub/commands.rb).

I've added them.

I also normalized the capitalization of "Commands" across `improved_help_text`.
