### PR TITLE
Add file path to browse command tree subpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ superpowers:
     $ git browse schacon/ticgit commit/SHA
     > open https://github.com/schacon/ticgit/commit/SHA
 
+    $ git browse schacon/ticgit tree FILE_PATH
+    > open https://github.com/schacon/ticgit/FILE_PATH
+
     $ git browse resque
     > open https://github.com/YOUR_USER/resque
 

--- a/features/browse.feature
+++ b/features/browse.feature
@@ -53,6 +53,12 @@ Feature: hub browse
     When I successfully run `hub browse`
     Then "open https://github.com/mislav/dotfiles/tree/experimental" should be run
 
+  Scenario: Current branch, with file path
+    Given I am in "git://github.com/mislav/dotfiles.git" git repo
+    And I am on the "feature" branch with upstream "origin/experimental"
+    When I successfully run `hub browse -- tree bin/dotfile#L10-15`
+    Then "open https://github.com/mislav/dotfiles/tree/experimental/bin/dotfile#L10-15" should be run
+
   Scenario: Default branch
     Given I am in "git://github.com/mislav/dotfiles.git" git repo
     And the default branch for "origin" is "develop"

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -626,6 +626,9 @@ module Hub
     #
     # $ hub browse github-services wiki
     # > open https://github.com/YOUR_LOGIN/github-services/wiki
+    #
+    # $ hub browse -- tree file_path
+    # > open https://github.com/CURRENT_REPO/CURRENT_BRANCH/file_path
     def browse(args)
       args.shift
       browse_command(args) do
@@ -651,7 +654,9 @@ module Hub
         when 'commits'
           "/commits/#{branch_in_url(branch)}"
         when 'tree', NilClass
-          "/tree/#{branch_in_url(branch)}" if branch and !branch.master?
+          file_path = args.shift
+          file_path = "/" + file_path if file_path
+          "/tree/#{branch_in_url(branch)}#{file_path}" if branch and (!branch.master? || file_path)
         else
           "/#{subpage}"
         end


### PR DESCRIPTION
Hi,

Many times, I would want to show highlighted code to other people. The GitHub interface for traversing through files is slow. Though I can type the file path in the url myself, I miss the autocompletion for files. This pull request will allow:

`git browse github/hub tree lib/hub.rb#L1-8` and it'll open the url `https://github.com/github/hub/tree/master/lib/hub.rb#L1-8`

Let me know what you think! (And if I need to update any documentation)
