### PR TITLE
`hub` now requires Go 1.3 or better to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ brew install --HEAD hub
 #### Source
 
 To install `hub` 2.x from source, you need to have a [Go development environment](http://golang.org/doc/install),
-version 1.1 or better:
+version 1.3 or better:
 
 ~~~ sh
 $ git clone https://github.com/github/hub.git


### PR DESCRIPTION
Due to some breaking changes in Go's standard library which we need,
e.g., https://code.google.com/p/go/source/diff?spec=svn733fefb1deae5490f2d6fcf498667a9077f92a42&r=733fefb1deae5490f2d6fcf498667a9077f92a42&format=side&path=/src/pkg/net/http/transport.go
