### PR TITLE
Add HTTPS support to hub remote

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -339,6 +339,7 @@ module Hub
       end
       return unless user # do not touch arguments
 
+      https = args.delete('-h')
       ssh = args.delete('-p')
 
       if args.words[2] == 'origin' && args.words[3].nil?
@@ -356,7 +357,7 @@ module Hub
         args.pop
       end
 
-      args << git_url(user, repo, :private => ssh)
+      args << git_url(user, repo, :https => https, :private => ssh)
     end
 
     # $ hub fetch mislav


### PR DESCRIPTION
In some cases you need to use an HTTPS remote (depending on how draconian the firewall is), so I added `hub remote -h` to make it easy to create such remotes.
