### PR TITLE
hub clone fail when repo name start with dot.

### DIFF
--- a/features/clone.feature
+++ b/features/clone.feature
@@ -9,6 +9,11 @@ Feature: hub clone
     Then it should clone "git://github.com/hookio/hook.js.git"
     And there should be no output
 
+  Scenario: Clone a public repo startwith period in name
+    When I successfully run `hub clone zhuangya/.vim`
+    Then it should clone "git://github.com/zhuangya/.vim.git"
+    And there should be no output
+
   Scenario: Clone a public repo with HTTPS
     Given HTTPS is preferred
     When I successfully run `hub clone rtomayko/ronn`
@@ -89,3 +94,4 @@ Feature: hub clone
     When I successfully run `hub clone dotfiles`
     Then the git command should be unchanged
     And there should be no output
+

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -34,7 +34,7 @@ module Hub
     # provides git interrogation methods
     extend Context
 
-    NAME_RE = /[\.\w][\w.-]*/
+    NAME_RE = /[\w.][\w.-]*/
     OWNER_RE = /[a-zA-Z0-9-]+/
     NAME_WITH_OWNER_RE = /^(?:#{NAME_RE}|#{OWNER_RE}\/#{NAME_RE})$/
 


### PR DESCRIPTION
@defunkt, @mislav:

relate to this issue:

https://github.com/defunkt/hub/issues/197

i solve it myself :)
