### PR TITLE
439 PR title is empty

### DIFF
--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -102,6 +102,33 @@ Feature: hub pull-request
     Then the output should contain exactly "https://github.com/mislav/coral/pull/12\n"
     And the file ".git/PULLREQ_EDITMSG" should not exist
 
+  Scenario: Text editor adds title and body with multiple lines
+    Given the text editor adds:
+      """
+
+
+      This title is on the third line
+
+
+      This body
+
+
+      has multiple
+      lines.
+
+      """
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :title => 'This title is on the third line',
+               :body  => "This body\n\n\nhas multiple\nlines."
+        json :html_url => "https://github.com/mislav/coral/pull/12"
+      }
+      """
+    When I successfully run `hub pull-request`
+    Then the output should contain exactly "https://github.com/mislav/coral/pull/12\n"
+    And the file ".git/PULLREQ_EDITMSG" should not exist
+
   Scenario: Failed pull request preserves previous message
     Given the text editor adds:
       """

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -1102,7 +1102,7 @@ help
       File.open(file, 'r') { |msg|
         msg.each_line do |line|
           next if line.index('#') == 0
-          ((body.empty? and line =~ /\S/) ? title : body) << line
+          ((title.empty? and line =~ /\S/) ? title : body) << line
         end
       }
       title.tr!("\n", ' ')


### PR DESCRIPTION
I hope you don't mind me jumping in to get a pull request for this issue. Seems like a simple fix. :smile:

The logic I was thinking of was:

``` ruby
if line =~ /\S/ and title.empty?
  title << line
elsif !title.empty?
  body << line
end
```

But the `strip!` call allows for a even simpler change. 

Fixes #439
