### PR TITLE
fix windows browser, 'start' is not command. use 'cmd /c start'.

### DIFF
--- a/lib/hub/context.rb
+++ b/lib/hub/context.rb
@@ -441,7 +441,7 @@ module Hub
       # Returns an array, e.g.: ['open']
       def browser_launcher
         browser = ENV['BROWSER'] || (
-          osx? ? 'open' : windows? ? 'start' :
+          osx? ? 'open' : windows? ? ['cmd', '/c', 'start'] :
           %w[xdg-open cygstart x-www-browser firefox opera mozilla netscape].find { |comm| which comm }
         )
 


### PR DESCRIPTION
`hub browse` does not work.
`start` is not a command. use `cmd /c start`.
