### PR TITLE
Fix naming: Aruba::Process -> Aruba::SpawnProcess

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 require 'forwardable'
 
 # needed to avoid "Too many open files" on 1.8.7
-Aruba::Process.class_eval do
+Aruba::SpawnProcess.class_eval do
   def close_streams
     @out.close
     @err.close


### PR DESCRIPTION
Aruba::Process was renamed to Aruba:SpawnProcess in 0.5.2

Relevant commit: https://github.com/cucumber/aruba/commit/a9b2171
