### PR TITLE
Fix package's file extensions

### DIFF
--- a/script/package
+++ b/script/package
@@ -157,7 +157,7 @@ class Packer
     glob_dir(path).each do |dir|
       puts "Archiving #{dir}"
       Dir.chdir(root_path("target")) do
-        exec!("tar -zcf #{File.basename(dir)}.gz.tar #{File.basename(dir)}")
+        exec!("tar -zcf #{File.basename(dir)}.tar.gz #{File.basename(dir)}")
       end
     end
   end


### PR DESCRIPTION
Tarballs are traditionally .tar.gz, not .gz.tar
This can be seen in the tarballs for 2.2.0-rc1 provided on https://github.com/github/hub/releases