### PR TITLE
Extract logic of printing out to console

### DIFF
--- a/commands/alias.go
+++ b/commands/alias.go
@@ -2,10 +2,12 @@ package commands
 
 import (
 	"fmt"
-	"github.com/github/hub/utils"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/github/hub/ui"
+	"github.com/github/hub/utils"
 )
 
 var cmdAlias = &Command{
@@ -61,7 +63,7 @@ func alias(command *Command, args *Args) {
 			alias = "alias git=hub"
 		}
 
-		fmt.Println(alias)
+		ui.Println(alias)
 	} else {
 		var profile string
 		switch shell {
@@ -82,7 +84,7 @@ func alias(command *Command, args *Args) {
 		}
 
 		msg := fmt.Sprintf("# Wrap git automatically by adding the following to %s:\n", profile)
-		fmt.Println(msg)
+		ui.Println(msg)
 
 		var eval string
 		switch shell {
@@ -93,7 +95,7 @@ func alias(command *Command, args *Args) {
 		default:
 			eval = `eval "$(hub alias -s)"`
 		}
-		fmt.Println(eval)
+		ui.Println(eval)
 	}
 
 	os.Exit(0)

--- a/commands/ci_status.go
+++ b/commands/ci_status.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/github/hub/git"
 	"github.com/github/hub/github"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -65,14 +66,14 @@ func ciStatus(cmd *Command, args *Args) {
 	utils.Check(err)
 
 	if args.Noop {
-		fmt.Printf("Would request CI status for %s\n", sha)
+		ui.Printf("Would request CI status for %s\n", sha)
 	} else {
 		state, targetURL, exitCode, err := fetchCiStatus(project, sha)
 		utils.Check(err)
 		if flagCiStatusVerbose && targetURL != "" {
-			fmt.Printf("%s: %s\n", state, targetURL)
+			ui.Printf("%s: %s\n", state, targetURL)
 		} else {
-			fmt.Println(state)
+			ui.Println(state)
 		}
 
 		os.Exit(exitCode)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	flag "github.com/github/hub/Godeps/_workspace/src/github.com/ogier/pflag"
+	"github.com/github/hub/ui"
 )
 
 var (
@@ -32,7 +33,7 @@ type Command struct {
 func (c *Command) Call(args *Args) (err error) {
 	runCommand, err := c.lookupSubCommand(args)
 	if err != nil {
-		fmt.Println(err)
+		ui.Errorln(err)
 		return
 	}
 
@@ -68,10 +69,10 @@ func (c *Command) Use(subCommand *Command) {
 
 func (c *Command) PrintUsage() {
 	if c.Runnable() {
-		fmt.Printf("usage: %s\n\n", c.FormattedUsage())
+		ui.Printf("usage: %s\n\n", c.FormattedUsage())
 	}
 
-	fmt.Println(strings.Trim(c.Long, "\n"))
+	ui.Println(strings.Trim(c.Long, "\n"))
 }
 
 func (c *Command) FormattedUsage() string {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -1,10 +1,18 @@
 package commands
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
+	"github.com/github/hub/ui"
 )
+
+func TestMain(m *testing.M) {
+	ui.Default = ui.Console{Stdout: ioutil.Discard, Stderr: ioutil.Discard}
+	os.Exit(m.Run())
+}
 
 func TestCommandUseSelf(t *testing.T) {
 	c := &Command{Usage: "foo"}

--- a/commands/create.go
+++ b/commands/create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/github/hub/git"
 	"github.com/github/hub/github"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -91,7 +92,7 @@ func create(command *Command, args *Args) {
 
 	var action string
 	if gh.IsRepositoryExist(project) {
-		fmt.Printf("%s already exists on %s\n", project, project.Host)
+		ui.Printf("%s already exists on %s\n", project, project.Host)
 		action = "set remote origin"
 	} else {
 		action = "created repository"

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/github/hub/github"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -50,7 +51,7 @@ func init() {
 func issue(cmd *Command, args *Args) {
 	runInLocalRepo(func(localRepo *github.GitHubRepo, project *github.Project, gh *github.Client) {
 		if args.Noop {
-			fmt.Printf("Would request list of issues for %s\n", project)
+			ui.Printf("Would request list of issues for %s\n", project)
 		} else {
 			issues, err := gh.Issues(project)
 			utils.Check(err)
@@ -63,7 +64,7 @@ func issue(cmd *Command, args *Args) {
 					url = issue.HTMLURL
 				}
 				// "nobody" should have more than 1 million github issues
-				fmt.Printf("% 7d] %s ( %s )\n", issue.Number, issue.Title, url)
+				ui.Printf("% 7d] %s ( %s )\n", issue.Number, issue.Title, url)
 			}
 		}
 	})
@@ -72,7 +73,7 @@ func issue(cmd *Command, args *Args) {
 func createIssue(cmd *Command, args *Args) {
 	runInLocalRepo(func(localRepo *github.GitHubRepo, project *github.Project, gh *github.Client) {
 		if args.Noop {
-			fmt.Printf("Would create an issue for %s\n", project)
+			ui.Printf("Would create an issue for %s\n", project)
 		} else {
 			title, body, err := getTitleAndBodyFromFlags(flagIssueMessage, flagIssueFile)
 			utils.Check(err)
@@ -85,7 +86,7 @@ func createIssue(cmd *Command, args *Args) {
 			issue, err := gh.CreateIssue(project, title, body, flagIssueLabels)
 			utils.Check(err)
 
-			fmt.Println(issue.HTMLURL)
+			ui.Println(issue.HTMLURL)
 		}
 	})
 }

--- a/commands/release.go
+++ b/commands/release.go
@@ -12,6 +12,7 @@ import (
 	"github.com/github/hub/Godeps/_workspace/src/github.com/octokit/go-octokit/octokit"
 	"github.com/github/hub/git"
 	"github.com/github/hub/github"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -63,7 +64,7 @@ func init() {
 func release(cmd *Command, args *Args) {
 	runInLocalRepo(func(localRepo *github.GitHubRepo, project *github.Project, client *github.Client) {
 		if args.Noop {
-			fmt.Printf("Would request list of releases for %s\n", project)
+			ui.Printf("Would request list of releases for %s\n", project)
 		} else {
 			releases, err := client.Releases(project)
 			utils.Check(err)
@@ -73,7 +74,7 @@ func release(cmd *Command, args *Args) {
 				outputs = append(outputs, out)
 			}
 
-			fmt.Println(strings.Join(outputs, "\n\n"))
+			ui.Println(strings.Join(outputs, "\n\n"))
 		}
 	})
 }
@@ -142,12 +143,12 @@ func createRelease(cmd *Command, args *Args) {
 			}
 			err = uploader.UploadAll(paths)
 			if err != nil {
-				fmt.Println("")
+				ui.Println("")
 				utils.Check(err)
 			}
 		}
 
-		fmt.Printf("\n%s\n", release.HTMLURL)
+		ui.Printf("\n%s\n", release.HTMLURL)
 	})
 }
 

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -11,6 +11,7 @@ import (
 	flag "github.com/github/hub/Godeps/_workspace/src/github.com/ogier/pflag"
 	"github.com/github/hub/cmd"
 	"github.com/github/hub/git"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -106,7 +107,7 @@ func (r *Runner) Call(cmd *Command, args *Args) ExecError {
 
 func printCommands(cmds []*cmd.Cmd) {
 	for _, c := range cmds {
-		fmt.Println(c)
+		ui.Println(c)
 	}
 }
 

--- a/commands/updater.go
+++ b/commands/updater.go
@@ -16,6 +16,7 @@ import (
 	goupdate "github.com/github/hub/Godeps/_workspace/src/github.com/inconshreveable/go-update"
 	"github.com/github/hub/git"
 	"github.com/github/hub/github"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -67,8 +68,8 @@ func (updater *Updater) PromptForUpdate() (err error) {
 		case "always":
 			err = updater.updateTo(releaseName, version)
 		default:
-			fmt.Println("There is a newer version of hub available.")
-			fmt.Print("Would you like to update? ([Y]es/[N]o/[A]lways/N[e]ver): ")
+			ui.Println("There is a newer version of hub available.")
+			ui.Printf("Would you like to update? ([Y]es/[N]o/[A]lways/N[e]ver): ")
 			var confirm string
 			fmt.Scan(&confirm)
 
@@ -87,18 +88,18 @@ func (updater *Updater) PromptForUpdate() (err error) {
 func (updater *Updater) Update() (err error) {
 	config := autoUpdateConfig()
 	if config == "never" {
-		fmt.Println("Update is disabled")
+		ui.Println("Update is disabled")
 		return
 	}
 
 	releaseName, version := updater.latestReleaseNameAndVersion()
 	if version == "" {
-		fmt.Println("There is no newer version of hub available.")
+		ui.Println("There is no newer version of hub available.")
 		return
 	}
 
 	if version == updater.CurrentVersion {
-		fmt.Printf("You're already on the latest version: %s\n", version)
+		ui.Printf("You're already on the latest version: %s\n", version)
 	} else {
 		err = updater.updateTo(releaseName, version)
 	}
@@ -116,7 +117,7 @@ func (updater *Updater) latestReleaseNameAndVersion() (name, version string) {
 }
 
 func (updater *Updater) updateTo(releaseName, version string) (err error) {
-	fmt.Printf("Updating gh to %s...\n", version)
+	ui.Printf("Updating gh to %s...\n", version)
 	downloadURL := fmt.Sprintf("https://%s/github/hub/releases/download/%s/hub%s_%s_%s.zip", updater.Host, releaseName, version, runtime.GOOS, runtime.GOARCH)
 	path, err := downloadFile(downloadURL)
 	if err != nil {
@@ -130,7 +131,7 @@ func (updater *Updater) updateTo(releaseName, version string) (err error) {
 
 	err, _ = goupdate.New().FromFile(exec)
 	if err == nil {
-		fmt.Println("Done!")
+		ui.Println("Done!")
 	}
 
 	return

--- a/commands/version.go
+++ b/commands/version.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/github/hub/git"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -27,8 +28,8 @@ func runVersion(cmd *Command, args *Args) {
 
 	ghVersion := fmt.Sprintf("hub version %s", Version)
 
-	fmt.Println(gitVersion)
-	fmt.Println(ghVersion)
+	ui.Println(gitVersion)
+	ui.Println(ghVersion)
 
 	os.Exit(0)
 }

--- a/github/config.go
+++ b/github/config.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/github/hub/Godeps/_workspace/src/github.com/howeyc/gopass"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -69,7 +70,7 @@ func (c *Config) PromptForHost(host string) (h *Host, err error) {
 
 		if ae, ok := err.(*AuthError); ok && ae.IsRequired2FACodeError() {
 			if code != "" {
-				fmt.Fprintln(os.Stderr, "warning: invalid two-factor code")
+				ui.Errorln("warning: invalid two-factor code")
 			}
 			code = c.PromptForOTP()
 		} else {
@@ -105,7 +106,7 @@ func (c *Config) PromptForUser(host string) (user string) {
 		return
 	}
 
-	fmt.Printf("%s username: ", host)
+	ui.Printf("%s username: ", host)
 	user = c.scanLine()
 
 	return
@@ -117,7 +118,7 @@ func (c *Config) PromptForPassword(host, user string) (pass string) {
 		return
 	}
 
-	fmt.Printf("%s password for %s (never stored): ", host, user)
+	ui.Printf("%s password for %s (never stored): ", host, user)
 	if isTerminal(os.Stdout.Fd()) {
 		pass = string(gopass.GetPasswd())
 	} else {
@@ -166,7 +167,7 @@ func (c *Config) selectHost() *Host {
 	}
 	prompt += fmt.Sprint("> ")
 
-	fmt.Printf(prompt)
+	ui.Printf(prompt)
 	index := c.scanLine()
 	i, err := strconv.Atoi(index)
 	if err != nil || i < 1 || i > options {

--- a/github/crash_report.go
+++ b/github/crash_report.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/github/hub/git"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -70,7 +71,7 @@ func report(reportedError error, stack string) {
 	issue, err := gh.CreateIssue(project, title, body, []string{"Crash Report"})
 	utils.Check(err)
 
-	fmt.Println(issue.HTMLURL)
+	ui.Println(issue.HTMLURL)
 }
 
 func reportTitleAndBody(reportedError error, stack string) (title, body string, err error) {
@@ -111,8 +112,8 @@ func formatStack(buf []byte) string {
 }
 
 func printError(err error, stack string) {
-	fmt.Printf("%v\n\n", err)
-	fmt.Println(stack)
+	ui.Printf("%v\n\n", err)
+	ui.Println(stack)
 }
 
 func saveReportConfiguration(confirm string, always bool) {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1,0 +1,53 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+type UI interface {
+	Printf(format string, a ...interface{}) (n int, err error)
+	Println(a ...interface{}) (n int, err error)
+	Errorf(format string, a ...interface{}) (n int, err error)
+	Errorln(a ...interface{}) (n int, err error)
+}
+
+var Default UI = Console{Stdout: os.Stdout, Stderr: os.Stderr}
+
+func Printf(format string, a ...interface{}) (n int, err error) {
+	return Default.Printf(format, a...)
+}
+
+func Println(a ...interface{}) (n int, err error) {
+	return Default.Println(a...)
+}
+
+func Errorf(format string, a ...interface{}) (n int, err error) {
+	return Default.Errorf(format, a...)
+}
+
+func Errorln(a ...interface{}) (n int, err error) {
+	return Default.Errorln(a...)
+}
+
+type Console struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func (c Console) Printf(format string, a ...interface{}) (n int, err error) {
+	return fmt.Fprintf(c.Stdout, format, a...)
+}
+
+func (c Console) Println(a ...interface{}) (n int, err error) {
+	return fmt.Fprintln(c.Stdout, a...)
+}
+
+func (c Console) Errorf(format string, a ...interface{}) (n int, err error) {
+	return fmt.Fprintf(c.Stderr, format, a...)
+}
+
+func (c Console) Errorln(a ...interface{}) (n int, err error) {
+	return fmt.Fprintln(c.Stderr, a...)
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,17 +2,18 @@ package utils
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/github/hub/ui"
 )
 
 func Check(err error) {
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		ui.Errorln(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Introduce a `console` package which encapsulates logic of printing out
to console. This provides flexibility of discarding output in tests.
It also allows us to unify format of printing to console (if we want to).

This fixes #801.