### PR TITLE
would be nice if git fork <username> would "just work"

### DIFF
--- a/features/fork.feature
+++ b/features/fork.feature
@@ -43,8 +43,14 @@ Feature: hub fork
   Scenario: Unrelated fork already exists
     Given the GitHub API server:
       """
-      get('/repos/evilchelu/dotfiles') { '' }
-      get('/repos/mislav/dotfiles') { '' }
+      get('/repos/evilchelu/dotfiles') { json \
+        :url => "http://github.com/evilchelu/dotfiles"
+       }
+      get('/repos/mislav/dotfiles') { json \
+        :parent => {
+		:url => "http://github.com/mislav/dotfiles"	
+		}		
+       }
       """
     When I run `hub fork`
     Then the exit status should be 1
@@ -53,6 +59,23 @@ Feature: hub fork
       Error creating fork: mislav/dotfiles already exists on github.com and is not a direct fork of evilchelu/dotfiles\n
       """
     And there should be no "mislav" remote
+
+Scenario: Related fork already exists
+    Given the GitHub API server:
+      """
+      get('/repos/evilchelu/dotfiles') { json \
+        :url => "http://github.com/evilchelu/dotfiles"
+       }
+      get('/repos/mislav/dotfiles') { json \
+        :parent => {
+		:url => "http://github.com/evilchelu/dotfiles"	
+		}		
+       }
+      """
+    When I run `hub fork`
+    Then the exit status should be 0
+    And "git remote add -f mislav git@github.com:mislav/dotfiles.git" should be run	
+    And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
 
   Scenario: Invalid OAuth token
     Given the GitHub API server:

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -467,9 +467,15 @@ module Hub
 
       if api_client.repo_exists?(forked_project) 
         orig_url = api_client.repo_info(project).data["url"]
-        parent_url = api_client.repo_info(forked_project).data["parent"]["url"]
-        notfork = orig_url!=parent_url
         
+        parent_data = api_client.repo_info(forked_project).data
+        if parent_data.has_key?("parent")
+          parent_url = parent_data["parent"]["url"]
+          notfork = orig_url!=parent_url
+        else
+          notfork = false
+        end
+
         if notfork
           abort "Error creating fork: %s already exists on %s and is not a direct fork of %s" %
             [ forked_project.name_with_owner, forked_project.host, project.name_with_owner ]


### PR DESCRIPTION
I like the idea that I can just do:

  hub clone jbosstools/jbosstools-build
  cd jbosstools-build
  hub fork maxandersen

Now if I have no repo, it will fork it and add my personal writable/pushable repo as a remote. Great!

but this fails if I already have fork on github.

Would it not make sense that hub fork would just use the existing fork and continue to add the remote ?

Otherwise I'll have to remember if I actually have a proper fork and then do a git remote add manually or remember to do git remote add -p maxandersen since git remote add maxandersen is not enough either.
