### PR TITLE
ci-status with remote repository specification with -r option

### DIFF
--- a/features/ci_status.feature
+++ b/features/ci_status.feature
@@ -29,6 +29,22 @@ Feature: hub ci-status
     Then the output should contain exactly "success\n"
     And the exit status should be 0
 
+  Scenario: Fetch specified remote commit SHA
+    Given there is a commit named "the_sha"
+    Given the "mislav" remote has url "https://github.com/mislav/pencilbox.git"
+    Given the remote commit state of "mislav/pencilbox" "the_sha" is "success"
+    When I run `hub ci-status -r mislav the_sha`
+    Then the output should contain exactly "success\n"
+    And the exit status should be 0
+
+  Scenario: Fetch specified remote commit SHA with URL
+    Given there is a commit named "the_sha"
+    Given the "mislav" remote has url "https://github.com/mislav/pencilbox.git"
+    Given the remote commit state of "mislav/pencilbox" "the_sha" is "success"
+    When I run `hub ci-status -r mislav the_sha -v`
+    Then the output should contain "success: https://travis-ci.org/mislav/pencilbox/builds/1234567"
+    And the exit status should be 0
+
   Scenario: Exit status 1 for 'error' and 'failure'
     Given the remote commit state of "michiels/pencilbox" "HEAD" is "error"
     When I run `hub ci-status`

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -77,10 +77,20 @@ module Hub
     # $ hub ci-status origin/master
     def ci_status(args)
       args.shift
-      ref = args.words.first || 'HEAD'
-      verbose = args.include?('-v')
+      verbose = !!args.delete('-v')
+      ref = 'HEAD'
+      project = local_repo.main_project
 
-      unless project = local_repo.main_project
+      while arg = args.shift
+        case arg
+        when '-r'
+          project = local_repo.remote_by_name(args.shift).project
+        else
+          ref = arg
+        end
+      end
+
+      unless project
         abort "Aborted: the origin remote doesn't point to a GitHub repository."
       end
 


### PR DESCRIPTION
When local repository's remotes are like:
- michiels https://github.com/michiels/pencilbox.git
- mine https://github.com/__username__/pencilbox.git

Then run `ci-status` fetches always from 'michiels' remote's build status.
Because there are no 'upstream', 'github' or 'origin' remote names.
So, based on dictionary order, 'michiels' remote is choosed as a main
remote repository and there is no way to fetch 'mine' remote ci-status.

This commit make it possible to choose remote repository's commit
build status with -r option like:

```
hub ci-status -r mine __commit_sha__
```

You can also use -v option to retrieve build url:

```
hub ci-status -r mine __commit_sha__ -v
```
