### PR TITLE
Add Github Enterprise configuration steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,15 @@ $ git clone defunkt/repl
 < https clone >
 ~~~
 
+### Github Enterprise
+
+Hub supports connecting to a Github Enterprise server.
+
+~~~ sh
+$ git config --global --add hub.host my.git.org
+$ git config --global github."my.git.org".user mislav
+~~~
+
 
 Contributing
 ------------


### PR DESCRIPTION
From #98, it appears that Github Enterprise support
was added a year ago, however the documentation did not
explain how to get it setup.

Added a Github Enterprise section to the Configuration 
section of the README.md.
#98 also had `git config --global github."my.git.org".token 1234abcd`,

but I found I didn't need that line.
