### PR TITLE
Add example for issue number

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ superpowers:
     $ git browse -- issues
     > open https://github.com/YOUR_USER/CURRENT_REPO/issues
 
+    $ git browse -- issues/10
+    > open https://github.com/YOUR_USER/CURRENT_REPO/issues/10
+
     $ git browse schacon/ticgit
     > open https://github.com/schacon/ticgit
 


### PR DESCRIPTION
Technically, anything in the third argument is passes as a string, so you can look at any file if you know the hash (for instance, `blob/HASH/app/index.js`. However, having the issue number passed seems to me to be something really useful to my workflow, so I was hoping to find something in the documentation about it. 

Another possibility would be to enable a fourth argument for issue number. I'm happy to do a PR for this if something things it might be of more worth than just this edit.
