### PR TITLE
pull-request: warn against attaching pull-requests to others' issues

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -186,6 +186,9 @@ module Hub
       args.replace [pull['html_url']]
     rescue GitHubAPI::Exceptions
       display_api_exception("creating pull request", $!.response)
+      if options.has_key?(:issue) and 422 == $!.response.status and $!.response.message == "Unprocessable Entity"
+        $stderr.puts "Remember that you can only attach pull requests to your own issues"
+      end
       exit 1
     end
 


### PR DESCRIPTION
You can only attach a pull request to your own issues [1](https://github.com/defunkt/hub/issues/189#issuecomment-6353354).  If there is
something wrong with a pull request [2](https://github.com/defunkt/hub/issues/114#issuecomment-3079021) and the user was trying to attach it
to an existing issue, warn the user about this limitation.

I was expecting something along these lines after @mislav's comment in #189 ([3](https://github.com/defunkt/hub/issues/189#issuecomment-9732490)),
but I don't think a clearer error message made it into the trunk yet, so I added it myself.
