### PR TITLE
Add instruction to install `hub` 2.x from Homebrew for gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,8 +122,11 @@
 <em>better at GitHub</em>.
 </p>
 
-<pre><span class="comment"># install from source for 2.x preview</span>
-<span class="comment"># it requires a Go development environment: http://golang.org/doc/install</span>
+<pre><span class="comment"># install on OS X for 2.x preview</span>
+$ <a href="http://brew.sh/">brew</a> install --HEAD hub
+
+<span class="comment"># install from source for 2.x preview</span>
+<span class="comment"># you need  a Go development environment: http://golang.org/doc/install</span>
 $ git clone <strong>https://github.com/github/hub.git</strong>
 $ cd hub
 $ <strong>./script/build</strong>


### PR DESCRIPTION
Updated Homebrew recipe has been merged: Homebrew/homebrew@a746c26
