### PR TITLE
Fix newline characters in `hub pull-request -m`

### DIFF
--- a/commands/utils.go
+++ b/commands/utils.go
@@ -95,6 +95,11 @@ func getTitleAndBodyFromFlags(messageFlag, fileFlag string) (title, body string,
 
 func readMsg(msg string) (title, body string) {
 	split := strings.SplitN(msg, "\n\n", 2)
+	// newline may appear as "\\n\\n" from the command line
+	if len(split) == 1 {
+		split = strings.SplitN(msg, "\\n\\n", 2)
+	}
+
 	title = strings.TrimSpace(split[0])
 	if len(split) > 1 {
 		body = strings.TrimSpace(split[1])

--- a/commands/utils_test.go
+++ b/commands/utils_test.go
@@ -1,10 +1,11 @@
 package commands
 
 import (
-	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestDirIsNotEmpty(t *testing.T) {
@@ -20,6 +21,16 @@ func TestDirIsEmpty(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	assert.T(t, isEmptyDir(dir))
+}
+
+func TestGetTitleAndBodyFromFlags(t *testing.T) {
+	title, body, _ := getTitleAndBodyFromFlags("title\n\nbody", "")
+	assert.Equal(t, "title", title)
+	assert.Equal(t, "body", body)
+
+	title, body, _ = getTitleAndBodyFromFlags("title\\n\\nbody", "")
+	assert.Equal(t, "title", title)
+	assert.Equal(t, "body", body)
 }
 
 func createTempDir(t *testing.T) string {


### PR DESCRIPTION
Newline appears as "\n\n" from command line. Put on extra step to
split title and body.

See https://github.com/github/hub/issues/677.
