### PR TITLE
Hub merge should use rep name from api

### DIFF
--- a/features/merge.feature
+++ b/features/merge.feature
@@ -11,7 +11,7 @@ Feature: hub merge
       get('/repos/defunkt/hub/pulls/164') { json \
         :head => {
           :label => 'jfirebaugh:hub_merge',
-          :repo  => {:private => false}
+          :repo  => {:private => false, :name=>"hub"}
         },
         :title => "Add `hub merge` command"
       }
@@ -34,7 +34,7 @@ Feature: hub merge
       get('/repos/defunkt/hub/pulls/164') { json \
         :head => {
           :label => 'jfirebaugh:hub_merge',
-          :repo  => {:private => false}
+          :repo  => {:private => false, :name=>"hub"}
         },
         :title => "Add `hub merge` command"
       }
@@ -55,7 +55,7 @@ Feature: hub merge
       get('/repos/defunkt/hub/pulls/164') { json \
         :head => {
           :label => 'jfirebaugh:hub_merge',
-          :repo  => {:private => true}
+          :repo  => {:private => true, :name=>"hub"}
         },
         :title => "Add `hub merge` command"
       }
@@ -81,6 +81,21 @@ Feature: hub merge
       """
       Error: jfirebaugh's fork is not available anymore\n
       """
+
+  Scenario: Renamed repo
+    Given the GitHub API server:
+      """
+      require 'json'
+      get('/repos/defunkt/hub/pulls/164') { json \
+        :head => {
+          :label => 'jfirebaugh:hub_merge',
+          :repo  => {:private => false, :name=>"hub-1"}
+        }
+      }
+      """
+    And there is a commit named "jfirebaugh/hub_merge"
+    When I successfully run `hub merge https://github.com/defunkt/hub/pull/164`
+    Then "git fetch git://github.com/jfirebaugh/hub-1.git +refs/heads/hub_merge:refs/remotes/jfirebaugh/hub_merge" should be run
 
   Scenario: Unchanged merge
     When I run `hub merge master`

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -443,8 +443,9 @@ module Hub
         user, branch = pull_data['head']['label'].split(':', 2)
         abort "Error: #{user}'s fork is not available anymore" unless pull_data['head']['repo']
 
-        url = github_project(url.project_name, user).git_url(:private => pull_data['head']['repo']['private'],
-                                                             :https => https_protocol?)
+        repo_name = pull_data['head']['repo']['name']
+        url = github_project(repo_name, user).git_url(:private => pull_data['head']['repo']['private'],
+                                                      :https => https_protocol?)
 
         merge_head = "#{user}/#{branch}"
         args.before ['fetch', url, "+refs/heads/#{branch}:refs/remotes/#{merge_head}"]


### PR DESCRIPTION
See #379. Seems like an easy fix so I went ahead and did that! (even though I know hub is transitioning to go).

If you would like to try this on an actual repository, you can use it on https://github.com/ivantsepp/yolo10/pull/1 for now :wink: 

From the commit:

The repository name of the pull request head doesn't necessarily match the
name of the project's repository. This can happen when a user forks a project
but already has a repository of the same name. Use the name returned in the
api response for the fetch url to avoid this edge case.
