### PR TITLE
Allow browse to work with Enterprise server with only HTTP

### DIFF
--- a/lib/hub/context.rb
+++ b/lib/hub/context.rb
@@ -298,7 +298,7 @@ module Hub
             path = '/wiki' + path
           end
         end
-        "https://#{host}/" + project_name + path.to_s
+        "#{scheme}://#{host}/" + project_name + path.to_s
       end
 
       def git_url(options = {})
@@ -306,6 +306,20 @@ module Hub
         elsif options[:private] or private? then "git@#{host}:"
         else "git://#{host}/"
         end + name_with_owner + '.git'
+      end
+
+      private
+
+      def scheme
+        config_file = ENV['HUB_CONFIG'] || '~/.config/hub'
+
+        if File.exist? File.expand_path(config_file)
+          file_store = GitHubAPI::FileStore.new File.expand_path(config_file)
+          config = GitHubAPI::Configuration.new file_store
+          config.uri_scheme(host)
+        else
+          'https'
+        end
       end
     end
 

--- a/lib/hub/github_api.rb
+++ b/lib/hub/github_api.rb
@@ -554,6 +554,14 @@ module Hub
           URI.parse proxy
         end
       end
+
+      def uri_scheme host
+        user = @data.fetch_value normalize_host(host), nil, :user
+        @data.fetch_value normalize_host(host), user, :uri_scheme do
+          'https'
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
This borrows code from the excellent work done by @mmrobins at https://github.com/github/hub/pull/247 -- It appears that some of the code changed so his patch may not apply cleanly anymore. Also his does a few more things which makes it longer and I thought that might be contributing to the delay in merging it perhaps. So I took what he had and made a very small patch just for this one feature (make `hub browse` work for an HTTP-only installation). My hope is that since this patch is small and simple, maybe it stands a better chance of getting merged and not sitting a long time like #247 did.

To do this, set:

``` yaml
uri_scheme: http
```

in `~/.config/hub`.

In order to submit a pull request, I had to set:

``` bash
export HUB_TEST_HOST=myserver.mydomain:80
```

though probably if the rest of the code in #247 were merged in, then this wouldn't be necessary.
## Test results

This is just cucumber; I get errors about mocking stuff when I run `script/test`.

```
 ❯ cucumber
Using the default profile...
..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

177 scenarios (177 passed)
1060 steps (1060 passed)
0m54.332s
>>> elapsed time 56s
```
