### PR TITLE
Rewrite `script/build` and `script/version` in Go

### DIFF
--- a/make/build.go
+++ b/make/build.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func build(path string) error {
+	goDir, err := ioutil.TempDir("", "hub-build")
+	if err != nil {
+		return err
+	}
+
+	os.Setenv("GOPATH", goDir)
+
+	hubDir := filepath.Join(goDir, "src", "github.com", "github", "hub")
+	err = copyDir(path, hubDir)
+	if err != nil {
+		return err
+	}
+
+	version, err := hubVersion(path)
+	if err != nil {
+		return err
+	}
+
+	err = os.Chdir(path)
+	if err != nil {
+		return err
+	}
+
+	versionFlag := fmt.Sprintf("-X github.com/github/hub/commands.Version %s", version)
+	return runCmd("go", "build", "-ldflags", versionFlag)
+}

--- a/make/main.go
+++ b/make/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+var (
+	flagSet     flag.FlagSet
+	buildFlag   bool
+	versionFlag bool
+)
+
+func init() {
+	flagSet.BoolVar(&buildFlag, "b", false, "build Hub")
+	flagSet.BoolVar(&versionFlag, "v", false, "show Hub version")
+}
+
+func showUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: REPO_PATH [-b] [-v]\n\n")
+}
+
+func main() {
+	flag.Usage = showUsage
+	flag.Parse()
+	log.SetFlags(0)
+	log.SetPrefix("make: ")
+
+	args := flag.Args()
+	if len(args) < 2 {
+		showUsage()
+		os.Exit(1)
+	}
+
+	path := args[0]
+	path, err := filepath.Abs(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = os.Stat(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	flagSet.Usage = showUsage
+	flagSet.Parse(args[1:])
+
+	if buildFlag {
+		err = build(path)
+	} else if versionFlag {
+		err = version(path)
+	} else {
+		showUsage()
+	}
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/make/util.go
+++ b/make/util.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func runCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func runCmdOutput(name string, args ...string) ([]string, error) {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	result := bytes.Split(out, []byte("\n"))
+	output := []string{}
+	for _, o := range result {
+		o = bytes.TrimSpace(o)
+		if len(o) != 0 {
+			output = append(output, string(o))
+		}
+	}
+
+	return output, nil
+}
+
+// copyFile copies file from source to dest
+func copyFile(source string, dest string) (err error) {
+	sf, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer sf.Close()
+	df, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer df.Close()
+	_, err = io.Copy(df, sf)
+	if err == nil {
+		si, err := os.Stat(source)
+		if err != nil {
+			err = os.Chmod(dest, si.Mode())
+		}
+
+	}
+
+	return
+}
+
+// copyDir recursively copies a directory tree, attempting to preserve permissions.
+func copyDir(source string, dest string) (err error) {
+	// get properties of source dir
+	fi, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+
+	if !fi.IsDir() {
+		return fmt.Errorf("Source is not a directory")
+	}
+
+	// ensure dest dir does not already exist
+	_, err = os.Open(dest)
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("Destination already exists")
+	}
+
+	// create dest dir
+	err = os.MkdirAll(dest, fi.Mode())
+	if err != nil {
+		return err
+	}
+
+	entries, err := ioutil.ReadDir(source)
+	for _, entry := range entries {
+		sfp := filepath.Join(source, entry.Name())
+		dfp := filepath.Join(dest, entry.Name())
+		if entry.IsDir() {
+			err = copyDir(sfp, dfp)
+			if err != nil {
+				return err
+			}
+		} else {
+			// perform copy
+			err = copyFile(sfp, dfp)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return
+}

--- a/make/version.go
+++ b/make/version.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func hubVersion(path string) (string, error) {
+	output, err := runCmdOutput("git", "describe", "--tags", "HEAD")
+	if err == nil {
+		v := strings.TrimPrefix(output[0], "v")
+		return strings.TrimSpace(v), nil
+	}
+
+	vf := filepath.Join(path, "commands", "version.go")
+	content, err := ioutil.ReadFile(vf)
+	if err != nil {
+		return "", err
+	}
+
+	r := regexp.MustCompile(`var Version = "(.+)"`)
+	if !r.Match(content) {
+		return "", fmt.Errorf("Can't find version in %s", vf)
+	}
+
+	version := string(r.FindSubmatch(content)[1])
+	output, err = runCmdOutput("git", "rev-parse", "--short", "HEAD")
+	if err == nil {
+		headSha := strings.TrimSpace(output[0])
+		version = fmt.Sprintf("%s-q%s", version, headSha)
+	}
+
+	return version, nil
+}
+
+func version(path string) error {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	version, err := hubVersion(path)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(version)
+	return nil
+}


### PR DESCRIPTION
A cross platform build script is needed to build `hub`. Instead of
maintaining different shell scripts for *nix and Windows, writing
everything in Go is a viable approach - all we need is a Go compiler.

The process of building hub becomes building make and using the make binary to build hub:

``` sh
$ go run make/*.go . -b

or

$ go build -o hub-make make/*.go
$ ./hub-make . -b
```

This is a proof of concept. I'm taking feedback before I go further, e.g. `script/package` needs to be rewritten as well.

/cc @mislav 
