### PR TITLE
Improve fork remote naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ superpowers:
 
     $ git fork
     [ repo forked on GitHub ]
-    > git remote add -f YOUR_USER git@github.com:YOUR_USER/CURRENT_REPO.git
+    > git remote rename origin upstream
+    > git remote add -f origin git@github.com:YOUR_USER/CURRENT_REPO.git
 
 ### git pull-request
 

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -12,9 +12,15 @@ Feature: hub fork
       post('/repos/evilchelu/dotfiles/forks', :host_name => 'api.github.com') { '' }
       """
     When I successfully run `hub fork`
-    Then the output should contain exactly "new remote: mislav\n"
-    And "git remote add -f mislav git@github.com:mislav/dotfiles.git" should be run
-    And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
+    Then the output should contain exactly:
+      """
+      renamed remote: origin -> upstream
+      new remote (your fork): origin\n
+      """
+    And "git remote rename origin upstream" should be run
+    And "git remote add -f origin git@github.com:mislav/dotfiles.git" should be run
+    And the url for "upstream" should be "git://github.com/evilchelu/dotfiles.git"
+    And the url for "origin" should be "git@github.com:mislav/dotfiles.git"
 
   Scenario: --no-remote
     Given the GitHub API server:
@@ -23,7 +29,7 @@ Feature: hub fork
       """
     When I successfully run `hub fork --no-remote`
     Then there should be no output
-    And there should be no "mislav" remote
+    And there should be no "upstream" remote
 
   Scenario: Fork failed
     Given the GitHub API server:
@@ -36,7 +42,7 @@ Feature: hub fork
       """
       Error creating fork: Internal Server Error (HTTP 500)\n
       """
-    And there should be no "mislav" remote
+    And there should be no "upstream" remote
 
   Scenario: Unrelated fork already exists
     Given the GitHub API server:
@@ -51,7 +57,7 @@ Feature: hub fork
       """
       Error creating fork: mislav/dotfiles already exists on github.com\n
       """
-    And there should be no "mislav" remote
+    And there should be no "upstream" remote
 
 Scenario: Related fork already exists
     Given the GitHub API server:
@@ -62,7 +68,8 @@ Scenario: Related fork already exists
       """
     When I run `hub fork`
     Then the exit status should be 0
-    And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
+    And the url for "upstream" should be "git://github.com/evilchelu/dotfiles.git"
+    And the url for "origin" should be "git@github.com:mislav/dotfiles.git"
 
   Scenario: Invalid OAuth token
     Given the GitHub API server:
@@ -84,8 +91,13 @@ Scenario: Related fork already exists
       """
     And HTTPS is preferred
     When I successfully run `hub fork`
-    Then the output should contain exactly "new remote: mislav\n"
-    And the url for "mislav" should be "https://github.com/mislav/dotfiles.git"
+    Then the output should contain exactly:
+      """
+      renamed remote: origin -> upstream
+      new remote (your fork): origin\n
+      """
+    And the url for "upstream" should be "git://github.com/evilchelu/dotfiles.git"
+    And the url for "origin" should be "https://github.com/mislav/dotfiles.git"
 
   Scenario: Not in repo
     Given the current dir is not a repo
@@ -112,4 +124,5 @@ Scenario: Related fork already exists
     And I am "mislav" on git.my.org with OAuth token "FITOKEN"
     And "git.my.org" is a whitelisted Enterprise host
     When I successfully run `hub fork`
-    Then the url for "mislav" should be "git@git.my.org:mislav/dotfiles.git"
+    Then the url for "upstream" should be "git@git.my.org:evilchelu/dotfiles.git"
+    And the url for "origin" should be "git@git.my.org:mislav/dotfiles.git"

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -481,8 +481,10 @@ module Hub
         exit
       else
         url = forked_project.git_url(:private => true, :https => https_protocol?)
-        args.replace %W"remote add -f #{forked_project.owner} #{url}"
-        args.after 'echo', ['new remote:', forked_project.owner]
+        args.before 'git', %W"remote rename origin upstream"
+        args.replace %W"remote add -f origin #{url}"
+        args.after 'echo', ['-e',
+          'renamed remote: origin -> upstream\nnew remote (your fork): origin']
       end
     rescue GitHubAPI::Exceptions
       display_api_exception("creating fork", $!.response)

--- a/man/hub.1
+++ b/man/hub.1
@@ -139,7 +139,7 @@ Open a GitHub compare view page in the system\'s default web browser\. \fISTART\
 .
 .TP
 \fBgit fork\fR [\fB\-\-no\-remote\fR]
-Forks the original project (referenced by "origin" remote) on GitHub and adds a new remote for it under your username\.
+Forks the original project (referenced by "origin" remote) on GitHub, renames the current "origin" branch to "upstream", and creates a new "origin" branch with your fork\.
 .
 .TP
 \fBgit pull\-request\fR [\fB\-f\fR] [\fITITLE\fR|\fB\-i\fR \fIISSUE\fR|\fIISSUE\-URL\fR] [\fB\-b\fR \fIBASE\fR] [\fB\-h\fR \fIHEAD\fR]

--- a/man/hub.1.html
+++ b/man/hub.1.html
@@ -175,8 +175,9 @@ subpage: one of "wiki", "commits", "issues" or other (the default is
 the range of history to compare. If a range with two dots (<code>a..b</code>) is given,
 it will be transformed into one with three dots. If <var>START</var> is omitted,
 GitHub will compare against the base branch (the default is "master").</p></dd>
-<dt><code>git fork</code> [<code>--no-remote</code>]</dt><dd><p>Forks the original project (referenced by "origin" remote) on GitHub and
-adds a new remote for it under your username.</p></dd>
+<dt><code>git fork</code> [<code>--no-remote</code>]</dt><dd><p>Forks the original project (referenced by "origin" remote) on GitHub,
+renames the current "origin" branch to "upstream", and creates a new
+"origin" branch with your fork.</p></dd>
 <dt><code>git pull-request</code> [<code>-f</code>] [<var>TITLE</var>|<code>-i</code> <var>ISSUE</var>|<var>ISSUE-URL</var>] [<code>-b</code> <var>BASE</var>] [<code>-h</code> <var>HEAD</var>]</dt><dd><p>Opens a pull request on GitHub for the project that the "origin" remote
 points to. The default head of the pull request is the current branch.
 Both base and head of the pull request can be explicitly given in one of

--- a/man/hub.1.ronn
+++ b/man/hub.1.ronn
@@ -132,8 +132,9 @@ hub also adds some custom commands that are otherwise not present in git:
     GitHub will compare against the base branch (the default is "master").
 
   * `git fork` [`--no-remote`]:
-    Forks the original project (referenced by "origin" remote) on GitHub and
-    adds a new remote for it under your username.
+    Forks the original project (referenced by "origin" remote) on GitHub, renames
+    the current "origin" branch to "upstream", and creates a new "origin" branch
+    with your fork.
 
   * `git pull-request` [`-f`] [<TITLE>|`-i` <ISSUE>|<ISSUE-URL>] [`-b` <BASE>] [`-h` <HEAD>]:
     Opens a pull request on GitHub for the project that the "origin" remote


### PR DESCRIPTION
The general practice with forking, and the one that is recommended in GitHub's own help pages, is to have the remote that pushes to your fork named "origin", and the one pointing to the maintainer's repo named "upstream". With this commit, `git fork` will have this behaviour.
