### PR TITLE
Revert to @mislav's solution to get base branch for pull request

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -158,9 +158,21 @@ func pullRequest(cmd *Command, args *Args) {
 
 	var editor *github.Editor
 	if title == "" && flagPullRequestIssue == "" {
-		baseBranch := fmt.Sprintf("%s/%s", baseProject.Remote, base)
-		remoteBranch := fmt.Sprintf("%s/%s", headProject.Remote, head)
-		message, err := pullRequestChangesMessage(baseBranch, remoteBranch, fullBase, fullHead)
+		baseTracking := base
+		headTracking := head
+
+		remote := gitRemoteForProject(baseProject)
+		if remote != nil {
+			baseTracking = fmt.Sprintf("%s/%s", remote.Name, base)
+		}
+		if remote == nil || !baseProject.SameAs(headProject) {
+			remote = gitRemoteForProject(headProject)
+		}
+		if remote != nil {
+			headTracking = fmt.Sprintf("%s/%s", remote.Name, head)
+		}
+
+		message, err := pullRequestChangesMessage(baseTracking, headTracking, fullBase, fullHead)
 		utils.Check(err)
 
 		editor, err = github.NewEditor("PULLREQ", "pull request", message)

--- a/github/project.go
+++ b/github/project.go
@@ -15,7 +15,6 @@ type Project struct {
 	Owner    string
 	Host     string
 	Protocol string
-	Remote   *Remote
 }
 
 func (p Project) String() string {
@@ -100,17 +99,6 @@ func useHttpProtocol() bool {
 	}
 
 	return https == "https"
-}
-
-func NewProjectFromRemote(remote *Remote) (*Project, error) {
-	p, err := NewProjectFromURL(remote.URL)
-	if err != nil {
-		return nil, err
-	}
-
-	p.Remote = remote
-
-	return p, nil
 }
 
 func NewProjectFromURL(url *url.URL) (p *Project, err error) {

--- a/github/remote.go
+++ b/github/remote.go
@@ -23,7 +23,7 @@ func (remote *Remote) String() string {
 }
 
 func (remote *Remote) Project() (*Project, error) {
-	return NewProjectFromRemote(remote)
+	return NewProjectFromURL(remote.URL)
 }
 
 func Remotes() (remotes []Remote, err error) {


### PR DESCRIPTION
As discussed https://github.com/github/hub/pull/646/files#r19065050,
we'd need to defend against getting base branch and tracking branch when
generating diff.

/cc @mislav 
