### PR TITLE
Use GitHub's `archive` URL for SHA1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -152,7 +152,7 @@ task :homebrew do
     sh 'git pull -q origin master'
 
     formula_file = 'Library/Formula/hub.rb'
-    sha = `curl -fsSL https://github.com/github/hub/tarball/v#{Hub::VERSION} | shasum`.split(/\s+/).first
+    sha = `curl -fsSL https://github.com/github/hub/archive/v#{Hub::VERSION}.tar.gz | shasum`.split(/\s+/).first
     abort unless $?.success? and sha.length == 40
 
     formula = File.read formula_file


### PR DESCRIPTION
To compensate for
https://github.com/mxcl/homebrew/commit/174acd649c19dbc83f34a6a9e95bdc137b1a2a1b,
we need to use the archive URL, rather than the tarball one so that we
calculate the correct SHA1 when generating the Homebrew formula.
