### PR TITLE
Use "/usr/bin/env ruby" for shebang if it exists

### DIFF
--- a/lib/hub/standalone.rb
+++ b/lib/hub/standalone.rb
@@ -49,7 +49,8 @@ preamble
     end
 
     def ruby_executable
-      if File.executable? '/usr/bin/ruby' then '/usr/bin/ruby'
+      if File.executable? '/usr/bin/env' then '/usr/bin/env ruby'
+      elsif File.executable? '/usr/bin/ruby' then '/usr/bin/ruby'
       else
         require 'rbconfig'
         File.join RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']


### PR DESCRIPTION
I'm using rbenv usually but some other packages provided by system (Ubuntu) installed old Ruby to `/usr/bin/ruby`. If `/usr/bin/ruby` exists, it is used always. Can it be changed to `/usr/bin/env ruby`?
