### PR TITLE
merge.feature git commit failure: "Please tell me who you are"

### DIFF
--- a/features/steps.rb
+++ b/features/steps.rb
@@ -47,6 +47,8 @@ Given /^a git repo in "([^"]*)"$/ do |dir_name|
   step %(a directory named "#{dir_name}")
   dirs << dir_name
   step %(I successfully run `git init --quiet`)
+  step %(I successfully run `git config user.name Hub`)
+  step %(I successfully run `git config user.email '<hub@test.local>'`)
   dirs.pop
 end
 


### PR DESCRIPTION
I tried to test the merge.feature, and got:

```
hub $ RUBYLIB=lib cucumber -f progress -t ~@wip features/merge.feature
.......F----....F--............

(::) failed steps (::)

command "git commit --quiet -m '' --allow-empty --allow-empty-message --author 'Hub <hub@test.local>'" exited with status 128:
  *** Please tell me who you are.

  Run

    git config --global user.email "you@example.com"
    git config --global user.name "Your Name"

  to set your account's default identity.
  Omit --global to set the identity only in this repository.

  fatal: empty ident name (for <wking@tremily.us>) not allowed (RSpec::Expectations::ExpectationNotMetError)
./features/support/env.rb:125:in `run_silent'
./features/support/env.rb:123:in `run_silent'
./features/support/env.rb:133:in `empty_commit'
./features/steps.rb:54:in `/^there is a commit named "([^"]+)"$/'
features/merge.feature:19:in `And there is a commit named "jfirebaugh/hub_merge"'

command "git commit --quiet -m '' --allow-empty --allow-empty-message --author 'Hub <hub@test.local>'" exited with status 128:
  *** Please tell me who you are.

  Run

    git config --global user.email "you@example.com"
    git config --global user.name "Your Name"

  to set your account's default identity.
  Omit --global to set the identity only in this repository.

  fatal: empty ident name (for <wking@tremily.us>) not allowed (RSpec::Expectations::ExpectationNotMetError)
./features/support/env.rb:125:in `run_silent'
./features/support/env.rb:123:in `run_silent'
./features/support/env.rb:133:in `empty_commit'
./features/steps.rb:54:in `/^there is a commit named "([^"]+)"$/'
features/merge.feature:42:in `And there is a commit named "jfirebaugh/hub_merge"'

Failing Scenarios:
cucumber features/merge.feature:7 # Scenario: Merge pull request
cucumber features/merge.feature:30 # Scenario: Merge pull request

4 scenarios (2 failed, 2 passed)
28 steps (2 failed, 6 skipped, 20 passed)
0m7.610s
```

I expect the problem is due to the unspecified contributor, and recent versions of Git may have tightened their checking (I'm running Git 1.8.0).
