### PR TITLE
Pull request vim - improve options

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -1004,7 +1004,7 @@ help
         end
       }
       edit_cmd = Array(git_editor).dup
-      edit_cmd << '-c' << 'set ft=gitcommit' if edit_cmd[0] =~ /^[mg]?vim$/
+      edit_cmd << '-c' << 'set ft=git syn=gitcommit' if edit_cmd[0] =~ /^[mg]?vim$/
       edit_cmd << message_file
       system(*edit_cmd)
       abort "can't open text editor for pull request message" unless $?.success?


### PR DESCRIPTION
First of all, thank you for working on this fantastic project. I've began using it daily.

Now about the issue.
I noticed pull request message file is set to `gitcommit` file type. Here are the downsides of it:
- textwidth is set to 72 - perfectly fine when writing actual commits, less so when writing a message that will be read solely on the web. Just for the reference, here is a dummy pull request with `tw=72` when [viewed on github](http://cl.ly/image/3F2g1p3M1y44). I'd just let github's designers worry about text width.
- `DiffGitCached` command is present but broken [link](https://github.com/tpope/vim-git/blob/master/ftplugin/gitcommit.vim#L32).

This pull request I hope eliminates the above mentioned downsides, while keeping the benefits of nice syntax highlighting and `keywordprg` from git file type.
