### PR TITLE
Private fetch

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -327,7 +327,7 @@ module Hub
 
       if projects.any?
         projects.each do |project|
-          args.before ['remote', 'add', project.owner, project.git_url(:https => https_protocol?)]
+          args.before ['remote', 'add', project.owner, project.git_url(:private => api_client.private_repo?(project), :https => https_protocol?)]
         end
       end
     end


### PR DESCRIPTION
A second try, off the api-v3 branch.

This commit makes the hub fetch command add the remote as an ssh url if the fork is private. Right now hub fetch always adds the public url which does not work correctly.

I left the test in that I wrote off master, but the tests seem to largely be broken. 
