### PR TITLE
Naming consistency in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,18 +326,18 @@ superpowers:
 
 ### git submodule
 
-    $ hub submodule add wycats/bundler vendor/bundler
+    $ git submodule add wycats/bundler vendor/bundler
     > git submodule add git://github.com/wycats/bundler.git vendor/bundler
 
-    $ hub submodule add -p wycats/bundler vendor/bundler
+    $ git submodule add -p wycats/bundler vendor/bundler
     > git submodule add git@github.com:wycats/bundler.git vendor/bundler
 
-    $ hub submodule add -b ryppl --name pip ryppl/pip vendor/pip
+    $ git submodule add -b ryppl --name pip ryppl/pip vendor/pip
     > git submodule add -b ryppl --name pip git://github.com/ryppl/pip.git vendor/pip
 
 ### git ci-status
 
-    $ hub ci-status [commit]
+    $ git ci-status [commit]
     > (prints CI state of commit and exits with appropriate code)
     > One of: success (0), error (1), failure (1), pending (2), no status (3)
 


### PR DESCRIPTION
In each command we are assuming that we have aliased `hub` as `git`
