### PR TITLE
Fix syntax error on `eval $(hub alias -s)'

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -671,11 +671,11 @@ module Hub
       end
 
       if script
-        puts "alias git=hub"
+        puts "alias git=hub;"
         if 'zsh' == shell
           puts "if type compdef >/dev/null; then"
-          puts "   compdef hub=git"
-          puts "fi"
+          puts "   compdef hub=git;"
+          puts "fi;"
         end
       else
         profile = case shell


### PR DESCRIPTION
According to README.md, aliasing from git to hub is done by eval.
Currently, hub outputs alias script like below:

```
$ hub alias -s
alias git=hub
if type compdef >/dev/null; then
    compdef hub=git
fi
```

With $(cmd) or `cmd`, this will be broken by concatenation.

```
$ echo $(hub alias -s)
alias git=hub if type compdef >/dev/null; then compdef hub=git fi
```

To solve this, added semicolons on each end of lines:

```
$ echo $(hub alias -s)
alias git=hub; if type compdef >/dev/null; then compdef hub=git; fi
```

(not added after 'then' because it would be syntax error on bash)

This solution is also used by ssh-agent.
