### PR TITLE
Enable to post body from command line when pull-request

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -95,16 +95,18 @@ module Hub
 
       while arg = args.shift
         case arg
-        when '-f'
+        when '-f', '--force'
           force = true
-        when '-b'
+        when '-b', '--base'
           base_project, options[:base] = from_github_ref.call(args.shift, base_project)
-        when '-h'
+        when '-h', '--head'
           head = args.shift
           explicit_owner = !!head.index(':')
           head_project, options[:head] = from_github_ref.call(head, head_project)
-        when '-i'
+        when '-i', '--issue'
           options[:issue] = args.shift
+        when '--body'
+          options[:body] = args.shift
         else
           if url = resolve_github_url(arg) and url.project_path =~ /^issues\/(\d+)/
             options[:issue] = $1


### PR DESCRIPTION
When PR, I would like to post body from command line without editor.
`-b` is already used by base, so add long option name all of these commands.
