### PR TITLE
Fix wrong URL of current user for GHE

### DIFF
--- a/features/fork.feature
+++ b/features/fork.feature
@@ -151,3 +151,32 @@ Scenario: Related fork already exists
     And "git.my.org" is a whitelisted Enterprise host
     When I successfully run `hub fork`
     Then the url for "mislav" should be "git@git.my.org:mislav/dotfiles.git"
+
+  Scenario: Enterprise fork authentication with username & password, re-using existing authorization
+    Given the GitHub API server:
+      """
+      require 'rack/auth/basic'
+      get('/api/v3/authorizations', :host_name => 'git.my.org') {
+        auth = Rack::Auth::Basic::Request.new(env)
+        halt 401 unless auth.credentials == %w[mislav kitty]
+        json [
+          {:token => 'SKIPPD', :note_url => 'http://example.com'},
+          {:token => 'OTOKEN', :note_url => 'http://hub.github.com/'}
+        ]
+      }
+      get('/api/v3/user', :host_name => 'git.my.org') {
+        json :login => 'mislav'
+      }
+      post('/api/v3/repos/evilchelu/dotfiles/forks', :host_name => 'git.my.org') { '' }
+      """
+    And "git.my.org" is a whitelisted Enterprise host
+    And the "origin" remote has url "git@git.my.org:evilchelu/dotfiles.git"
+    When I run `hub fork` interactively
+    And I type "mislav"
+    And I type "kitty"
+    Then the output should contain "git.my.org password for mislav (never stored):"
+    And the exit status should be 0
+    And the file "../home/.config/hub" should contain "git.my.org"
+    And the file "../home/.config/hub" should contain "user: mislav"
+    And the file "../home/.config/hub" should contain "oauth_token: OTOKEN"
+    And the url for "mislav" should be "git@git.my.org:mislav/dotfiles.git"

--- a/github/client.go
+++ b/github/client.go
@@ -431,7 +431,7 @@ func (client *Client) CurrentUser() (user *octokit.User, err error) {
 		return
 	}
 
-	user, result := api.Users(url).One()
+	user, result := api.Users(client.requestURL(url)).One()
 	if result.HasError() {
 		err = FormatError("getting current user", result.Err)
 		return


### PR DESCRIPTION
GHE is using /api/v3 as the path prefix for all API URLs. There’s one miss case when getting current user.

This is to fix https://github.com/github/hub/issues/660#issuecomment-60757883
