### PR TITLE
Fix test suite for systems where /bin/sh links to dash

### DIFF
--- a/features/support/fakebin/git
+++ b/features/support/fakebin/git
@@ -1,17 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 # A wrapper for system git that prevents commands such as `clone` or `fetch` to be
 # executed in testing. It logs commands to "~/.history" so afterwards it can be
 # asserted that they ran.
 
 command="$1"
-[ "$command" == "config" ] || echo git "$@" >> "$HOME"/.history
+[ "$command" = "config" ] || echo git "$@" >> "$HOME"/.history
 
 case "$command" in
   "clone" | "fetch" | "pull" | "push" )
     exit
     ;;
   * )
-    [ "$command $2 $3" == "remote add -f" ] && exit
+    [ "$command $2 $3" = "remote add -f" ] && exit
     # note: `submodule add` also initiates a clone, but we work around it
     ;;
   esac


### PR DESCRIPTION
This fixes it twice: Use /bin/bash to guarantee same shell on all OS,
and use standard = operator for conditionals.
