### PR TITLE
gh: release command improvements

### DIFF
--- a/commands/release_test.go
+++ b/commands/release_test.go
@@ -1,52 +1,52 @@
 package commands
 
-import (
-	"github.com/bmizerany/assert"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"testing"
-)
+//import (
+//	"github.com/bmizerany/assert"
+//	"io/ioutil"
+//	"os"
+//	"path/filepath"
+//	"testing"
+//)
 
-func TestAssetsDirWithoutFlag(t *testing.T) {
-	dir := createTempDir(t)
-	pwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		os.Chdir(pwd)
-		os.RemoveAll(dir)
-	}()
-
-	os.Chdir(dir)
-
-	tagDir := filepath.Join(dir, "releases", "v1.0.0")
-	assertAssetsDirSelected(t, tagDir, "")
-}
-
-func TestAssetsDirWithFlag(t *testing.T) {
-	dir := createTempDir(t)
-	defer os.RemoveAll(dir)
-
-	tagDir := filepath.Join(dir, "releases", "v1.0.0")
-	assertAssetsDirSelected(t, tagDir, tagDir)
-}
-
-func assertAssetsDirSelected(t *testing.T, expectedDir, flagDir string) {
-	assets, err := getAssetsDirectory(flagDir, "v1.0.0")
-	assert.NotEqual(t, nil, err) // Error if it doesn't exist
-
-	os.MkdirAll(expectedDir, 0755)
-	assets, err = getAssetsDirectory(flagDir, "v1.0.0")
-	assert.NotEqual(t, nil, err) // Error if it's empty
-
-	ioutil.TempFile(expectedDir, "gh-test")
-	assets, err = getAssetsDirectory(flagDir, "v1.0.0")
-
-	fiExpected, err := os.Stat(expectedDir)
-	fiAssets, err := os.Stat(assets)
-
-	assert.Equal(t, nil, err)
-	assert.T(t, os.SameFile(fiExpected, fiAssets))
-}
+//func TestAssetsDirWithoutFlag(t *testing.T) {
+//	dir := createTempDir(t)
+//	pwd, err := os.Getwd()
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	defer func() {
+//		os.Chdir(pwd)
+//		os.RemoveAll(dir)
+//	}()
+//
+//	os.Chdir(dir)
+//
+//	tagDir := filepath.Join(dir, "releases", "v1.0.0")
+//	assertAssetsDirSelected(t, tagDir, "")
+//}
+//
+//func TestAssetsDirWithFlag(t *testing.T) {
+//	dir := createTempDir(t)
+//	defer os.RemoveAll(dir)
+//
+//	tagDir := filepath.Join(dir, "releases", "v1.0.0")
+//	assertAssetsDirSelected(t, tagDir, tagDir)
+//}
+//
+//func assertAssetsDirSelected(t *testing.T, expectedDir, flagDir string) {
+//	assets, err := getAssetsDirectory(flagDir, "v1.0.0")
+//	assert.NotEqual(t, nil, err) // Error if it doesn't exist
+//
+//	os.MkdirAll(expectedDir, 0755)
+//	assets, err = getAssetsDirectory(flagDir, "v1.0.0")
+//	assert.NotEqual(t, nil, err) // Error if it's empty
+//
+//	ioutil.TempFile(expectedDir, "gh-test")
+//	assets, err = getAssetsDirectory(flagDir, "v1.0.0")
+//
+//	fiExpected, err := os.Stat(expectedDir)
+//	fiAssets, err := os.Stat(assets)
+//
+//	assert.Equal(t, nil, err)
+//	assert.T(t, os.SameFile(fiExpected, fiAssets))
+//}


### PR DESCRIPTION
Fixes #477

I've removed the defaults for the release command and now it will only upload assets explicitly. It detects whether you want to upload a file of every file inside a directory using the flag --attach or -a.

This change made all the tests that we had for this command obsolete. I'm trying to find a way we can add some coverage to the new changes.
