### PR TITLE
Trap SIGINT to suppress stack traces

### DIFF
--- a/bin/hub
+++ b/bin/hub
@@ -3,5 +3,8 @@
 # hub(1)
 # alias git=hub
 
+# Trap interrupts to quit without an ugly stack trace.
+Signal.trap("INT") { abort }
+
 require 'hub'
 Hub::Runner.execute(*ARGV)


### PR DESCRIPTION
@mitchellh [via Twitter](https://twitter.com/mitchellh/status/283014103189053442):

> Ruby CLI pro-tip: Avoid crazy stack traces from early Ctrl-Cs by making this your first effective LOC, override later. https://github.com/mitchellh/vagrant/blob/8cc4910fa9ca6059697459d0cdee1557af8d0507/bin/vagrant#L3-L6
