### PR TITLE
Send User-Agent

### DIFF
--- a/lib/hub/github_api.rb
+++ b/lib/hub/github_api.rb
@@ -180,6 +180,8 @@ module Hub
         apply_authentication(req, url)
         yield req if block_given?
 
+        req['User-Agent'] = "hub/#{Hub::VERSION}"
+
         begin
           res = http.start { http.request(req) }
           res.extend ResponseMethods


### PR DESCRIPTION
GitHub now [requires a User-Agent header for API requests](http://developer.github.com/v3/#user-agent-required). This sends the string `hub/#{Hub::VERSION}` as the User-Agent.
