### PR TITLE
Delegate `git —-version` and `git —-help` to Hub

### DIFF
--- a/commands/args.go
+++ b/commands/args.go
@@ -173,6 +173,8 @@ func slurpGlobalFlags(args []string) (aa []string, noop bool) {
 		if arg == "--noop" {
 			noop = true
 			aa, _ = removeItem(args, i)
+		} else if arg == "--version" || arg == "--help" {
+			aa[i] = strings.TrimPrefix(arg, "--")
 		}
 	}
 

--- a/commands/args_test.go
+++ b/commands/args_test.go
@@ -23,6 +23,14 @@ func TestNewArgs(t *testing.T) {
 	assert.Equal(t, "command", args.Command)
 	assert.Equal(t, 1, args.ParamsSize())
 	assert.T(t, args.Noop)
+
+	args = NewArgs([]string{"--version"})
+	assert.Equal(t, "version", args.Command)
+	assert.Equal(t, 0, args.ParamsSize())
+
+	args = NewArgs([]string{"--help"})
+	assert.Equal(t, "help", args.Command)
+	assert.Equal(t, 0, args.ParamsSize())
 }
 
 func TestArgs_Words(t *testing.T) {


### PR DESCRIPTION
Previously it's showing the git default `--version` and `--help`.
See https://github.com/github/hub/issues/657#issuecomment-60055063
