### PR TITLE
Initial support for checkout a tree url in addition to pull-request urls.

### DIFF
--- a/github/url.go
+++ b/github/url.go
@@ -10,6 +10,15 @@ type URL struct {
 	*Project
 }
 
+func (url URL) User() (projectPath string) {
+	split := strings.SplitN(url.Path, "/", 4)
+	if len(split) > 3 {
+		projectPath = split[1]
+	}
+
+	return
+}
+
 func (url URL) ProjectPath() (projectPath string) {
 	split := strings.SplitN(url.Path, "/", 4)
 	if len(split) > 3 {


### PR DESCRIPTION
Getting used to use git co <pullrequest-url> and then see it fail when using a tree url (ttps://github.com/jbosstools/jbosstools-forge/tree/jbosstools-4.2.x) 
always annoyed me.

Here is the basic initial implementation of this.

I would like to write tests for it too, but the current one fails so I'm not sure how to
add tests for it knowing if I broke something. 

Any pointers would be appreciated on what to do about that.