### PR TITLE
gh pages: `hub` homebrew formula doesn’t require `—HEAD` now

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
 </p>
 
 <pre><span class="comment"># OS X: install latest revision</span>
-$ <a href="http://brew.sh/">brew</a> install --HEAD hub
+$ <a href="http://brew.sh/">brew</a> install hub
 
 <span class="comment"># Other platforms: fetch a <a href="https://github.com/github/hub/releases">precompiled binary release</a>, or</span>
 <span class="comment"># build your own from source. You'll need a <a href="http://golang.org/doc/install">Go development environment</a>.</span>


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew/commit/69096c85c710679a83fbc32d9950d42668707aec