### PR TITLE
merge.feature: Disambiguate private pull request scenario

### DIFF
--- a/features/merge.feature
+++ b/features/merge.feature
@@ -27,7 +27,7 @@ Feature: hub merge
       Add `hub merge` command
       """
 
-  Scenario: Merge pull request
+  Scenario: Merge private pull request
     Given the GitHub API server:
       """
       require 'json'


### PR DESCRIPTION
Previously both the public pull request and the private pull request 
scenarios were named "Merge pull request", and you had to look at their
contents to find the difference.  Now you can just read the titles.
