### PR TITLE
Extract out script/godep for running any Go command

### DIFF
--- a/script/build
+++ b/script/build
@@ -5,16 +5,6 @@
 
 set -e
 
-TMP_GOPATH="${TMPDIR:-/tmp}/go"
-TMP_SELF="${TMP_GOPATH}/src/github.com/jingweno/gh"
-
-export GOPATH="${TMP_GOPATH}:${PWD}/Godeps/_workspace:$GOPATH"
-
-if [ ! -e "$TMP_SELF" ]; then
-  mkdir -p "${TMP_SELF%/*}"
-  ln -snf "$PWD" "$TMP_SELF"
-fi
-
 find_source_files() {
   find . -maxdepth 2 -name '*.go' -not -name '*_test.go' "$@"
 }
@@ -29,10 +19,10 @@ up_to_date() {
 
 case "$1" in
 "" )
-  up_to_date hub || go build -o hub
+  up_to_date hub || ./script/godep go build -o hub
   ;;
 test )
-  go test ./...
+  ./script/godep go test ./...
   ;;
 -h | --help )
   sed -ne '/^#/!q;s/.\{1,2\}//;1d;p' < "$0"

--- a/script/godep
+++ b/script/godep
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Usage: script/build [test]
+#
+# Sets up GOPATH and run command
+
+set -e
+
+TMP_GOPATH="${TMPDIR:-/tmp}/go"
+TMP_SELF="${TMP_GOPATH}/src/github.com/jingweno/gh"
+
+export GOPATH="${TMP_GOPATH}:${PWD}/Godeps/_workspace:$GOPATH"
+
+if [ ! -e "$TMP_SELF" ]; then
+  mkdir -p "${TMP_SELF%/*}"
+  ln -snf "$PWD" "$TMP_SELF"
+fi
+
+$@


### PR DESCRIPTION
Now I could run any Go command with the right `GOPATH`: `script/godep go xxx`. Similar to `godep go xxx`
