### PR TITLE
use HTTPS in project URL in gemspec

### DIFF
--- a/hub.gemspec
+++ b/hub.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name              = "hub"
   s.version           = Hub::VERSION
   s.summary           = "Command-line wrapper for git and GitHub"
-  s.homepage          = "http://hub.github.com/"
+  s.homepage          = "https://hub.github.com/"
   s.email             = "mislav.marohnic@gmail.com"
   s.authors           = [ "Chris Wanstrath", "Mislav Marohnić" ]
   s.license           = "MIT"


### PR DESCRIPTION
This pull request updates the hub gemspec metadata to use an encrypted HTTPS URL for the gem's homepage.
