### PR TITLE
-m is not accepted in hub pull-request

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ superpowers:
     [ opened pull request on GitHub for "YOUR_USER:feature" ]
 
     # explicit title, pull base & head:
-    $ git pull-request -m "Implemented feature X" -b defunkt:master -h mislav:feature
+    $ git pull-request "Implemented feature X" -b defunkt:master -h mislav:feature
 
 ### git checkout
 


### PR DESCRIPTION
## Bad Examples

```
∴ hub pull-request -m "Fix spec suite typo; All tests now pass" -b sevos:master -h pboling:fix-specs
invalid argument: Fix spec suite typo; All tests now pass
```

```
∴ hub pull-request -m "All tests now pass" -b sevos:master -h pboling:fix-specs
invalid argument: All tests now pass
```
## Good example

```
∴ hub pull-request "Fix spec suite typo; All tests now pass" -b sevos:master -h pboling:fix-specs
https://github.com/sevos/zeus-parallel_tests/pull/28
```
