### PR TITLE
Better arguments processing for `init` command

### DIFF
--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/github/hub/github"
 )
 
-func setup() {
+func setupInitContext() {
 	os.Setenv("HUB_PROTOCOL", "git")
 	github.CreateTestConfigs("jingweno", "123")
 }
 
 func TestEmptyParams(t *testing.T) {
-	setup()
+	setupInitContext()
 
 	args := NewArgs([]string{"init"})
 	err := transformInitArgs(args)
@@ -26,7 +26,7 @@ func TestEmptyParams(t *testing.T) {
 }
 
 func TestFlagToAddRemote(t *testing.T) {
-	setup()
+	setupInitContext()
 
 	args := NewArgs([]string{"init", "-g", "--quiet"})
 	err := transformInitArgs(args)
@@ -48,7 +48,7 @@ func TestFlagToAddRemote(t *testing.T) {
 }
 
 func TestInitInAnotherDir(t *testing.T) {
-	setup()
+	setupInitContext()
 
 	args := NewArgs([]string{"init", "-g", "--template", "mytpl", "my project"})
 	err := transformInitArgs(args)
@@ -70,7 +70,7 @@ func TestInitInAnotherDir(t *testing.T) {
 }
 
 func TestSeparateGitDir(t *testing.T) {
-	setup()
+	setupInitContext()
 
 	args := NewArgs([]string{"init", "-g", "--separate-git-dir", "/tmp/where-i-play.git", "my/playground"})
 	err := transformInitArgs(args)

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -50,13 +50,13 @@ func TestFlagToAddRemote(t *testing.T) {
 func TestInitInAnotherDir(t *testing.T) {
 	setupInitContext()
 
-	args := NewArgs([]string{"init", "-g", "--template", "mytpl", "my project"})
+	args := NewArgs([]string{"init", "-g", "--template", "mytpl", "--shared=umask", "my project"})
 	err := transformInitArgs(args)
 	assert.Equal(t, nil, err)
 
 	commands := args.Commands()
 	assert.Equal(t, 2, len(commands))
-	assert.Equal(t, "git init --template mytpl my project", commands[0].String())
+	assert.Equal(t, "git init --template mytpl --shared=umask my project", commands[0].String())
 
 	currentDir, err := os.Getwd()
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
Now the optional `directory` argument to `git init` is detected by looking for the first "word" in arguments that isn't a value for one of `--template`, `--shared`, or `--separate-git-dir` params.

This is done by simply iterating through args instead of pulling in a full-blown flag-parsing library. This is also the approach we take in the `clone` command.

This is an alternative implementation to #793. @jingweno, let me know what you think.

Fixes #792