### PR TITLE
[trivial] typo 'isPriavte' should be 'isPrivate'.

### DIFF
--- a/commands/remote.go
+++ b/commands/remote.go
@@ -66,7 +66,7 @@ func transformRemoteArgs(args *Args) {
 	}
 
 	words := args.Words()
-	isPriavte := parseRemotePrivateFlag(args)
+	isPrivate := parseRemotePrivateFlag(args)
 	if len(words) == 2 && words[1] == "origin" {
 		// Origin special case triggers default user/repo
 		host, err := github.CurrentConfig().DefaultHost()
@@ -87,8 +87,8 @@ func transformRemoteArgs(args *Args) {
 
 	project := github.NewProject(owner, name, host)
 	// for GitHub Enterprise
-	isPriavte = isPriavte || project.Host != github.GitHubHost
-	url := project.GitURL(name, owner, isPriavte)
+	isPrivate = isPrivate || project.Host != github.GitHubHost
+	url := project.GitURL(name, owner, isPrivate)
 	args.AppendParams(url)
 }
 


### PR DESCRIPTION
All relevant tests based as expected.

% hub --version
git version 1.9.3 (Apple Git-50)
hub version 1.12.2-gb311b7b

./script/test
Failing Scenarios:
cucumber -p all features/bash_completion.feature:8 # Scenario: "pu" matches multiple commands including "pull-request"
cucumber -p all features/bash_completion.feature:14 # Scenario: "ci-" expands to "ci-status"
cucumber -p all features/bash_completion.feature:18 # Scenario: Offers pull-request flags
cucumber -p all features/bash_completion.feature:23 # Scenario: Doesn't offer already used pull-request flags
cucumber -p all features/bash_completion.feature:28 # Scenario: Browse to issues
cucumber -p all features/bash_completion.feature:32 # Scenario: Browse to punch-card graph
cucumber -p all features/bash_completion.feature:36 # Scenario: Completion of fork argument

245 scenarios (7 failed, 238 passed)
1448 steps (7 failed, 1441 passed)
1m54.153s
