### PR TITLE
Fork fetch illusion

### DIFF
--- a/features/fork.feature
+++ b/features/fork.feature
@@ -17,6 +17,20 @@ Feature: hub fork
     And "git remote set-url mislav git@github.com:mislav/dotfiles.git" should be run
     And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
 
+  Scenario: Fork the repository when origin URL is private
+    Given the "origin" remote has url "git@github.com:evilchelu/dotfiles.git"
+    Given the GitHub API server:
+      """
+      before { halt 401 unless request.env['HTTP_AUTHORIZATION'] == 'token OTOKEN' }
+      get('/repos/mislav/dotfiles', :host_name => 'api.github.com') { 404 }
+      post('/repos/evilchelu/dotfiles/forks', :host_name => 'api.github.com') { '' }
+      """
+    When I successfully run `hub fork`
+    Then the output should contain exactly "new remote: mislav\n"
+    And "git remote add -f mislav ssh://git@github.com/evilchelu/dotfiles.git" should be run
+    And "git remote set-url mislav git@github.com:mislav/dotfiles.git" should be run
+    And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
+
   Scenario: --no-remote
     Given the GitHub API server:
       """

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -556,8 +556,9 @@ module Hub
       if args.include?('--no-remote')
         exit
       else
+        origin_url = project.remote.github_url
         url = forked_project.git_url(:private => true, :https => https_protocol?)
-        args.replace %W"remote add -f #{forked_project.owner} #{project.git_url}"
+        args.replace %W"remote add -f #{forked_project.owner} #{origin_url}"
         args.after %W"remote set-url #{forked_project.owner} #{url}"
         args.after 'echo', ['new remote:', forked_project.owner]
       end

--- a/lib/hub/context.rb
+++ b/lib/hub/context.rb
@@ -397,6 +397,10 @@ module Hub
         nil
       end
 
+      def github_url
+        urls.detect {|url| local_repo.known_host?(url.host) }
+      end
+
       def urls
         @urls ||= raw_urls.map do |url|
           with_normalized_url(url) do |normalized|


### PR DESCRIPTION
See [#301](https://github.com/github/hub/issues/301#issuecomment-32990717).

Forking is done asynchronously through the GitHub API call so running `git remote add -f ...` can result in a error if the fork hasn't been created yet. 

This pull request uses an alternative to fetching the fork. It insteads fetches from the "origin" and then set the remote url to the fork.
