### PR TITLE
Don’t shell out commands in Go tests

### DIFF
--- a/commands/runner.go
+++ b/commands/runner.go
@@ -39,10 +39,14 @@ func newExecError(err error) ExecError {
 
 type Runner struct {
 	commands map[string]*Command
+	execute  func(cmds []*cmd.Cmd) error
 }
 
 func NewRunner() *Runner {
-	return &Runner{commands: make(map[string]*Command)}
+	return &Runner{
+		commands: make(map[string]*Command),
+		execute:  executeCommands,
+	}
 }
 
 func (r *Runner) All() map[string]*Command {
@@ -93,7 +97,7 @@ func (r *Runner) Call(cmd *Command, args *Args) ExecError {
 	if args.Noop {
 		printCommands(cmds)
 	} else {
-		err = executeCommands(cmds)
+		err = r.execute(cmds)
 	}
 
 	return newExecError(err)

--- a/commands/runner_test.go
+++ b/commands/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
+	"github.com/github/hub/cmd"
 )
 
 func TestRunner_splitAliasCmd(t *testing.T) {
@@ -19,7 +20,10 @@ func TestRunner_splitAliasCmd(t *testing.T) {
 }
 
 func TestRunnerUseCommands(t *testing.T) {
-	r := NewRunner()
+	r := &Runner{
+		commands: make(map[string]*Command),
+		execute:  func(cmds []*cmd.Cmd) error { return nil },
+	}
 	c := &Command{Usage: "foo"}
 	r.Use(c)
 
@@ -33,7 +37,10 @@ func TestRunnerCallCommands(t *testing.T) {
 		args.Replace("git", "version", "")
 	}
 
-	r := NewRunner()
+	r := &Runner{
+		commands: make(map[string]*Command),
+		execute:  func(cmds []*cmd.Cmd) error { return nil },
+	}
 	c := &Command{Usage: "foo", Run: f}
 	r.Use(c)
 


### PR DESCRIPTION
The changes in https://github.com/github/hub/commit/0ed14758b756f2b878a0a34f442cd2b178907525 mess up `go test`’s exit code since it executes test commands with exec(3) - `go test` always return 0. We need to stop shelling out commands in tests.
