### PR TITLE
Friendly error when pull-request in detached HEAD

### DIFF
--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -3,6 +3,13 @@ Feature: hub pull-request
     Given I am in "dotfiles" git repo
     And I am "mislav" on github.com with OAuth token "OTOKEN"
 
+  Scenario: Detached HEAD
+    Given the "origin" remote has url "git://github.com/mislav/coral.git"
+    And I am in detached HEAD
+    When I run `hub pull-request`
+    Then the stderr should contain "Aborted: not currently on any branch.\n"
+    And the exit status should be 1
+
   Scenario: Non-GitHub repo
     Given the "origin" remote has url "mygh:Manganeez/repo.git"
     When I run `hub pull-request`

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -69,6 +69,12 @@ Given /^I am on the "([^"]+)" branch(?: with upstream "([^"]+)")?$/ do |name, up
   run_silent %(git checkout --quiet -B #{name} --track #{upstream})
 end
 
+Given /^I am in detached HEAD$/ do
+  empty_commit
+  empty_commit
+  run_silent %(git checkout HEAD^)
+end
+
 Given /^the current dir is not a repo$/ do
   in_current_dir do
     FileUtils.rm_rf '.git'

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -81,6 +81,10 @@ module Hub
       base_project = local_repo.main_project
       head_project = local_repo.current_project
 
+      unless current_branch
+        abort "Aborted: not currently on any branch."
+      end
+
       unless base_project
         abort "Aborted: the origin remote doesn't point to a GitHub repository."
       end

--- a/test/hub_test.rb
+++ b/test/hub_test.rb
@@ -308,6 +308,15 @@ class HubTest < Test::Unit::TestCase
     expected = "https://github.com/defunkt/hub/pull/1\n"
     assert_output expected, "pull-request hereyougo -f"
   end
+  
+  def test_pullrequest_detached_head
+    stub_repo_url('git@git.my.org:defunkt/hub.git')
+    stub_branch(nil)
+    stub_tracking('feature', 'origin', 'feature')
+
+    expected = "Aborted: not currently on any branch.\n"
+    assert_output expected, "pull-request hereyougo"
+  end
 
   def test_pullrequest_invalid_remote
     stub_repo_url('gh:singingwolfboy/sekrit.git')


### PR DESCRIPTION
This PR fixes #291 by showing an informative error message when trying
to pull-request in a detached HEAD.
