### PR TITLE
fix for github:e that supports http protocol only

### DIFF
--- a/lib/hub/github_api.rb
+++ b/lib/hub/github_api.rb
@@ -308,6 +308,7 @@ module Hub
           end
         end
 
+        url = URI.parse(url.to_s)
         http = Net::HTTP.new(url.host, url.port, *proxy_args)
 
         if http.use_ssl = use_ssl


### PR DESCRIPTION
When using gh:e on http protocol,
url.scheme was updated, but url.class is still URI::HTTPS,
so api try to connect 443 port and fail.
