### PR TITLE
Refactor to `configService` to read & write `Config`

### DIFF
--- a/commands/clone.go
+++ b/commands/clone.go
@@ -59,8 +59,8 @@ func transformCloneArgs(args *Args) {
 				name, owner := parseCloneNameAndOwner(a)
 				var host *github.Host
 				if owner == "" {
-					configs := github.CurrentConfigs()
-					h, err := configs.DefaultHost()
+					config := github.CurrentConfig()
+					h, err := config.DefaultHost()
 					if err != nil {
 						utils.Check(github.FormatError("cloning repository", err))
 					}

--- a/commands/create.go
+++ b/commands/create.go
@@ -73,8 +73,8 @@ func create(command *Command, args *Args) {
 		newRepoName = args.FirstParam()
 	}
 
-	configs := github.CurrentConfigs()
-	host, err := configs.DefaultHost()
+	config := github.CurrentConfig()
+	host, err := config.DefaultHost()
 	if err != nil {
 		utils.Check(github.FormatError("creating repository", err))
 	}

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -2,9 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/github/hub/github"
 	"github.com/github/hub/utils"
-	"os"
 )
 
 var cmdFork = &Command{
@@ -41,8 +42,8 @@ func fork(cmd *Command, args *Args) {
 		utils.Check(fmt.Errorf("Error: repository under 'origin' remote is not a GitHub project"))
 	}
 
-	configs := github.CurrentConfigs()
-	host, err := configs.PromptForHost(project.Host)
+	config := github.CurrentConfig()
+	host, err := config.PromptForHost(project.Host)
 	if err != nil {
 		utils.Check(github.FormatError("forking repository", err))
 	}

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -86,7 +86,7 @@ func pullRequest(cmd *Command, args *Args) {
 	baseProject, err := localRepo.MainProject()
 	utils.Check(err)
 
-	host, err := github.CurrentConfigs().PromptForHost(baseProject.Host)
+	host, err := github.CurrentConfig().PromptForHost(baseProject.Host)
 	if err != nil {
 		utils.Check(github.FormatError("creating pull request", err))
 	}

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -69,7 +69,7 @@ func transformRemoteArgs(args *Args) {
 	isPriavte := parseRemotePrivateFlag(args)
 	if len(words) == 2 && words[1] == "origin" {
 		// Origin special case triggers default user/repo
-		host, err := github.CurrentConfigs().DefaultHost()
+		host, err := github.CurrentConfig().DefaultHost()
 		if err != nil {
 			utils.Check(github.FormatError("adding remote", err))
 		}

--- a/github/client.go
+++ b/github/client.go
@@ -443,7 +443,7 @@ func (client *Client) FindOrCreateToken(user, password, twoFactorCode string) (t
 
 func (client *Client) api() (c *octokit.Client, err error) {
 	if client.Host.AccessToken == "" {
-		host, e := CurrentConfigs().PromptForHost(client.Host.Host)
+		host, e := CurrentConfig().PromptForHost(client.Host.Host)
 		if e != nil {
 			err = e
 			return

--- a/github/config_decoder.go
+++ b/github/config_decoder.go
@@ -1,0 +1,19 @@
+package github
+
+import (
+	"io"
+
+	"github.com/BurntSushi/toml"
+)
+
+type configDecoder interface {
+	Decode(r io.Reader, v interface{}) error
+}
+
+type tomlConfigDecoder struct {
+}
+
+func (t *tomlConfigDecoder) Decode(r io.Reader, v interface{}) error {
+	_, err := toml.DecodeReader(r, v)
+	return err
+}

--- a/github/config_encoder.go
+++ b/github/config_encoder.go
@@ -1,0 +1,19 @@
+package github
+
+import (
+	"io"
+
+	"github.com/BurntSushi/toml"
+)
+
+type configEncoder interface {
+	Encode(w io.Writer, v interface{}) error
+}
+
+type tomlConfigEncoder struct {
+}
+
+func (t *tomlConfigEncoder) Encode(w io.Writer, v interface{}) error {
+	enc := toml.NewEncoder(w)
+	return enc.Encode(v)
+}

--- a/github/config_service.go
+++ b/github/config_service.go
@@ -1,0 +1,43 @@
+package github
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func newConfigService() *configService {
+	return &configService{
+		Encoder: &tomlConfigEncoder{},
+		Decoder: &tomlConfigDecoder{},
+	}
+}
+
+type configService struct {
+	Encoder configEncoder
+	Decoder configDecoder
+}
+
+func (s *configService) Save(filename string, c *Config) error {
+	err := os.MkdirAll(filepath.Dir(filename), 0771)
+	if err != nil {
+		return err
+	}
+
+	w, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	return s.Encoder.Encode(w, c)
+}
+
+func (s *configService) Load(filename string, c *Config) error {
+	r, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	return s.Decoder.Decode(r, c)
+}

--- a/github/config_service_test.go
+++ b/github/config_service_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/github/hub/fixtures"
 )
 
-func TestConfigs_loadFrom(t *testing.T) {
-	testConfigs := fixtures.SetupTestConfigs()
-	defer testConfigs.TearDown()
+func TestConfigService_Load(t *testing.T) {
+	testConfig := fixtures.SetupTestConfigs()
+	defer testConfig.TearDown()
 
-	cc := &Configs{}
-	err := loadFrom(testConfigs.Path, cc)
+	cc := &Config{}
+	err := newConfigService().Load(testConfig.Path, cc)
 	assert.Equal(t, nil, err)
 
 	assert.Equal(t, 1, len(cc.Hosts))
@@ -26,7 +26,7 @@ func TestConfigs_loadFrom(t *testing.T) {
 	assert.Equal(t, "http", host.Protocol)
 }
 
-func TestConfigs_saveTo(t *testing.T) {
+func TestConfigService_Save(t *testing.T) {
 	file, _ := ioutil.TempFile("", "test-gh-config-")
 	defer os.RemoveAll(file.Name())
 
@@ -36,9 +36,9 @@ func TestConfigs_saveTo(t *testing.T) {
 		AccessToken: "123",
 		Protocol:    "https",
 	}
-	c := Configs{Hosts: []Host{host}}
+	c := Config{Hosts: []Host{host}}
 
-	err := saveTo(file.Name(), &c)
+	err := newConfigService().Save(file.Name(), &c)
 	assert.Equal(t, nil, err)
 
 	b, _ := ioutil.ReadFile(file.Name())

--- a/github/project.go
+++ b/github/project.go
@@ -151,7 +151,7 @@ func newProject(owner, name, host, protocol string) *Project {
 		protocol = ""
 	}
 	if protocol == "" {
-		h := CurrentConfigs().Find(host)
+		h := CurrentConfig().Find(host)
 		if h != nil {
 			protocol = h.Protocol
 		}
@@ -161,7 +161,7 @@ func newProject(owner, name, host, protocol string) *Project {
 	}
 
 	if owner == "" {
-		h := CurrentConfigs().Find(host)
+		h := CurrentConfig().Find(host)
 		if h != nil {
 			owner = h.User
 		}


### PR DESCRIPTION
`configService` can save and load `Config` using a strategy of `configEncoder`
and `configDecoder`. This pave the path for swapping out `tomlConfigEncoder`
and `tomlConfigDecoder` with `yamlConfigEncoder` and `yamlConfigDecoder`.

`Configs` also has been renamed to `Config`.

/cc @mislav 
