### PR TITLE
Changed completion to work with modern zsh and git 

### DIFF
--- a/etc/hub.zsh_completion
+++ b/etc/hub.zsh_completion
@@ -18,5 +18,5 @@ if declare -f _git_commands > /dev/null; then
     'compare:open GitHub compare view'
   )
   # Extend the '_git_commands' function with hub commands
-  eval "$(declare -f _git_commands | sed -e 's/main_porcelain_commands=(/main_porcelain_commands=(${_hub_commands} /')"
+  eval "$(declare -f _git_commands | sed -e 's/\(base\|main_porcelain\)_commands=(/\1_commands=(${_hub_commands} /')"
 fi


### PR DESCRIPTION
base_commands did not exist on my Ubuntu 12.10 with git 1.7.10.4 and zsh 5.0.0
