### PR TITLE
Don't wrap default pull request message

### DIFF
--- a/lib/hub/commands.rb
+++ b/lib/hub/commands.rb
@@ -222,11 +222,11 @@ module Hub
         when 0
           default_message = commit_summary = nil
         when 1
-          format = '%w(78,0,0)%s%n%+b'
+          format = '%w(0,0,0)%s%n%+b'
           default_message = git_command "show -s --format='#{format}' #{commits.first}"
           commit_summary = nil
         else
-          format = '%h (%aN, %ar)%n%w(78,3,3)%s%n%+b'
+          format = '%h (%aN, %ar)%n%w(0,3,3)%s%n%+b'
           default_message = nil
           commit_summary = git_command "log --no-color --format='%s' --cherry %s...%s" %
             [format, base_branch, remote_branch]


### PR DESCRIPTION
GitHub's markdown parsing honors line breaks. Since you don't want hard-wrapped lines when submitting a pull request, this means that it's annoying to have them added to the pre-filled markdown message. This change causes lines not to be wrapped by default.
