### PR TITLE
Remove sensitivity to leading double slashes

### DIFF
--- a/lib/hub/context.rb
+++ b/lib/hub/context.rb
@@ -251,7 +251,7 @@ module Hub
     class GithubProject < Struct.new(:local_repo, :owner, :name, :host)
       def self.from_url(url, local_repo)
         if local_repo.known_host?(url.host)
-          _, owner, name = url.path.split('/', 4)
+          owner, name = url.path.gsub(/^\/+/, '').split('/', 3)
           GithubProject.new(local_repo, owner, name.sub(/\.git$/, ''), url.host)
         end
       end


### PR DESCRIPTION
For whatever reason, I ended up with a URL that looked like "ssh://git@github.com//org/repo.git". The double slash was causing `owner` to be "repo" and `name` to be nil. This lead to situations like this:

```
⇒ hub pull-request -b release
Error creating pull request: Not Found (HTTP 404)
Are you sure that github.com//repo exists?
```

Cleaned up the code to trim leading slashes.
