### PR TITLE
Back port cukes from v1.12.3

### DIFF
--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -583,3 +583,15 @@ Feature: hub pull-request
       """
     When I successfully run `hub pull-request -m hereyougo`
     Then the output should contain exactly "the://url\n"
+
+  Scenario: Branch with quotation mark in name
+    Given I am on the "feat'ure" branch with upstream "origin/feat'ure"
+    Given the GitHub API server:
+    """
+    post('/repos/mislav/coral/pulls') {
+    assert :head  => "mislav:feat'ure"
+    json :html_url => "the://url"
+    }
+    """
+    When I successfully run `hub pull-request -m hereyougo`
+    Then the output should contain exactly "the://url\n"

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -96,7 +96,7 @@ Given(/^I am on the "([^"]+)" branch(?: (pushed to|with upstream) "([^"]+)")?$/)
     end unless upstream == 'refs/heads/master'
   end
   track = type == 'pushed to' ? '--no-track' : '--track'
-  run_silent %(git checkout --quiet -B #{name} #{track} #{upstream})
+  run_silent %(git checkout --quiet -B #{shell_escape name} #{track} #{shell_escape upstream})
 end
 
 Given(/^the default branch for "([^"]+)" is "([^"]+)"$/) do |remote, branch|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -163,4 +163,8 @@ World Module.new {
   def announcer
     @announcer ||= super
   end
+
+  def shell_escape(message)
+    message.to_s.gsub(/['"\\ $]/) { |m| "\\#{m}" }
+  end
 }


### PR DESCRIPTION
v2.2.0 doesn’t have the bug https://github.com/github/hub/commit/bc4b450b613ba9a79f71ccb3246d87f8e99a1b00 but back porting the cukes in case there’ll be regression for v2.2.0.
