### PR TITLE
Properly parse global flags:

### DIFF
--- a/commands/args_test.go
+++ b/commands/args_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
@@ -36,10 +37,9 @@ func TestNewArgs(t *testing.T) {
 	assert.T(t, args.Noop)
 	assert.Equal(t, "version", args.Command)
 
-	args = NewArgs([]string{"-c", "foo=bar", "-c", "a=b"})
-	assert.Equal(t, 2, len(args.ConfigParam))
-	assert.Equal(t, "bar", args.ConfigParam["foo"])
-	assert.Equal(t, "b", args.ConfigParam["a"])
+	args = NewArgs([]string{"-c", "foo=bar", "--git-dir=path", "--bare", "-c", "a=b"})
+	assert.Equal(t, 7, len(args.GlobalFlags))
+	assert.Equal(t, "-c foo=bar -c a=b --bare --git-dir path", strings.Join(args.GlobalFlags, " "))
 }
 
 func TestArgs_Words(t *testing.T) {

--- a/commands/args_test.go
+++ b/commands/args_test.go
@@ -31,6 +31,15 @@ func TestNewArgs(t *testing.T) {
 	args = NewArgs([]string{"--help"})
 	assert.Equal(t, "help", args.Command)
 	assert.Equal(t, 0, args.ParamsSize())
+
+	args = NewArgs([]string{"--noop", "--version"})
+	assert.T(t, args.Noop)
+	assert.Equal(t, "version", args.Command)
+
+	args = NewArgs([]string{"-c", "foo=bar", "-c", "a=b"})
+	assert.Equal(t, 2, len(args.ConfigParam))
+	assert.Equal(t, "bar", args.ConfigParam["foo"])
+	assert.Equal(t, "b", args.ConfigParam["a"])
 }
 
 func TestArgs_Words(t *testing.T) {
@@ -63,12 +72,4 @@ func TestArgs_Remove(t *testing.T) {
 	assert.Equal(t, 2, args.ParamsSize())
 	assert.Equal(t, "2", args.FirstParam())
 	assert.Equal(t, "4", args.GetParam(1))
-}
-
-func TestSlurpGlobalFlags(t *testing.T) {
-	args := []string{"--noop", "--version"}
-	aa, noop := slurpGlobalFlags(args)
-
-	assert.T(t, noop)
-	assert.Equal(t, []string{"version"}, aa)
 }

--- a/commands/args_test.go
+++ b/commands/args_test.go
@@ -37,9 +37,9 @@ func TestNewArgs(t *testing.T) {
 	assert.T(t, args.Noop)
 	assert.Equal(t, "version", args.Command)
 
-	args = NewArgs([]string{"-c", "foo=bar", "--git-dir=path", "--bare", "-c", "a=b"})
-	assert.Equal(t, 7, len(args.GlobalFlags))
-	assert.Equal(t, "-c foo=bar -c a=b --bare --git-dir path", strings.Join(args.GlobalFlags, " "))
+	args = NewArgs([]string{"-c", "foo=bar", "--git-dir=path", "--bare"})
+	assert.Equal(t, 5, len(args.GlobalFlags))
+	assert.Equal(t, "-c foo=bar --bare --git-dir path", strings.Join(args.GlobalFlags, " "))
 }
 
 func TestArgs_Words(t *testing.T) {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -30,7 +30,7 @@ type Command struct {
 }
 
 func (c *Command) Call(args *Args) (err error) {
-	runCommand, err := lookupCommand(c, args)
+	runCommand, err := c.lookupSubCommand(args)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -113,7 +113,7 @@ func (c *Command) List() bool {
 	return c.Short != ""
 }
 
-func lookupCommand(c *Command, args *Args) (runCommand *Command, err error) {
+func (c *Command) lookupSubCommand(args *Args) (runCommand *Command, err error) {
 	if len(c.subCommands) > 0 && args.HasSubcommand() {
 		subCommandName := args.FirstParam()
 		if subCommand, ok := c.subCommands[subCommandName]; ok {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
-	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
 	"testing"
+
+	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
 )
 
 func TestCommandUseSelf(t *testing.T) {
@@ -10,7 +11,7 @@ func TestCommandUseSelf(t *testing.T) {
 
 	args := NewArgs([]string{"foo"})
 
-	run, err := lookupCommand(c, args)
+	run, err := c.lookupSubCommand(args)
 
 	assert.Equal(t, nil, err)
 	assert.Equal(t, c, run)
@@ -23,7 +24,7 @@ func TestCommandUseSubcommand(t *testing.T) {
 
 	args := NewArgs([]string{"foo", "bar"})
 
-	run, err := lookupCommand(c, args)
+	run, err := c.lookupSubCommand(args)
 
 	assert.Equal(t, nil, err)
 	assert.Equal(t, s, run)
@@ -36,7 +37,7 @@ func TestCommandUseErrorWhenMissingSubcommand(t *testing.T) {
 
 	args := NewArgs([]string{"foo", "baz"})
 
-	_, err := lookupCommand(c, args)
+	_, err := c.lookupSubCommand(args)
 
 	assert.NotEqual(t, nil, err)
 }
@@ -46,7 +47,7 @@ func TestArgsForCommand(t *testing.T) {
 
 	args := NewArgs([]string{"foo", "bar", "baz"})
 
-	lookupCommand(c, args)
+	c.lookupSubCommand(args)
 
 	assert.Equal(t, 2, len(args.Params))
 }
@@ -58,7 +59,7 @@ func TestArgsForSubCommand(t *testing.T) {
 
 	args := NewArgs([]string{"foo", "bar", "baz"})
 
-	lookupCommand(c, args)
+	c.lookupSubCommand(args)
 
 	assert.Equal(t, 1, len(args.Params))
 }

--- a/commands/flag.go
+++ b/commands/flag.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+type stringSliceValue []string
+
+func (s *stringSliceValue) Set(val string) error {
+	*s = append(*s, val)
+	return nil
+}
+
+func (s *stringSliceValue) String() string {
+	return fmt.Sprintf("%s", *s)
+}
+
+type mapValue map[string]string
+
+func (m mapValue) Set(val string) error {
+	v := strings.SplitN(val, "=", 2)
+	if len(v) != 2 {
+		return fmt.Errorf("Flag should be in the format of <name>=<value>")
+	}
+
+	m[v[0]] = v[1]
+
+	return nil
+}
+
+func (m mapValue) String() string {
+	s := make([]string, 0)
+	for k, v := range m {
+		s = append(s, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(s, ",")
+}

--- a/commands/release.go
+++ b/commands/release.go
@@ -15,17 +15,6 @@ import (
 	"github.com/github/hub/utils"
 )
 
-type stringSliceValue []string
-
-func (s *stringSliceValue) Set(val string) error {
-	*s = append(*s, val)
-	return nil
-}
-
-func (s *stringSliceValue) String() string {
-	return fmt.Sprintf("%s", *s)
-}
-
 var (
 	cmdRelease = &Command{
 		Run:   release,

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -73,7 +73,7 @@ func (r *Runner) Execute() ExecError {
 	err := updater.PromptForUpdate()
 	utils.Check(err)
 
-	git.ConfigParam = args.ConfigParam // preserve git config param specified with `-c`
+	git.GlobalFlags = args.GlobalFlags // preserve git global flags
 	expandAlias(args)
 
 	cmd := r.Lookup(args.Command)

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -73,6 +73,7 @@ func (r *Runner) Execute() ExecError {
 	err := updater.PromptForUpdate()
 	utils.Check(err)
 
+	git.ConfigParam = args.ConfigParam // preserve git config param specified with `-c`
 	expandAlias(args)
 
 	cmd := r.Lookup(args.Command)

--- a/git/git.go
+++ b/git/git.go
@@ -10,7 +10,7 @@ import (
 	"github.com/github/hub/cmd"
 )
 
-var ConfigParam map[string]string = make(map[string]string)
+var GlobalFlags []string
 
 func Version() (string, error) {
 	output, err := gitOutput("version")
@@ -196,9 +196,8 @@ func Alias(name string) (string, error) {
 func Run(command string, args ...string) error {
 	cmd := cmd.New("git")
 
-	for k, v := range ConfigParam {
-		cmd.WithArg("-c")
-		cmd.WithArg(fmt.Sprintf("%s=%s", k, v))
+	for _, v := range GlobalFlags {
+		cmd.WithArg(v)
 	}
 
 	cmd.WithArg(command)
@@ -213,9 +212,8 @@ func Run(command string, args ...string) error {
 func gitOutput(input ...string) (outputs []string, err error) {
 	cmd := cmd.New("git")
 
-	for k, v := range ConfigParam {
-		cmd.WithArg("-c")
-		cmd.WithArg(fmt.Sprintf("%s=%s", k, v))
+	for _, v := range GlobalFlags {
+		cmd.WithArg(v)
 	}
 
 	for _, i := range input {

--- a/git/git.go
+++ b/git/git.go
@@ -10,6 +10,8 @@ import (
 	"github.com/github/hub/cmd"
 )
 
+var ConfigParam map[string]string = make(map[string]string)
+
 func Version() (string, error) {
 	output, err := execGitCmd("version")
 	if err != nil {
@@ -193,7 +195,14 @@ func Alias(name string) (string, error) {
 
 func Run(command string, args ...string) error {
 	cmd := cmd.New("git")
+
+	for k, v := range ConfigParam {
+		cmd.WithArg("-c")
+		cmd.WithArg(fmt.Sprintf("%s=%s", k, v))
+	}
+
 	cmd.WithArg(command)
+
 	for _, a := range args {
 		cmd.WithArg(a)
 	}
@@ -203,6 +212,12 @@ func Run(command string, args ...string) error {
 
 func execGitCmd(input ...string) (outputs []string, err error) {
 	cmd := cmd.New("git")
+
+	for k, v := range ConfigParam {
+		cmd.WithArg("-c")
+		cmd.WithArg(fmt.Sprintf("%s=%s", k, v))
+	}
+
 	for _, i := range input {
 		cmd.WithArg(i)
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -13,7 +13,7 @@ import (
 var ConfigParam map[string]string = make(map[string]string)
 
 func Version() (string, error) {
-	output, err := execGitCmd("version")
+	output, err := gitOutput("version")
 	if err != nil {
 		return "", fmt.Errorf("Can't load git version")
 	}
@@ -22,7 +22,7 @@ func Version() (string, error) {
 }
 
 func Dir() (string, error) {
-	output, err := execGitCmd("rev-parse", "-q", "--git-dir")
+	output, err := gitOutput("rev-parse", "-q", "--git-dir")
 	if err != nil {
 		return "", fmt.Errorf("Not a git repository (or any of the parent directories): .git")
 	}
@@ -79,7 +79,7 @@ func BranchAtRef(paths ...string) (name string, err error) {
 }
 
 func Editor() (string, error) {
-	output, err := execGitCmd("var", "GIT_EDITOR")
+	output, err := gitOutput("var", "GIT_EDITOR")
 	if err != nil {
 		return "", fmt.Errorf("Can't load git var: GIT_EDITOR")
 	}
@@ -92,7 +92,7 @@ func Head() (string, error) {
 }
 
 func SymbolicFullName(name string) (string, error) {
-	output, err := execGitCmd("rev-parse", "--symbolic-full-name", name)
+	output, err := gitOutput("rev-parse", "--symbolic-full-name", name)
 	if err != nil {
 		return "", fmt.Errorf("Unknown revision or path not in the working tree: %s", name)
 	}
@@ -101,7 +101,7 @@ func SymbolicFullName(name string) (string, error) {
 }
 
 func Ref(ref string) (string, error) {
-	output, err := execGitCmd("rev-parse", "-q", ref)
+	output, err := gitOutput("rev-parse", "-q", ref)
 	if err != nil {
 		return "", fmt.Errorf("Unknown revision or path not in the working tree: %s", ref)
 	}
@@ -111,7 +111,7 @@ func Ref(ref string) (string, error) {
 
 func RefList(a, b string) ([]string, error) {
 	ref := fmt.Sprintf("%s...%s", a, b)
-	output, err := execGitCmd("rev-list", "--cherry-pick", "--right-only", "--no-merges", ref)
+	output, err := gitOutput("rev-list", "--cherry-pick", "--right-only", "--no-merges", ref)
 	if err != nil {
 		return []string{}, fmt.Errorf("Can't load rev-list for %s", ref)
 	}
@@ -155,7 +155,7 @@ func Log(sha1, sha2 string) (string, error) {
 }
 
 func Remotes() ([]string, error) {
-	return execGitCmd("remote", "-v")
+	return gitOutput("remote", "-v")
 }
 
 func Config(name string) (string, error) {
@@ -172,7 +172,7 @@ func SetGlobalConfig(name, value string) error {
 }
 
 func gitGetConfig(args ...string) (string, error) {
-	output, err := execGitCmd(gitConfigCommand(args)...)
+	output, err := gitOutput(gitConfigCommand(args)...)
 	if err != nil {
 		return "", fmt.Errorf("Unknown config %s", args[len(args)-1])
 	}
@@ -181,7 +181,7 @@ func gitGetConfig(args ...string) (string, error) {
 }
 
 func gitConfig(args ...string) ([]string, error) {
-	return execGitCmd(gitConfigCommand(args)...)
+	return gitOutput(gitConfigCommand(args)...)
 }
 
 func gitConfigCommand(args []string) []string {
@@ -210,7 +210,7 @@ func Run(command string, args ...string) error {
 	return cmd.Run()
 }
 
-func execGitCmd(input ...string) (outputs []string, err error) {
+func gitOutput(input ...string) (outputs []string, err error) {
 	cmd := cmd.New("git")
 
 	for k, v := range ConfigParam {


### PR DESCRIPTION
* It preserves global flags like `-c`
* It preserves global `COMMAND --help`
* Some refactorings

This fixes https://github.com/github/hub/issues/763 and https://github.com/github/hub/issues/756