### PR TITLE
Don't cache results of failed git commands

### DIFF
--- a/lib/hub/context.rb
+++ b/lib/hub/context.rb
@@ -19,7 +19,7 @@ module Hub
         # caches output when shelling out to git
         read_proc ||= lambda { |cache, cmd|
           result = %x{#{command_to_string(cmd)} 2>#{NULL}}.chomp
-          cache[cmd] = $?.success? && !result.empty? ? result : nil
+          $?.success? && !result.empty? ? cache[cmd] = result : nil
         }
         @cache = Hash.new(&read_proc)
       end


### PR DESCRIPTION
I think this was the intention in the first place. 

Prior to this change, if a command failed, hub would cache nil as the result and never run the failed command again. 
