### PR TITLE
pull-request: Ensure head is pulled from current branch if empty

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -184,6 +184,7 @@ module Hub
 
       options[:project] = base_project
       options[:base] ||= master_branch.short_name
+      options[:head] = nil if options[:head].empty?
 
       if options[:head].nil? && tracked_branch
         if !tracked_branch.remote?


### PR DESCRIPTION
In both companies that I've worked at, the practice is to clone the primary repo to our development machines, not to fork into your account and work against that. This means that `hub pull-request` used for code review purposes don't work by default, and there's lots of repetition when using `-h`.

The current workflow is that if I'm on branch `really-neat-change`, just using `hub pull-request` results in a pull request from `person:really-neat-change` onto `organization:master`. What I'm actually wanting is a pull request from `organization:really-neat-change` onto `organization:master`. I can do this manually with: `hub pull-request -h organization:really-neat-change`.

This code change makes it possible to do `hub pull-request -h organization:` and it will infer `really-neat-branch` the same way it does automatically. I'm not sure this is the _best_ choice; there are at least two other options:
1. `hub` could probably look at `origin` to see the person/organization it belongs to as a default behaviour, rather than assuming the user;
2. `hub pull-request` could accept a different parameter (`-o`?) to indicate an alternate organization/person.

I think `-h organization:` is reasonably clear and simple, but I can see that there are perhaps other (better? clearer?) ways.
