### PR TITLE
escape branch name as uri component in hub browse

### DIFF
--- a/features/browse.feature
+++ b/features/browse.feature
@@ -59,6 +59,12 @@ Feature: hub browse
     When I successfully run `hub browse`
     Then "open https://github.com/mislav/dotfiles" should be run
 
+  Scenario: Current branch with special chars
+    Given I am in "git://github.com/mislav/dotfiles.git" git repo
+    And I am on the "fix-bug-#123" branch with upstream "origin/fix-bug-#123"
+    When I successfully run `hub browse`
+    Then "open https://github.com/mislav/dotfiles/tree/fix-bug-%23123" should be run
+
   Scenario: Commits on current branch
     Given I am in "git://github.com/mislav/dotfiles.git" git repo
     And I am on the "feature" branch with upstream "origin/experimental"

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -645,12 +645,13 @@ module Hub
 
         abort "Usage: hub browse [<USER>/]<REPOSITORY>" unless project
 
+        require 'CGI'
         # $ hub browse -- wiki
         path = case subpage = args.shift
         when 'commits'
-          "/commits/#{branch.short_name}"
+          "/commits/#{CGI.escape(branch.short_name).sub("%2F", "/")}"
         when 'tree', NilClass
-          "/tree/#{branch.short_name}" if branch and !branch.master?
+          "/tree/#{CGI.escape(branch.short_name).sub("%2F", "/")}" if branch and !branch.master?
         else
           "/#{subpage}"
         end


### PR DESCRIPTION
if your branch name contains some characters that are significant to
uri's, then `hub browse` sends you to a 404 page. this change uses
`CGI.escape` to properly encode that when constructing the URL.

an example of where this is a problem is if you use topic branches named
by issues stored in an issue tracker, i.e. `fix-something-#123`
indicating what you're working on and the corresponding issue number.

i don't know anything about ruby, but it seems like there's a better way to
do this (adding a `branch.url_name` property [here](https://github.com/defunkt/hub/blob/master/lib/hub/context.rb#L306)?), so please let me
know if you'd prefer i implement something like that.
