### PR TITLE
Add correct hub alias for fish shell (fixes #248)

### DIFF
--- a/features/alias.feature
+++ b/features/alias.feature
@@ -10,6 +10,16 @@ Feature: hub alias
       eval "$(hub alias -s)"\n
       """
 
+  Scenario: fish instructions
+    Given $SHELL is "/usr/local/bin/fish"
+    When I successfully run `hub alias`
+    Then the output should contain exactly:
+      """
+      # Wrap git automatically by adding the following to ~/.config/fish/config.fish:
+
+      eval (hub alias -s)\n
+      """
+
   Scenario: zsh instructions
     Given $SHELL is "/bin/zsh"
     When I successfully run `hub alias`
@@ -22,6 +32,14 @@ Feature: hub alias
 
   Scenario: bash code
     Given $SHELL is "/bin/bash"
+    When I successfully run `hub alias -s`
+    Then the output should contain exactly:
+      """
+      alias git=hub\n
+      """
+
+  Scenario: fish code
+    Given $SHELL is "/usr/local/bin/fish"
     When I successfully run `hub alias -s`
     Then the output should contain exactly:
       """

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -731,13 +731,17 @@ module Hub
           when 'bash' then '~/.bash_profile'
           when 'zsh'  then '~/.zshrc'
           when 'ksh'  then '~/.profile'
+          when 'fish' then '~/.config/fish/config.fish'
           else
             'your profile'
           end
-
         puts "# Wrap git automatically by adding the following to #{profile}:"
         puts
-        puts 'eval "$(hub alias -s)"'
+        if shell == 'fish'
+          puts 'eval (hub alias -s)'
+        else
+          puts 'eval "$(hub alias -s)"'
+        end
       end
 
       exit


### PR DESCRIPTION
Added proper alias and path to fish dotfile `~/.config/fish/config.fish`. Commit adds two new tests; all scenarios + steps pass. @dideler + @KangOl, please let me know if this works for you. :fish:!
