### PR TITLE
Rake task for Windows installations (fix for issue #298)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -104,11 +104,13 @@ end
 desc "Build standalone script"
 task :standalone => "hub"
 
-desc "Install standalone script and man pages if unix-based OS. Configure PATH if windows"
+desc "Install standalone script and man pages if unix-based OS. If Windows, install executable and .bat file inside ruby/bin"
 task :install => "hub" do
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
-    Rake::Task[:windows].invoke
+    ruby_dir = RbConfig::CONFIG['bindir']
+    File.open(File.join(ruby_dir, 'hub.bat'), 'w') { |f| f.write('@"ruby.exe" "%~dpn0" %*') }
+    FileUtils.cp 'hub', File.join(ruby_dir, 'hub')
   else 
     prefix = ENV['PREFIX'] || ENV['prefix'] || '/usr/local'
 
@@ -175,9 +177,3 @@ task :homebrew do
     sh "git checkout -q master"
   end
 end
-
-task :windows do
-  ruby_dir = RbConfig::CONFIG['bindir']
-  File.open(ruby_dir + '/hub.bat', 'w') { |f| f.write('@"ruby.exe" "%~dpn0" %*') }
-  FileUtils.cp 'hub', ruby_dir << '/hub'
-end 


### PR DESCRIPTION
I added a rake task called `windows` which adds the hub bin directory to the windows local user `PATH` variable, and also creates a file called `hub.bat` inside the bin directory. This essentially automates the steps I listed in [issue #298](https://github.com/github/hub/issues/298).

The reason I put the existing `install` code inside the `else` check is because there is no environment variable called prefix in windows, nor is there a `/usr/local`. If there's some other way to install `man` pages in windows they can be put outside of the `else`.
