### PR TITLE
gh: Fix merge PR title to be followed with proper new line

### DIFF
--- a/commands/merge.go
+++ b/commands/merge.go
@@ -73,7 +73,7 @@ func transformMergeArgs(args *Args) error {
 	idx := args.IndexOfParam(mergeURL)
 	args.RemoveParam(idx)
 
-	mergeMsg := fmt.Sprintf(`"Merge pull request #%v from %s\n\n%s"`, id, mergeHead, pullRequest.Title)
+	mergeMsg := fmt.Sprintf("Merge pull request #%v from %s\n\n%s", id, mergeHead, pullRequest.Title)
 	args.AppendParams(mergeHead, "-m", mergeMsg)
 
 	if args.IndexOfParam("--ff-only") == -1 {


### PR DESCRIPTION
Now, merge pull-request makes a commit like:

```
Merge pull request #8 from yasuoza/blahblah\n\nOriginal Pull Request Title
```

This commit fixes it to:

```
Merge pull request #8 from yasuoza/blahblah

Original Pull Request Title
```
