### PR TITLE
`Args.InsertParam` resets index to param size if it’s out of bound

### DIFF
--- a/commands/args.go
+++ b/commands/args.go
@@ -95,11 +95,15 @@ func (a *Args) HasSubcommand() bool {
 }
 
 func (a *Args) InsertParam(i int, items ...string) {
-	if i < 0 || (i != 0 && i > a.ParamsSize()-1) {
+	if i < 0 {
 		panic(fmt.Sprintf("Index %d is out of bound", i))
 	}
 
-	newParams := []string{}
+	if i > a.ParamsSize() {
+		i = a.ParamsSize()
+	}
+
+	newParams := make([]string, 0)
 	newParams = append(newParams, a.Params[:i]...)
 	newParams = append(newParams, items...)
 	newParams = append(newParams, a.Params[i:]...)

--- a/commands/args_test.go
+++ b/commands/args_test.go
@@ -62,6 +62,19 @@ func TestArgs_Insert(t *testing.T) {
 
 	assert.Equal(t, 5, args.ParamsSize())
 	assert.Equal(t, "foo", args.Params[3])
+
+	args = NewArgs([]string{"checkout", "-b"})
+	args.InsertParam(1, "foo")
+
+	assert.Equal(t, 2, args.ParamsSize())
+	assert.Equal(t, "-b", args.Params[0])
+	assert.Equal(t, "foo", args.Params[1])
+
+	args = NewArgs([]string{"checkout"})
+	args.InsertParam(1, "foo")
+
+	assert.Equal(t, 1, args.ParamsSize())
+	assert.Equal(t, "foo", args.Params[0])
 }
 
 func TestArgs_Remove(t *testing.T) {

--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -64,6 +64,11 @@ func transformCheckoutArgs(args *Args) error {
 		return nil
 	}
 
+	err = sanitizeCheckoutFlags(args)
+	if err != nil {
+		return err
+	}
+
 	id := pullURLRegex.FindStringSubmatch(projectPath)[1]
 	gh := github.NewClient(url.Project.Host)
 	pullRequest, err := gh.PullRequest(url.Project, id)
@@ -99,6 +104,18 @@ func transformCheckoutArgs(args *Args) error {
 
 	remoteName := fmt.Sprintf("%s/%s", user, branch)
 	replaceCheckoutParam(args, checkoutURL, newBranchName, remoteName)
+
+	return nil
+}
+
+func sanitizeCheckoutFlags(args *Args) error {
+	if i := args.IndexOfParam("-b"); i != -1 {
+		return fmt.Errorf("Unsupported flag -b when checking out pull request")
+	}
+
+	if i := args.IndexOfParam("--orphan"); i != -1 {
+		return fmt.Errorf("Unsupported flag --orphan when checking out pull request")
+	}
 
 	return nil
 }

--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -97,9 +97,14 @@ func transformCheckoutArgs(args *Args) error {
 		args.Before("git", "remote", "add", "-f", "-t", branch, user, u)
 	}
 
-	idx := args.IndexOfParam(checkoutURL)
-	args.RemoveParam(idx)
-	args.InsertParam(idx, "--track", "-B", newBranchName, fmt.Sprintf("%s/%s", user, branch))
+	remoteName := fmt.Sprintf("%s/%s", user, branch)
+	replaceCheckoutParam(args, checkoutURL, newBranchName, remoteName)
 
 	return nil
+}
+
+func replaceCheckoutParam(args *Args, checkoutURL, branchName, remoteName string) {
+	idx := args.IndexOfParam(checkoutURL)
+	args.RemoveParam(idx)
+	args.InsertParam(idx, "--track", "-B", branchName, remoteName)
 }

--- a/commands/checkout_test.go
+++ b/commands/checkout_test.go
@@ -1,0 +1,16 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
+)
+
+func TestReplaceCheckoutParam(t *testing.T) {
+	checkoutURL := "https://github.com/github/hub/pull/12"
+	args := NewArgs([]string{"checkout", "-b", checkoutURL})
+	replaceCheckoutParam(args, checkoutURL, "jingweno", "origin/master")
+
+	cmd := args.ToCmd()
+	assert.Equal(t, "git checkout -b --track -B jingweno origin/master", cmd.String())
+}

--- a/commands/checkout_test.go
+++ b/commands/checkout_test.go
@@ -8,9 +8,21 @@ import (
 
 func TestReplaceCheckoutParam(t *testing.T) {
 	checkoutURL := "https://github.com/github/hub/pull/12"
-	args := NewArgs([]string{"checkout", "-b", checkoutURL})
+	args := NewArgs([]string{"checkout", checkoutURL})
 	replaceCheckoutParam(args, checkoutURL, "jingweno", "origin/master")
 
 	cmd := args.ToCmd()
-	assert.Equal(t, "git checkout -b --track -B jingweno origin/master", cmd.String())
+	assert.Equal(t, "git checkout --track -B jingweno origin/master", cmd.String())
+}
+
+func TestTransformCheckoutArgs(t *testing.T) {
+	args := NewArgs([]string{"checkout", "-b", "https://github.com/github/hub/pull/12"})
+	err := transformCheckoutArgs(args)
+
+	assert.Equal(t, "Unsupported flag -b when checking out pull request", err.Error())
+
+	args = NewArgs([]string{"checkout", "--orphan", "https://github.com/github/hub/pull/12"})
+	err = transformCheckoutArgs(args)
+
+	assert.Equal(t, "Unsupported flag --orphan when checking out pull request", err.Error())
 }


### PR DESCRIPTION
`Args.InsertParam` panics about index out of bound if the index is larger than param size. These changes reset the index to param size for such case. This is equivalent to appending new items to the end.

This fixes #812.