### PR TITLE
merge: do not insert "--no-ff" for "--squash"

### DIFF
--- a/commands/merge.go
+++ b/commands/merge.go
@@ -76,7 +76,7 @@ func transformMergeArgs(args *Args) error {
 	mergeMsg := fmt.Sprintf("Merge pull request #%v from %s\n\n%s", id, mergeHead, pullRequest.Title)
 	args.AppendParams(mergeHead, "-m", mergeMsg)
 
-	if args.IndexOfParam("--ff-only") == -1 {
+	if args.IndexOfParam("--ff-only") == -1 && args.IndexOfParam("--squash") == -1 {
 		i := args.IndexOfParam("-m")
 		args.InsertParam(i, "--no-ff")
 	}

--- a/features/merge.feature
+++ b/features/merge.feature
@@ -19,6 +19,7 @@ Feature: hub merge
     And there is a commit named "jfirebaugh/hub_merge"
     When I successfully run `hub merge https://github.com/defunkt/hub/pull/164`
     Then "git fetch git://github.com/jfirebaugh/hub.git +refs/heads/hub_merge:refs/remotes/jfirebaugh/hub_merge" should be run
+    And "git merge jfirebaugh/hub_merge --no-ff -m Merge pull request #164 from jfirebaugh/hub_merge" should be run
     When I successfully run `git show -s --format=%B`
     Then the output should contain:
       """
@@ -42,6 +43,29 @@ Feature: hub merge
     And there is a commit named "jfirebaugh/hub_merge"
     When I successfully run `hub merge --ff-only https://github.com/defunkt/hub/pull/164`
     Then "git fetch git://github.com/jfirebaugh/hub.git +refs/heads/hub_merge:refs/remotes/jfirebaugh/hub_merge" should be run
+    And "git merge --ff-only jfirebaugh/hub_merge -m Merge pull request #164 from jfirebaugh/hub_merge" should be run
+    When I successfully run `git show -s --format=%B`
+    Then the output should contain:
+      """
+      Fast-forward (no commit created; -m option ignored)
+      """
+
+  Scenario: Merge pull request with --squash option
+    Given the GitHub API server:
+      """
+      require 'json'
+      get('/repos/defunkt/hub/pulls/164') { json \
+        :head => {
+          :label => 'jfirebaugh:hub_merge',
+          :repo  => {:private => false, :name=>"hub"}
+        },
+        :title => "Add `hub merge` command"
+      }
+      """
+    And there is a commit named "jfirebaugh/hub_merge"
+    When I successfully run `hub merge --squash https://github.com/defunkt/hub/pull/164`
+    Then "git fetch git://github.com/jfirebaugh/hub.git +refs/heads/hub_merge:refs/remotes/jfirebaugh/hub_merge" should be run
+    And "git merge --squash jfirebaugh/hub_merge -m Merge pull request #164 from jfirebaugh/hub_merge" should be run
     When I successfully run `git show -s --format=%B`
     Then the output should contain:
       """


### PR DESCRIPTION
`hub merge --squash PULL_URL` fails with:

```
You cannot combine --squash with --no-ff
```

This PR is to replace https://github.com/github/hub/pull/796 by adding tests.