### PR TITLE
Fix `hub checkout <PULLREQ-URL>` for renamed fork

### DIFF
--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -93,7 +93,7 @@ func transformCheckoutArgs(args *Args) error {
 		remoteURL := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, user, branch)
 		args.Before("git", "fetch", user, remoteURL)
 	} else {
-		u := url.Project.GitURL("", user, pullRequest.Head.Repo.Private)
+		u := url.Project.GitURL(pullRequest.Head.Repo.Name, user, pullRequest.Head.Repo.Private)
 		args.Before("git", "remote", "add", "-f", "-t", branch, user, u)
 	}
 

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -14,7 +14,10 @@ Feature: hub checkout <PULLREQ-URL>
         halt 406 unless request.env['HTTP_ACCEPT'] == 'application/vnd.github.v3+json;charset=utf-8'
         json :head => {
           :label => 'mislav:fixes',
-          :repo => { :private => false }
+          :repo => {
+            :name => 'jekyll',
+            :private => false
+          }
         }
       }
       """
@@ -22,13 +25,33 @@ Feature: hub checkout <PULLREQ-URL>
     Then "git remote add -f -t fixes mislav git://github.com/mislav/jekyll.git" should be run
     And "git checkout -f --track -B mislav-fixes mislav/fixes -q" should be run
 
+  Scenario: Pull request from a renamed fork
+    Given the GitHub API server:
+      """
+      get('/repos/mojombo/jekyll/pulls/77') {
+        json :head => {
+          :label => 'mislav:fixes',
+          :repo => {
+            :name => 'jekyll-blog',
+            :private => false
+          }
+        }
+      }
+      """
+    When I run `hub checkout https://github.com/mojombo/jekyll/pull/77`
+    Then "git remote add -f -t fixes mislav git://github.com/mislav/jekyll-blog.git" should be run
+    And "git checkout --track -B mislav-fixes mislav/fixes" should be run
+
   Scenario: Custom name for new branch
     Given the GitHub API server:
       """
       get('/repos/mojombo/jekyll/pulls/77') {
         json :head => {
           :label => 'mislav:fixes',
-          :repo => { :private => false }
+          :repo => {
+            :name => 'jekyll',
+            :private => false
+          }
         }
       }
       """
@@ -42,7 +65,10 @@ Feature: hub checkout <PULLREQ-URL>
       get('/repos/mojombo/jekyll/pulls/77') {
         json :head => {
           :label => 'mislav:fixes',
-          :repo => { :private => true }
+          :repo => {
+            :name => 'jekyll',
+            :private => true
+          }
         }
       }
       """
@@ -56,7 +82,10 @@ Feature: hub checkout <PULLREQ-URL>
       get('/repos/mojombo/jekyll/pulls/77') {
         json :head => {
           :label => 'mislav:fixes',
-          :repo => { :private => false }
+          :repo => {
+            :name => 'jekyll',
+            :private => false
+          }
         }
       }
       """
@@ -70,7 +99,10 @@ Feature: hub checkout <PULLREQ-URL>
       get('/repos/mojombo/jekyll/pulls/77') {
         json :head => {
           :label => 'mislav:fixes',
-          :repo => { :private => false }
+          :repo => {
+            :name => 'jekyll',
+            :private => false
+          }
         }
       }
       """


### PR DESCRIPTION
Start reading the `Head.Repo.Name` property from API payload to determine the name of the forked repo which might not match the name of the base repo.

Fixes #768