### PR TITLE
merge: do not insert "--no-ff" for "--squash"

### DIFF
--- a/commands/merge.go
+++ b/commands/merge.go
@@ -76,7 +76,7 @@ func transformMergeArgs(args *Args) error {
 	mergeMsg := fmt.Sprintf("Merge pull request #%v from %s\n\n%s", id, mergeHead, pullRequest.Title)
 	args.AppendParams(mergeHead, "-m", mergeMsg)
 
-	if args.IndexOfParam("--ff-only") == -1 {
+	if args.IndexOfParam("--ff-only") == -1 && args.IndexOfParam("--squash") == -1 {
 		i := args.IndexOfParam("-m")
 		args.InsertParam(i, "--no-ff")
 	}


### PR DESCRIPTION
Otherwise `git` aborts with an error:

> You cannot combine --squash with --no-ff

There should probably get a test added for it, but I wasn't sure what it should look like.. like the `--ff-only` one, but adjusted to different output, or just test that it won't fail?