### PR TITLE
Fix broken colorized verbose output

### DIFF
--- a/github/http.go
+++ b/github/http.go
@@ -18,6 +18,8 @@ type verboseTransport struct {
 	Transport   *http.Transport
 	Verbose     bool
 	OverrideURL *url.URL
+	Out         io.Writer
+	Colorized   bool
 }
 
 func (t *verboseTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
@@ -107,11 +109,11 @@ func (t *verboseTransport) dumpBody(body io.ReadCloser) io.ReadCloser {
 }
 
 func (t *verboseTransport) verbosePrintln(msg string) {
-	if isTerminal(os.Stderr.Fd()) {
-		msg = fmt.Sprintf("\\e[36m%s\\e[m", msg)
+	if t.Colorized {
+		msg = fmt.Sprintf("\033[36m%s\033[0m", msg)
 	}
 
-	fmt.Fprintln(os.Stderr, msg)
+	fmt.Fprintln(t.Out, msg)
 }
 
 func newHttpClient(testHost string, verbose bool) *http.Client {
@@ -123,6 +125,8 @@ func newHttpClient(testHost string, verbose bool) *http.Client {
 		Transport:   &http.Transport{Proxy: proxyFromEnvironment},
 		Verbose:     verbose,
 		OverrideURL: testURL,
+		Out:         os.Stderr,
+		Colorized:   isTerminal(os.Stderr.Fd()),
 	}
 	return &http.Client{Transport: tr}
 }

--- a/github/http_test.go
+++ b/github/http_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -51,4 +52,15 @@ func TestNewHttpClient_OverrideURL(t *testing.T) {
 
 	c = newHttpClient("", false)
 	c.Get(fmt.Sprintf("%s/not-override", s.URL.String()))
+}
+
+func TestVerboseTransport_VerbosePrintln(t *testing.T) {
+	var b bytes.Buffer
+	tr := &verboseTransport{
+		Out:       &b,
+		Colorized: true,
+	}
+
+	tr.verbosePrintln("foo")
+	assert.Equal(t, "\033[36mfoo\033[0m\n", b.String())
 }


### PR DESCRIPTION
From https://github.com/github/hub/issues/660#issuecomment-60757883, the
colorized verbose output is broken. The old implementation tries to use ‘\e’
which is not recognized in a Go string. Let’s Use ‘\033’ instead.
