### PR TITLE
Allow version script to run through even if certain calls fail

### DIFF
--- a/script/version
+++ b/script/version
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 # Displays hub's release version
-set -e
-
 version="$(git describe --tags HEAD 2>/dev/null)"
 
 if [ -z "$version" ]; then


### PR DESCRIPTION
When hub is installed via Homebrew, Homebrew does a shallow clone of the hub repo and so the `describe --tags` call in `script/version` fails and bash halts the script there.

Allowing the script to turn through will allow the fallback block to run. Another alternative is to change the homebrew formula to prevent a shallow clone as the git formula does: https://github.com/Homebrew/homebrew/blob/f2d3407e8ed9758ea351aedc5b72b1c65522d31f/Library/Formula/git.rb#L8

Here's an example of what you currently get when you install hub via Homebrew:

```
$ brew install --HEAD hub                                                                                                                                                                       
==> Cloning https://github.com/github/hub.git
Updating /Library/Caches/Homebrew/hub--git
==> Checking out branch master
==> script/build
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completion has been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/hub/HEAD: 6 files, 9.4M, built in 9 seconds
>>> elapsed time 11s

$ hub version                                                                                                                                                                                   
git version 2.2.1
hub version -extld=clang
```
