### PR TITLE
Don’t trim empty string arguments when building command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -22,9 +22,7 @@ func (cmd Cmd) String() string {
 }
 
 func (cmd *Cmd) WithArg(arg string) *Cmd {
-	if arg != "" {
-		cmd.Args = append(cmd.Args, arg)
-	}
+	cmd.Args = append(cmd.Args, arg)
 
 	return cmd
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
 	"testing"
+
+	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
 )
 
 func TestNew(t *testing.T) {
@@ -14,7 +15,7 @@ func TestNew(t *testing.T) {
 
 func TestWithArg(t *testing.T) {
 	execCmd := New("git")
-	execCmd.WithArg("log").WithArg("--no-color")
+	execCmd.WithArg("command").WithArg("--amend").WithArg("-m").WithArg(`""`)
 	assert.Equal(t, "git", execCmd.Name)
-	assert.Equal(t, 2, len(execCmd.Args))
+	assert.Equal(t, 4, len(execCmd.Args))
 }

--- a/commands/args.go
+++ b/commands/args.go
@@ -50,7 +50,20 @@ func (a *Args) Commands() []*cmd.Cmd {
 }
 
 func (a *Args) ToCmd() *cmd.Cmd {
-	return cmd.New(a.Executable).WithArg(a.Command).WithArgs(a.Params...)
+	c := cmd.New(a.Executable)
+	args := make([]string, 0)
+
+	if a.Command != "" {
+		args = append(args, a.Command)
+	}
+
+	for _, arg := range a.Params {
+		if arg != "" {
+			args = append(args, arg)
+		}
+	}
+
+	return c.WithArgs(args...)
 }
 
 func (a *Args) GetParam(i int) string {


### PR DESCRIPTION
Empty string arguments are removed when building an executable command, causing problems like https://github.com/github/hub/issues/725. However, we need to remove empty string arguments constructed from the commands layer, e.g., https://github.com/github/hub/blob/master/commands/browse.go#L112. We fix it by moving the removal logic to `Args.ToCmd`.

 The Args file is a bit of a mess now. I already have a better design in mind. Will do that in another PR.
