### PR TITLE
Bump to use Go 1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - export PATH=~/bin:"$PATH"
 language: go
 go:
-  - 1.4
+  - 1.4.1
 script: script/test
 install: bundle install --path "$HOME/build/$TRAVIS_REPO_SLUG/vendor/bundle" --without development --deployment --jobs=3 --retry=3
 cache:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing to hub
 
 You will need:
 
-1. Go 1.4
+1. Go 1.4 or better
 1. Ruby 1.9+
 2. git 1.8+
 3. tmux & zsh (optional) - for running shell completion tests
@@ -25,23 +25,23 @@ feature is a good idea for hub if it improves some workflow for a GitHub user.
 These instructions assume that _you already have hub installed_ and aliased as
 `git` (see "Aliasing").
 
-1. Clone hub:  
+1. Clone hub:
     `git clone github/hub && cd hub`
-1. Install necessary development dependencies:  
+1. Install necessary development dependencies:
     `script/bootstrap`
-2. Verify that existing tests pass:  
+2. Verify that existing tests pass:
     `script/test`
-3. Create a topic branch:  
+3. Create a topic branch:
     `git checkout -b feature`
-4. **Make your changes.**  
+4. **Make your changes.**
    (It helps a lot if you write tests first.)
-5. Verify that tests still pass:  
+5. Verify that tests still pass:
     `script/test`
-6. Fork hub on GitHub (adds a remote named "YOUR-USER"):  
+6. Fork hub on GitHub (adds a remote named "YOUR-USER"):
     `git fork`
-7. Push to your fork:  
+7. Push to your fork:
     `git push <YOUR-USER> HEAD`
-8. Open a pull request describing your changes:  
+8. Open a pull request describing your changes:
     `git pull-request`
 
 ## How to write tests

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 GO_ARCHIVES = {
-  "linux" => "go1.4.linux-amd64.tar.gz",
+  "linux" => "go1.4.1.linux-amd64.tar.gz",
 }
 
 INSTALL = {


### PR DESCRIPTION
Go 1.4.1 has some bug fixes for 1.4: https://github.com/golang/go/issues?q=milestone%3AGo1.4.1. Nothing is changed on our side.