### PR TITLE
Http support

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -93,6 +93,10 @@ module Hub
         [project || context_project, ref]
       end
 
+      if args.delete('-t')
+        options[:scheme] = 'http'
+      end
+
       while arg = args.shift
         case arg
         when '-f'

--- a/lib/hub/github_api.rb
+++ b/lib/hub/github_api.rb
@@ -102,7 +102,8 @@ module Hub
         params[:body]  = options[:body]  if options[:body]
       end
 
-      res = post "https://%s/repos/%s/%s/pulls" %
+      scheme = options[:scheme] || 'https'
+      res = post "#{scheme}://%s/repos/%s/%s/pulls" %
         [api_host(project.host), project.owner, project.name], params
 
       res.error! unless res.success?


### PR DESCRIPTION
I know it's kind of lame, but I'm working with a github enterprise instance that's not running over https, so when I try to do some stuff with hub like checkout or make pull requests, I get connection refused.  I'm talking to my sysadmins running the enterprise instance to see about turning https on, but until then these changes let me use hub with it.

If this is a change that might be worth merging in, let me know and I'll also update docs and tests.  Any other feedback also welcome.
