### PR TITLE
Opt out autoupdate by default.

### DIFF
--- a/commands/updater.go
+++ b/commands/updater.go
@@ -13,15 +13,17 @@ import (
 	"strings"
 	"time"
 
+	goupdate "github.com/github/hub/Godeps/_workspace/src/github.com/inconshreveable/go-update"
 	"github.com/github/hub/git"
 	"github.com/github/hub/github"
 	"github.com/github/hub/utils"
-	goupdate "github.com/github/hub/Godeps/_workspace/src/github.com/inconshreveable/go-update"
 )
 
 const (
 	hubAutoUpdateConfig = "hub.autoUpdate"
 )
+
+var EnableAutoUpdate = false
 
 func NewUpdater() *Updater {
 	version := os.Getenv("GH_VERSION")
@@ -256,9 +258,10 @@ func saveAutoUpdateConfiguration(confirm string, always bool) {
 }
 
 func autoUpdateConfig() (opt string) {
-	opt = os.Getenv("HUB_AUTOUPDATE")
-	if opt == "" {
+	if EnableAutoUpdate {
 		opt, _ = git.GlobalConfig(hubAutoUpdateConfig)
+	} else {
+		opt = "never"
 	}
 
 	return

--- a/commands/updater_autoupdate.go
+++ b/commands/updater_autoupdate.go
@@ -1,0 +1,7 @@
+// +build autoupdate
+
+package commands
+
+func init() {
+	EnableAutoUpdate = true
+}

--- a/commands/updater_config_noupdate.go
+++ b/commands/updater_config_noupdate.go
@@ -1,9 +1,0 @@
-// +build noupdate
-
-package commands
-
-import "os"
-
-func init() {
-	os.Setenv("HUB_AUTOUPDATE", "never")
-}

--- a/commands/updater_test.go
+++ b/commands/updater_test.go
@@ -93,9 +93,11 @@ func TestDoesntSaveNoAutoUpdateOption(t *testing.T) {
 }
 
 func checkSavedAutoUpdateOption(t *testing.T, always bool, confirm, expected string) {
+	EnableAutoUpdate = true
 	repo := fixtures.SetupTestRepo()
 	defer repo.TearDown()
 
 	saveAutoUpdateConfiguration(confirm, always)
 	assert.Equal(t, expected, autoUpdateConfig())
+	EnableAutoUpdate = false
 }

--- a/script/build
+++ b/script/build
@@ -29,10 +29,9 @@ up_to_date() {
   [ -e "$1" ] && [ "$(count_changed_files "$1")" -eq 0 ]
 }
 
-# always build with noupdate for now until Hub 2.0 is released
 build_hub() {
   setup_gopath
-  [ -n "$1" ] && (up_to_date "$1" || go build -tags "noupdate" -ldflags "-X github.com/github/hub/commands.Version `./script/version`" -o "$1")
+  [ -n "$1" ] && (up_to_date "$1" || go build -ldflags "-X github.com/github/hub/commands.Version `./script/version`" -o "$1")
 }
 
 test_hub() {

--- a/script/package
+++ b/script/package
@@ -114,7 +114,7 @@ class Packer
   def build_hub!
     puts "Building for #{OS.type}"
     release_version = `./script/version`
-    exec!("gox -os=#{OS.type} -output=./target/{{.Dir}}_#{version}_{{.OS}}_{{.Arch}}/{{.Dir}} -tags=noupdate -ldflags '-X github.com/github/hub/commands.Version #{release_version}'")
+    exec!("gox -os=#{OS.type} -output=./target/{{.Dir}}_#{version}_{{.OS}}_{{.Arch}}/{{.Dir}} -ldflags '-X github.com/github/hub/commands.Version #{release_version}'")
   end
 
   def cp_assets


### PR DESCRIPTION
This makes our build scripts even more simpler. To build with autoupdate, run `go build -tags autoupdate`
