### PR TITLE
Get home dir using `user.Current()` if `HOME` env var is not set

### DIFF
--- a/commands/updater.go
+++ b/commands/updater.go
@@ -26,7 +26,7 @@ const (
 var EnableAutoUpdate = false
 
 func NewUpdater() *Updater {
-	version := os.Getenv("GH_VERSION")
+	version := os.Getenv("HUB_VERSION")
 	if version == "" {
 		version = Version
 	}

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -54,8 +54,8 @@ Before do
   set_env 'GIT_AUTHOR_EMAIL',    author_email
   set_env 'GIT_COMMITTER_EMAIL', author_email
 
-  set_env 'GH_VERSION', 'dev'
-  set_env 'GH_REPORT_CRASH', 'never'
+  set_env 'HUB_VERSION', 'dev'
+  set_env 'HUB_REPORT_CRASH', 'never'
 
   FileUtils.mkdir_p ENV['HOME']
 

--- a/fixtures/test_configs.go
+++ b/fixtures/test_configs.go
@@ -10,7 +10,7 @@ type TestConfigs struct {
 }
 
 func (c *TestConfigs) TearDown() {
-	os.Setenv("GH_CONFIG", "")
+	os.Setenv("HUB_CONFIG", "")
 	os.RemoveAll(c.Path)
 }
 
@@ -23,7 +23,7 @@ func SetupTomlTestConfig() *TestConfigs {
   access_token = "123"
   protocol = "http"`
 	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
-	os.Setenv("GH_CONFIG", file.Name())
+	os.Setenv("HUB_CONFIG", file.Name())
 
 	return &TestConfigs{file.Name()}
 }
@@ -37,7 +37,7 @@ github.com:
   oauth_token: 123
   protocol: http`
 	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
-	os.Setenv("GH_CONFIG", file.Name())
+	os.Setenv("HUB_CONFIG", file.Name())
 
 	return &TestConfigs{file.Name()}
 }

--- a/github/config.go
+++ b/github/config.go
@@ -177,7 +177,7 @@ func (c *Config) selectHost() *Host {
 }
 
 func configsFile() string {
-	configsFile := os.Getenv("GH_CONFIG")
+	configsFile := os.Getenv("HUB_CONFIG")
 	if configsFile == "" {
 		configsFile = defaultConfigsFile
 	}

--- a/github/config.go
+++ b/github/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strconv"
 
@@ -12,9 +13,23 @@ import (
 	"github.com/github/hub/utils"
 )
 
-var (
-	defaultConfigsFile = filepath.Join(os.Getenv("HOME"), ".config", "hub")
-)
+var defaultConfigsFile string
+
+func init() {
+	homeDir := os.Getenv("HOME")
+
+	if homeDir == "" {
+		if u, err := user.Current(); err == nil {
+			homeDir = u.HomeDir
+		}
+	}
+
+	if homeDir == "" {
+		utils.Check(fmt.Errorf("Can't get current user's home dir"))
+	}
+
+	defaultConfigsFile = filepath.Join(homeDir, ".config", "hub")
+}
 
 type yamlHost struct {
 	User       string `yaml:"user"`
@@ -53,7 +68,7 @@ func (c *Config) PromptForHost(host string) (h *Host, err error) {
 		}
 
 		if ae, ok := err.(*AuthError); ok && ae.IsRequired2FACodeError() {
-			if (code != "") {
+			if code != "" {
 				fmt.Fprintln(os.Stderr, "warning: invalid two-factor code")
 			}
 			code = c.PromptForOTP()

--- a/github/crash_report.go
+++ b/github/crash_report.go
@@ -124,7 +124,7 @@ func saveReportConfiguration(confirm string, always bool) {
 }
 
 func reportCrashConfig() (opt string) {
-	opt = os.Getenv("GH_REPORT_CRASH")
+	opt = os.Getenv("HUB_REPORT_CRASH")
 	if opt == "" {
 		opt, _ = git.GlobalConfig(hubReportCrashConfig)
 	}


### PR DESCRIPTION
This fixes Windows issue: https://github.com/github/hub/issues/772. It also includes renaming of some environment variable names starting with `GH_`.