### PR TITLE
Always run browse tests with the fakebin `open`

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -37,6 +37,8 @@ Before do
   set_env 'HUB_SYSTEM_GIT', system_git
   # ensure that api.github.com is actually never hit in tests
   set_env 'HUB_TEST_HOST', '127.0.0.1:0'
+  # ensure we use fakebin `open` to test browsing
+  set_env 'BROWSER', 'open'
 
   author_name  = "Hub"
   author_email = "hub@test.local"


### PR DESCRIPTION
Otherwise web pages will be actually openned if the default browser command is
not `open`. Browse tests will all fail as the command will show up in history
only when the fakebin `open` acts as the browser.
