### PR TITLE
Support clone from owner/repo for Enterprise

### DIFF
--- a/commands/clone.go
+++ b/commands/clone.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"os"
 	"regexp"
 	"strings"
 
@@ -58,7 +59,7 @@ func transformCloneArgs(args *Args) {
 			if nameWithOwnerRegexp.MatchString(a) && !isDir(a) {
 				name, owner := parseCloneNameAndOwner(a)
 				var host *github.Host
-				if owner == "" {
+				if owner == "" || os.Getenv("HUB_CHOOSE_HOST") != "" {
 					config := github.CurrentConfig()
 					h, err := config.DefaultHost()
 					if err != nil {


### PR DESCRIPTION
Without this change, it seems to try to clone from github.com and it fails.

    $ ./hub clone my_org/my_repo
    Cloning into 'my_repo'...
    fatal: remote error:
      Repository not found.

With this, I get prompted to pick the host:

    $ ./hub clone my_org/my_repo
    Select host:
     1. github.com
     2. github-enterprise.mycompany.com
    > 2
    Cloning into 'my_repo'...
    remote: Counting objects: 9892, done.
    remote: Compressing objects: 100% (2838/2838), done.
    remote: Total 9892 (delta 7130), reused 9729 (delta 7004)
    Receiving objects: 100% (9892/9892), 3.45 MiB | 2.16 MiB/s, done.
    Resolving deltas: 100% (7130/7130), done.
    Checking connectivity... done.