### PR TITLE
Read title and body by taking into account Windows line endings

### DIFF
--- a/commands/utils.go
+++ b/commands/utils.go
@@ -1,14 +1,15 @@
 package commands
 
 import (
+	"bufio"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/github/hub/Godeps/_workspace/src/github.com/octokit/go-octokit/octokit"
 	"github.com/github/hub/github"
 	"github.com/github/hub/utils"
-	"github.com/github/hub/Godeps/_workspace/src/github.com/octokit/go-octokit/octokit"
 )
 
 type listFlag []string
@@ -94,10 +95,13 @@ func getTitleAndBodyFromFlags(messageFlag, fileFlag string) (title, body string,
 }
 
 func readMsg(msg string) (title, body string) {
-	split := strings.SplitN(msg, "\n\n", 2)
-	title = strings.TrimSpace(split[0])
-	if len(split) > 1 {
-		body = strings.TrimSpace(split[1])
+	s := bufio.NewScanner(strings.NewReader(msg))
+	if s.Scan() {
+		title = s.Text()
+		body = strings.TrimLeft(msg, title)
+
+		title = strings.TrimSpace(title)
+		body = strings.TrimSpace(body)
 	}
 
 	return

--- a/commands/utils_test.go
+++ b/commands/utils_test.go
@@ -1,11 +1,30 @@
 package commands
 
 import (
-	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
 )
+
+func TestReadMsg(t *testing.T) {
+	title, body := readMsg("")
+	assert.Equal(t, "", title)
+	assert.Equal(t, "", body)
+
+	title, body = readMsg("my pull title")
+	assert.Equal(t, "my pull title", title)
+	assert.Equal(t, "", body)
+
+	title, body = readMsg("my pull title\n\nmy description\n\nanother line")
+	assert.Equal(t, "my pull title", title)
+	assert.Equal(t, "my description\n\nanother line", body)
+
+	title, body = readMsg("my pull title\r\n\r\nmy description\r\n\r\nanother line")
+	assert.Equal(t, "my pull title", title)
+	assert.Equal(t, "my description\r\n\r\nanother line", body)
+}
 
 func TestDirIsNotEmpty(t *testing.T) {
 	dir := createTempDir(t)


### PR DESCRIPTION
`bufio.Scanner` takes care of line endings difference for different OSes. See http://golang.org/pkg/bufio/#ScanLines.

This fixes #805