### PR TITLE
Typo in build script to disable update

### DIFF
--- a/commands/updater.go
+++ b/commands/updater.go
@@ -65,7 +65,7 @@ func (updater *Updater) PromptForUpdate() (err error) {
 		case "always":
 			err = updater.updateTo(releaseName, version)
 		default:
-			fmt.Println("There is a newer version of gh available.")
+			fmt.Println("There is a newer version of hub available.")
 			fmt.Print("Would you like to update? ([Y]es/[N]o/[A]lways/N[e]ver): ")
 			var confirm string
 			fmt.Scan(&confirm)

--- a/script/package
+++ b/script/package
@@ -97,7 +97,7 @@ class Packer
 
   def build_toolchain!
     puts "Building Go toolchain"
-    result = system "gox -build-toolchain -os=#{OS.type} -tags=noupdate"
+    result = system "gox -build-toolchain -os=#{OS.type}"
     raise "Fail to build Go toolchain" unless result
   end
 
@@ -113,7 +113,7 @@ class Packer
 
   def build_hub!
     puts "Building for #{OS.type}"
-    exec!("script/godep gox -os=#{OS.type} -output=./target/{{.Dir}}_#{version}_{{.OS}}_{{.Arch}}/{{.Dir}}")
+    exec!("script/godep gox -os=#{OS.type} -output=./target/{{.Dir}}_#{version}_{{.OS}}_{{.Arch}}/{{.Dir}} -tags=noupdate")
   end
 
   def cp_assets


### PR DESCRIPTION
Also fix a output typo in autoupdate which never runs if it's disabled in build.

Note that these changes have been reflected in the latest build
