### PR TITLE
Add flag to sign pull-requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ superpowers:
     # explicit title, pull base & head:
     $ git pull-request -m "Implemented feature X" -b defunkt:master -h mislav:feature
 
+    # explicit pull-request sign off:
+    $ git pull-request -s
+
 ### git checkout
 
     $ git checkout https://github.com/defunkt/hub/pull/73

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ superpowers:
     # explicit pull-request sign off:
     $ git pull-request -s
 
+    # sign all pull requests by default:
+    $ git config --global --add hub.pullrequest.signoff true
+    $ git pull-request
+
 ### git checkout
 
     $ git checkout https://github.com/defunkt/hub/pull/73

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -250,7 +250,7 @@ func pullRequestChangesMessage(base, head, fullBase, fullHead string) (string, e
 	if flagPullRequestSignOff && !strings.Contains(defaultMsg, git.AuthorSignatureHeader) {
 		sign, err := git.AuthorSignature()
 		if err == nil {
-			defaultMsg = fmt.Sprintf("%s\n\n%s", defaultMsg, sign)
+			defaultMsg = fmt.Sprintf("%s\n%s", defaultMsg, sign)
 		}
 	}
 

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -247,7 +247,7 @@ func pullRequestChangesMessage(base, head, fullBase, fullHead string) (string, e
 		}
 	}
 
-	if flagPullRequestSignOff && !strings.Contains(defaultMsg, git.AuthorSignatureHeader) {
+	if signPullRequest(defaultMsg) {
 		sign, err := git.AuthorSignature()
 		if err == nil {
 			defaultMsg = fmt.Sprintf("%s\n%s", defaultMsg, sign)
@@ -289,4 +289,10 @@ func parsePullRequestIssueNumber(url string) string {
 	}
 
 	return ""
+}
+
+func signPullRequest(defaultMsg string) bool {
+	return (flagPullRequestSignOff ||
+		git.BoolConfig("hub.pullrequest.signoff")) &&
+		!strings.Contains(defaultMsg, git.AuthorSignatureHeader)
 }

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -640,3 +640,49 @@ Signed-off-by: Hub <hub@test.local>
 #    One on topic
 
       """
+
+  Scenario: Message template should include author signature by configuration
+    Given the text editor adds:
+      """
+      Hello
+      """
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        status 500
+      }
+      """
+    Given I am on the "master" branch
+    And I make a commit with message "One on master"
+    And I make a commit with message "Two on master"
+    And the "master" branch is pushed to "origin/master"
+    Given I successfully run `git reset --hard HEAD~2`
+    And I successfully run `git checkout --quiet -B topic origin/master`
+    Given I make a commit with message "One on topic"
+    And I make a commit with message "Two on topic"
+    Given the "topic" branch is pushed to "origin/topic"
+    And I successfully run `git reset --hard HEAD~1`
+    Given that pull requests require signature
+    When I run `hub pull-request`
+    Given the SHAs and timestamps are normalized in ".git/PULLREQ_EDITMSG"
+    Then the file ".git/PULLREQ_EDITMSG" should contain exactly:
+      """
+      Hello
+
+
+Signed-off-by: Hub <hub@test.local>
+
+# Requesting a pull to mislav:master from mislav:topic
+#
+# Write a message for this pull request. The first block
+# of text is the title and the rest is description.
+#
+# Changes:
+#
+# SHA1SHA (Hub, 0 seconds ago)
+#    Two on topic
+#
+# SHA1SHA (Hub, 0 seconds ago)
+#    One on topic
+
+      """

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -257,3 +257,7 @@ Given(/^the SHAs and timestamps are normalized in "([^"]+)"$/) do |file|
     File.open(file, "w") { |f| f.write(contents) }
   end
 end
+
+Given(/^that pull requests require signature$/) do
+  run_silent %(git config --global --add hub.pullrequest.signoff "true")
+end

--- a/git/git.go
+++ b/git/git.go
@@ -10,6 +10,8 @@ import (
 	"github.com/github/hub/cmd"
 )
 
+const AuthorSignatureHeader = "Signed-off-by: "
+
 func Version() (string, error) {
 	output, err := execGitCmd("version")
 	if err != nil {
@@ -189,6 +191,24 @@ func gitConfigCommand(args []string) []string {
 
 func Alias(name string) (string, error) {
 	return Config(fmt.Sprintf("alias.%s", name))
+}
+
+func AuthorSignature() (string, error) {
+	ident, err := AuthorIdent()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s%s", AuthorSignatureHeader, ident), nil
+}
+
+func AuthorIdent() (string, error) {
+	output, err := execGitCmd("var", "GIT_AUTHOR_IDENT")
+	if err != nil {
+		return "", fmt.Errorf("Can't load git var: GIT_AUTHOR_IDENT")
+	}
+
+	return output[0], nil
 }
 
 func Run(command string, args ...string) error {

--- a/git/git.go
+++ b/git/git.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/github/hub/cmd"
@@ -162,6 +163,35 @@ func Remotes() ([]string, error) {
 
 func Config(name string) (string, error) {
 	return gitGetConfig(name)
+}
+
+func BoolConfig(name string) bool {
+	v, err := gitGetConfig(name)
+	if err != nil {
+		return false
+	}
+
+	v = strings.ToLower(v)
+	if v == "" ||
+		v == "true" ||
+		v == "yes" ||
+		v == "on" {
+		return true
+	}
+
+	if v == "false" ||
+		v == "no" ||
+		v == "off" ||
+		v[0] == '0' {
+		return false
+	}
+
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return false
+	}
+
+	return i > 0
 }
 
 func SetConfig(name, value string) error {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -106,3 +106,28 @@ func TestGitSignatureWithEnv(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "Signed-off-by: Some Hacker <hacker@example.com>", s)
 }
+
+func TestBoolConfig(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	boolTestCases := map[string]bool{
+		"true":  true,
+		"yes":   true,
+		"on":    true,
+		"1":     true,
+		"false": false,
+		"no":    false,
+		"off":   false,
+		"-1":    false,
+		"0":     false,
+	}
+
+	for k, v := range boolTestCases {
+		err := SetConfig("hub.pullrequest.signoff", k)
+		assert.Equal(t, nil, err)
+
+		e := BoolConfig("hub.pullrequest.signoff")
+		assert.Equal(t, v, e)
+	}
+}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -76,4 +77,32 @@ func TestGitConfig(t *testing.T) {
 	v, err = GlobalConfig("gh.test")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "1", v)
+}
+
+func TestGitSignatureWithConfig(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	err := SetConfig("user.name", "Some Hacker")
+	assert.Equal(t, nil, err)
+	err = SetConfig("user.email", "hacker@example.com")
+	assert.Equal(t, nil, err)
+
+	s, err := AuthorSignature()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "Signed-off-by: Some Hacker <hacker@example.com>", s)
+}
+
+func TestGitSignatureWithEnv(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	os.Setenv("GIT_AUTHOR_NAME", "Some Hacker")
+	defer os.Setenv("GIT_AUTHOR_NAME", "")
+	os.Setenv("GIT_AUTHOR_EMAIL", "hacker@example.com")
+	defer os.Setenv("GIT_AUTHOR_EMAIL", "")
+
+	s, err := AuthorSignature()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "Signed-off-by: Some Hacker <hacker@example.com>", s)
 }


### PR DESCRIPTION
Pull requests are already signed if you use `commit -s` and there is only one
commit when you create them. This gives authors the possibility of
signing pull requests explicitly without signing every commit.

TODO:

- [x] Add config var to always sign pull requests by default
- [x] Add tests/specs
- [x] Add documentation