### PR TITLE
Alias `pull-request` with `e-note`

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -243,6 +243,12 @@ module Hub
       delete_editmsg
     end
 
+    # $ hub e-note
+    # $ hub e-note "My humble contribution"
+    # $ hub e-note -i 92
+    # $ hub e-note https://github.com/rtomayko/tilt/issues/92
+    alias_method :e_note, :pull_request
+
     # $ hub clone rtomayko/tilt
     # > git clone git://github.com/rtomayko/tilt.
     #

--- a/test/hub_test.rb
+++ b/test/hub_test.rb
@@ -288,6 +288,11 @@ class HubTest < Test::Unit::TestCase
     assert_output expected, "pull-request -m hereyougo -f"
   end
 
+  def test_pullrequest_alias
+    out = hub('e-note')
+    assert_equal hub('pull-request'), out
+  end
+
   def test_version
     out = hub('--version')
     assert_includes "git version 1.7.0.4", out


### PR DESCRIPTION
Alias for `pull-request` so it can be used interchangably to satisfy Fox™ Business' explanation of GitHub:

![fox-news-explanation](https://pbs.twimg.com/media/BT_5S-TCcAA-EF2.jpg)
