### PR TITLE
Send dummy request to trigger a 2FA SMS if there’s no 2FA code

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -447,11 +447,15 @@ func (client *Client) FindOrCreateToken(user, password, twoFactorCode string) (t
 		return
 	}
 
-	basicAuth := octokit.BasicAuth{Login: user, Password: password, OneTimePassword: twoFactorCode}
+	basicAuth := octokit.BasicAuth{
+		Login:           user,
+		Password:        password,
+		OneTimePassword: twoFactorCode,
+	}
 	c := client.newOctokitClient(basicAuth)
 	authsService := c.Authorizations(client.requestURL(authUrl))
 
-	if twoFactorCode != "" {
+	if twoFactorCode == "" {
 		// dummy request to trigger a 2FA SMS since a HTTP GET won't do it
 		authsService.Create(nil)
 	}


### PR DESCRIPTION
A typo in triggering 2FA SMS. See Ruby implementation: https://github.com/github/hub/blob/1.12-stable/lib/hub/github_api.rb#L340.
