### PR TITLE
add a command for listing all open pull requests

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -70,6 +70,14 @@ module Hub
       abort "fatal: #{err.message}"
     end
 
+    def pulls(args)
+      pull_data = api_client.pullrequests(local_repo.main_project)
+      pull_data.each do |pull|
+        puts "%s - %s\n%s\n\n" %
+          [pull["user"]["login"], pull["title"], pull["html_url"] ]
+      end
+      exit
+    end
 
     # $ hub ci-status
     # $ hub ci-status 6f6d9797f9d6e56c3da623a97cfc3f45daf9ae5f
@@ -858,6 +866,7 @@ Remote Commands:
    push       Upload data, tags and branches to a remote repository
    remote     View and manage a set of remote repositories
 
+
 Advanced Commands:
    reset      Reset your staging area or working directory to another point
    rebase     Re-apply a series of patches in one branch onto another
@@ -866,6 +875,7 @@ Advanced Commands:
 
 GitHub Commands:
    pull-request   Open a pull request on GitHub
+   pulls          List open pull requests on GitHub
    fork           Make a fork of a remote repository on GitHub and add as remote
    create         Create this repository on GitHub and add GitHub as origin
    browse         Open a GitHub page in the default browser

--- a/lib/hub/github_api.rb
+++ b/lib/hub/github_api.rb
@@ -88,6 +88,13 @@ module Hub
       res.data
     end
 
+    def pullrequests project
+      res = get "https://%s/repos/%s/%s/pulls" %
+                [api_host(project.host), project.owner, project.name]
+
+      res.error! unless res.success?
+      res.data
+    end
     # Returns parsed data from the new pull request.
     def create_pullrequest options
       project = options.fetch(:project)

--- a/test/hub_test.rb
+++ b/test/hub_test.rb
@@ -257,6 +257,28 @@ class HubTest < Test::Unit::TestCase
                     "push origin,staging master new-feature"
   end
 
+  def test_pullrequest_list
+    pull1 = {
+      :user => { :login => 'radamant'},
+      :title => 'fixes some bugs',
+      :html_url => 'https://github.com/defunkt/hub/pull/1'
+    }
+
+    pull2 = {
+      :user => { :login => 'defunkt'},
+      :title => 'fixes more bugs',
+      :html_url => 'https://github.com/defunkt/hub/pull/2'
+    }
+
+    stub_request(:get, "https://api.github.com/repos/defunkt/hub/pulls").
+      to_return(:body => Hub::JSON.generate([pull1, pull2]))
+
+    expected =  "radamant - fixes some bugs\nhttps://github.com/defunkt/hub/pull/1\n\n"
+    expected << "defunkt - fixes more bugs\nhttps://github.com/defunkt/hub/pull/2\n\n"
+
+    assert_output expected, 'pulls'
+  end
+
   def test_pullrequest_from_branch_tracking_local
     stub_branch('refs/heads/feature')
     stub_tracking('feature', 'refs/heads/master')


### PR DESCRIPTION
You can run:

`hub pulls`

And get output like:

```
jm3 - Add correct hub alias for fish shell (fixes #248)
https://github.com/defunkt/hub/pull/350

pchw - add pull-request to open-browser option
https://github.com/defunkt/hub/pull/344

mmozuras - Figure out default branch for the project instead of just using master
https://github.com/defunkt/hub/pull/326

timmow - Add info on using with Github Enterprise
https://github.com/defunkt/hub/pull/297

jianli - browse -b flag
https://github.com/defunkt/hub/pull/258
```
