### PR TITLE
don't exit when "git rev-parse" fails

### DIFF
--- a/script/version
+++ b/script/version
@@ -6,7 +6,7 @@ version="$(git describe --tags HEAD 2>/dev/null || true)"
 
 if [ -z "$version" ]; then
   version="$(grep Version commands/version.go | head -1 | cut -d '"' -f2)"
-  sha="$(git rev-parse --short HEAD 2>/dev/null)"
+  sha="$(git rev-parse --short HEAD 2>/dev/null || true)"
   [ -z "$sha" ] || version="${version}-g${sha}"
 fi
 


### PR DESCRIPTION
so that the version number is always echoed on stdout.

With this change, the version script will print a version
number even if git or the ".git" directory are not available
like in the "release-source.tar.gz" archive.