### PR TITLE
Fix Go tests on Windows

### DIFF
--- a/commands/runner_test.go
+++ b/commands/runner_test.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
-	"github.com/bmizerany/assert"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestRunner_splitAliasCmd(t *testing.T) {
@@ -29,7 +30,7 @@ func TestRunnerCallCommands(t *testing.T) {
 	var result string
 	f := func(c *Command, args *Args) {
 		result = args.FirstParam()
-		args.Replace("echo", "", "true")
+		args.Replace("git", "version", "")
 	}
 
 	r := NewRunner()

--- a/fixtures/test_repo.go
+++ b/fixtures/test_repo.go
@@ -57,17 +57,18 @@ func (r *TestRepo) clone(repo, dir string) error {
 }
 
 func (r *TestRepo) TearDown() {
-	err := os.RemoveAll(r.dir)
-	if err != nil {
-		panic(err)
-	}
-
-	err = os.Chdir(r.pwd)
+	err := os.Chdir(r.pwd)
 	if err != nil {
 		panic(err)
 	}
 
 	os.Setenv("HOME", r.home)
+
+	err = os.RemoveAll(r.dir)
+	if err != nil {
+		panic(err)
+	}
+
 }
 
 func SetupTestRepo() *TestRepo {

--- a/git/url.go
+++ b/git/url.go
@@ -16,7 +16,10 @@ type URLParser struct {
 }
 
 func (p *URLParser) Parse(rawURL string) (u *url.URL, err error) {
-	if !protocolRe.MatchString(rawURL) && strings.Contains(rawURL, ":") {
+	if !protocolRe.MatchString(rawURL) &&
+		strings.Contains(rawURL, ":") &&
+		// not a Windows path
+		!strings.Contains(rawURL, "\\") {
 		rawURL = "ssh://" + strings.Replace(rawURL, ":", "/", 1)
 	}
 
@@ -25,7 +28,7 @@ func (p *URLParser) Parse(rawURL string) (u *url.URL, err error) {
 		return
 	}
 
-	if u.Scheme == "http" || u.Scheme == "https" {
+	if u.Scheme != "ssh" {
 		return
 	}
 

--- a/git/url_test.go
+++ b/git/url_test.go
@@ -6,31 +6,33 @@ import (
 	"github.com/bmizerany/assert"
 )
 
-func TestURLParser_ParseURL(t *testing.T) {
+func createURLParser() *URLParser {
 	c := make(SSHConfig)
 	c["github.com"] = "ssh.github.com"
+	c["gh"] = "github.com"
 	c["git.company.com"] = "ssh.git.company.com"
 
-	p := &URLParser{c}
+	return &URLParser{c}
+}
+
+func TestURLParser_ParseURL_HTTPURL(t *testing.T) {
+	p := createURLParser()
 
 	u, err := p.Parse("https://github.com/octokit/go-octokit.git")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "github.com", u.Host)
 	assert.Equal(t, "https", u.Scheme)
 	assert.Equal(t, "/octokit/go-octokit.git", u.Path)
+}
 
-	u, err = p.Parse("git://github.com/octokit/go-octokit.git")
+func TestURLParser_ParseURL_GitURL(t *testing.T) {
+	p := createURLParser()
+
+	u, err := p.Parse("git://github.com/octokit/go-octokit.git")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "github.com", u.Host)
 	assert.Equal(t, "git", u.Scheme)
 	assert.Equal(t, "/octokit/go-octokit.git", u.Path)
-
-	u, err = p.Parse("git@github.com:lostisland/go-sawyer.git")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "github.com", u.Host)
-	assert.Equal(t, "ssh", u.Scheme)
-	assert.Equal(t, "git", u.User.Username())
-	assert.Equal(t, "/lostisland/go-sawyer.git", u.Path)
 
 	u, err = p.Parse("https://git.company.com/octokit/go-octokit.git")
 	assert.Equal(t, nil, err)
@@ -40,13 +42,44 @@ func TestURLParser_ParseURL(t *testing.T) {
 
 	u, err = p.Parse("git://git.company.com/octokit/go-octokit.git")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "ssh.git.company.com", u.Host)
+	assert.Equal(t, "git.company.com", u.Host)
 	assert.Equal(t, "git", u.Scheme)
 	assert.Equal(t, "/octokit/go-octokit.git", u.Path)
+}
+
+func TestURLParser_ParseURL_SSHURL(t *testing.T) {
+	p := createURLParser()
+
+	u, err := p.Parse("git@github.com:lostisland/go-sawyer.git")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "github.com", u.Host)
+	assert.Equal(t, "ssh", u.Scheme)
+	assert.Equal(t, "git", u.User.Username())
+	assert.Equal(t, "/lostisland/go-sawyer.git", u.Path)
+
+	u, err = p.Parse("gh:octokit/go-octokit")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "github.com", u.Host)
+	assert.Equal(t, "ssh", u.Scheme)
+	assert.Equal(t, "/octokit/go-octokit", u.Path)
 
 	u, err = p.Parse("git@git.company.com:octokit/go-octokit")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "ssh.git.company.com", u.Host)
 	assert.Equal(t, "ssh", u.Scheme)
 	assert.Equal(t, "/octokit/go-octokit", u.Path)
+}
+
+func TestURLParser_ParseURL_LocalPath(t *testing.T) {
+	p := createURLParser()
+
+	u, err := p.Parse("/path/to/repo.git")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", u.Host)
+	assert.Equal(t, "", u.Scheme)
+	assert.Equal(t, "/path/to/repo.git", u.Path)
+
+	u, err = p.Parse(`c:\path\to\repo.git`)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, `c:\path\to\repo.git`, u.String())
 }

--- a/github/editor_test.go
+++ b/github/editor_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestEditor_openAndEdit_deleteFileWhenOpeningEditorFails(t *testing.T) {
 	tempFile, _ := ioutil.TempFile("", "editor-test")
+	tempFile.Close()
+
 	ioutil.WriteFile(tempFile.Name(), []byte("hello"), 0644)
 	editor := Editor{
 		Program: "memory",
@@ -26,10 +28,13 @@ func TestEditor_openAndEdit_deleteFileWhenOpeningEditorFails(t *testing.T) {
 		},
 	}
 
-	_, err := editor.openAndEdit()
-	assert.NotEqual(t, nil, err)
+	_, err := os.Stat(tempFile.Name())
+	assert.Equal(t, nil, err)
+
+	_, err = editor.openAndEdit()
 	assert.Equal(t, "error using text editor for test message", fmt.Sprintf("%s", err))
 
+	// file is removed if there's error
 	_, err = os.Stat(tempFile.Name())
 	assert.T(t, os.IsNotExist(err))
 }

--- a/github/localrepo_test.go
+++ b/github/localrepo_test.go
@@ -15,7 +15,9 @@ func TestGitHubRepo_OriginRemote(t *testing.T) {
 	localRepo, _ := LocalRepo()
 	gitRemote, _ := localRepo.OriginRemote()
 	assert.Equal(t, "origin", gitRemote.Name)
-	assert.Equal(t, repo.Remote, gitRemote.URL.String())
+
+	u, _ := url.Parse(repo.Remote)
+	assert.Equal(t, u, gitRemote.URL)
 }
 
 func TestGitHubRepo_remotesForPublish(t *testing.T) {


### PR DESCRIPTION
A couple of Go tests failure on Windows, fix code or tests to make them green:

```
--- FAIL: TestSaveAlwaysReportOption (0.15 seconds)
panic: remove C:\Users\IEUser\AppData\Local\Temp\test-repo999546479\test.git: Th
e process cannot access the file because it is being used by another process. [r
ecovered]
        panic: remove C:\Users\IEUser\AppData\Local\Temp\test-repo999546479\test
.git: The process cannot access the file because it is being used by another pro
cess.

--- FAIL: TestRunnerCallCommands (0.00 seconds)
        assert.go:15: V:/src/github.com/github/hub/commands/runner_test.go:42
        assert.go:24: ! 0 != 1

--- FAIL: TestEditor_openAndEdit_deleteFileWhenOpeningEditorFails (0.00 seconds)
        assert.go:15: V:/src/github.com/github/hub/github/editor_test.go:34
        assert.go:36: !  Failure

--- FAIL: TestGitHubRepo_OriginRemote (0.16 seconds)
        assert.go:15: V:/src/github.com/github/hub/github/localrepo_test.go:18
        assert.go:24: ! "V:\\src\\github.com\\github\\hub\\fixtures\\test.git" !
= "ssh://V/%5Csrc%5Cgithub.com%5Cgithub%5Chub%5Cfixtures%5Ctest.git"
```
