### PR TITLE
Add pull request templates

### DIFF
--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -466,3 +466,28 @@ Feature: hub pull-request
       """
     When I successfully run `hub pull-request -o -m hereyougo`
     Then "open the://url" should be run
+
+  Scenario: Configure and use a pull-request template
+    Given I successfully run `git config --global hub.pull-request-template-path test-pullreq-template`
+    And a file named "test-pullreq-template" with:
+      """
+      This text comes from a template.
+
+      This text comes from a template as well.
+      """
+    And the text editor adds:
+      """
+      This text comes from vim!
+
+      This text comes from vim as well.
+      """
+    And the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :title => 'This text comes from vim!',
+               :body  => "This text comes from vim as well.\n\nThis text comes from a template.\n\nThis text comes from a template as well."
+        json :html_url => "https://github.com/mislav/coral/pull/12"
+      }
+      """
+    When I successfully run `hub pull-request`
+    Then the file ".git/PULLREQ_EDITMSG" should not exist

--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -232,7 +232,11 @@ module Hub
 
         options[:title], options[:body] = pullrequest_editmsg(commit_summary) { |msg, initial_message|
           initial_message ||= default_message
-          msg.puts initial_message if initial_message
+          if using_pullrequest_template?
+            msg.puts pullrequest_template
+          else
+            msg.puts initial_message if initial_message
+          end
           msg.puts ""
           msg.puts "# Requesting a pull to #{base_project.owner}:#{options[:base]} from #{options[:head]}"
           msg.puts "#"
@@ -257,6 +261,18 @@ module Hub
       exit 1
     else
       delete_editmsg
+    end
+
+    def using_pullrequest_template?
+      pullrequest_template_path != ''
+    end
+
+    def pullrequest_template
+      File.read(File.expand_path(pullrequest_template_path)).strip
+    end
+
+    def pullrequest_template_path
+      `git config --get hub.pull-request-template-path`.strip
     end
 
     # $ hub e-note


### PR DESCRIPTION
Configure a template file:

```
git config --global --add hub.pull-request-template-path ~/.pr-template
```

Now when you run:

```
hub pull-request
```

Your editor will be pre-populated with the contents of the file.

This can help teams who want to encourage good pull requests.

http://quickleft.com/blog/pull-request-templates-make-code-review-easier
