### PR TITLE
Add brew cask installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ $ brew install --HEAD hub
 [compiled binaries](https://github.com/github/hub/releases) and put it anywhere
 in your executable path.
 
+Precompiled binaries are also available on [Homebrew cask](https://github.com/caskroom/homebrew-cask).
+
+~~~ sh
+$ brew cask install hub
+~~~
+
 #### Source
 
 To install `hub` 2.x from source, you need to have a [Go development environment](http://golang.org/doc/install),


### PR DESCRIPTION
I have [just added](https://github.com/caskroom/homebrew-cask/commit/354168b4b17f1f67d5ecc408329f95f328ab6b2d
) hub to homebrew cask.
I thought it would be worth mentioning it in the README :) .