### PR TITLE
gh: Provide option to build `hub` without autoupdate

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -116,7 +116,6 @@ GitHub Commands:
    ci-status      Show the CI status of a commit
 
 See 'git help <command>' for more information on a specific command.
-Run 'git selfupdate' to update to the latest version of gh.
 `
 
 func printUsage() {

--- a/commands/selfupdate.go
+++ b/commands/selfupdate.go
@@ -1,15 +1,16 @@
 package commands
 
 import (
-	"github.com/github/hub/utils"
 	"os"
+
+	"github.com/github/hub/utils"
 )
 
 var cmdSelfupdate = &Command{
 	Run:   update,
 	Usage: "selfupdate",
-	Short: "Update gh",
-	Long: `Update gh to the latest version.
+	Short: "Update Hub",
+	Long: `Update Hub to the latest version.
 
 Examples:
   git selfupdate

--- a/commands/updater_config_noupdate.go
+++ b/commands/updater_config_noupdate.go
@@ -1,0 +1,9 @@
+// +build noupdate
+
+package commands
+
+import "os"
+
+func init() {
+	os.Setenv("HUB_AUTOUPDATE", "never")
+}

--- a/script/build
+++ b/script/build
@@ -19,7 +19,8 @@ up_to_date() {
 
 case "$1" in
 "" )
-  up_to_date hub || ./script/godep go build -o hub
+  # always build with noupdate for now until Hub 2.0 is released
+  up_to_date hub || ./script/godep go build -o hub --tags noupdate
   ;;
 test )
   ./script/godep go test ./...


### PR DESCRIPTION
Use Go build tag to build with/without autoupdate. For Homebrew, we build with `./script/build noupdate` and let it handle the update. We could also build with `./script/build` which has autoupdate built-in.

/cc @mislav 
