### PR TITLE
Upped Ruby version

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -16,7 +16,7 @@ fi
 { ruby --version
   bundle install --path vendor/bundle -j 4
 } || {
-  echo "You need Ruby 2.1 and Bundler to run hub tests" >&2
+  echo "You need Ruby 1.9+ and Bundler to run hub tests" >&2
   STATUS=1
 }
 


### PR DESCRIPTION
When running the test file, I got this error: 

```sh
$ script/bootstrap 
go version go1.4.1 darwin/amd64
ruby 2.0.0p481 (2014-05-08 revision 45883) [universal.x86_64-darwin14]
script/bootstrap: line 17: bundle: command not found
You need Ruby 2.1 and Bundler to run hub tests
```

Upped the Ruby version to reflect this.