### PR TITLE
[gh] `pull-request` resolves base branch and HEAD to upstream

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -146,6 +146,7 @@ func pullRequest(cmd *Command, args *Args) {
 
 	fullBase := fmt.Sprintf("%s:%s", baseProject.Owner, base)
 	fullHead := fmt.Sprintf("%s:%s", headProject.Owner, head)
+	remoteBranch := fmt.Sprintf("%s/%s", headProject.Remote, head)
 
 	if !force && trackedBranch != nil {
 		remoteCommits, _ := git.RefList(trackedBranch.LongName(), "")
@@ -158,7 +159,8 @@ func pullRequest(cmd *Command, args *Args) {
 
 	var editor *github.Editor
 	if title == "" && flagPullRequestIssue == "" {
-		message, err := pullRequestChangesMessage(base, head, fullBase, fullHead)
+		baseBranch := fmt.Sprintf("%s/%s", baseProject.Remote, base)
+		message, err := pullRequestChangesMessage(baseBranch, remoteBranch, fullBase, fullHead)
 		utils.Check(err)
 
 		editor, err = github.NewEditor("PULLREQ", "pull request", message)

--- a/github/project.go
+++ b/github/project.go
@@ -15,6 +15,7 @@ type Project struct {
 	Owner    string
 	Host     string
 	Protocol string
+	Remote   *Remote
 }
 
 func (p Project) String() string {
@@ -99,6 +100,17 @@ func useHttpProtocol() bool {
 	}
 
 	return https == "https"
+}
+
+func NewProjectFromRemote(remote *Remote) (*Project, error) {
+	p, err := NewProjectFromURL(remote.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	p.Remote = remote
+
+	return p, nil
 }
 
 func NewProjectFromURL(url *url.URL) (p *Project, err error) {

--- a/github/project_test.go
+++ b/github/project_test.go
@@ -75,7 +75,7 @@ func TestProject_GitURLEnterprise(t *testing.T) {
 	assert.Equal(t, "git@github.corporate.com:jingweno/gh.git", url)
 }
 
-func TestNewProjectFromURL(t *testing.T) {
+func TestProject_NewProjectFromURL(t *testing.T) {
 	testConfigs := fixtures.SetupTestConfigs()
 	defer testConfigs.TearDown()
 

--- a/github/remote.go
+++ b/github/remote.go
@@ -18,8 +18,12 @@ type Remote struct {
 	URL  *url.URL
 }
 
+func (remote *Remote) String() string {
+	return remote.Name
+}
+
 func (remote *Remote) Project() (*Project, error) {
-	return NewProjectFromURL(remote.URL)
+	return NewProjectFromRemote(remote)
 }
 
 func Remotes() (remotes []Remote, err error) {


### PR DESCRIPTION
This is to fix https://github.com/github/hub/issues/636.

I only manually tested this since setting up a fixture repo seems tricky:
we'd need a repo that has different upstream commits than local's and assert that the logs are generated for upstream.

/cc @mislav
