### PR TITLE
Avoid using "label" field when parsing PR response

### DIFF
--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -80,10 +80,12 @@ func transformCheckoutArgs(args *Args) error {
 		args.RemoveParam(idx)
 	}
 
-	user, branch := parseUserBranchFromPR(pullRequest)
-	if pullRequest.Head.Repo == nil {
-		return fmt.Errorf("Error: %s's fork is not available anymore", user)
+	branch := pullRequest.Head.Ref
+	headRepo := pullRequest.Head.Repo
+	if headRepo == nil {
+		return fmt.Errorf("Error: that fork is not available anymore")
 	}
+	user := headRepo.Owner.Name
 
 	if newBranchName == "" {
 		newBranchName = fmt.Sprintf("%s-%s", user, branch)

--- a/commands/merge.go
+++ b/commands/merge.go
@@ -59,13 +59,14 @@ func transformMergeArgs(args *Args) error {
 		return err
 	}
 
-	user, branch := parseUserBranchFromPR(pullRequest)
-	if pullRequest.Head.Repo == nil {
-		return fmt.Errorf("Error: %s's fork is not available anymore", user)
+	branch := pullRequest.Head.Ref
+	headRepo := pullRequest.Head.Repo
+	if headRepo == nil {
+		return fmt.Errorf("Error: that fork is not available anymore")
 	}
 
-	u := url.GitURL(pullRequest.Head.Repo.Name, user, pullRequest.Head.Repo.Private)
-	mergeHead := fmt.Sprintf("%s/%s", user, branch)
+	u := url.GitURL(headRepo.Name, headRepo.Owner.Name, headRepo.Private)
+	mergeHead := fmt.Sprintf("%s/%s", headRepo.Owner.Name, branch)
 	ref := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s", branch, mergeHead)
 	args.Before("git", "fetch", u, ref)
 

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/github/hub/Godeps/_workspace/src/github.com/octokit/go-octokit/octokit"
 	"github.com/github/hub/github"
 	"github.com/github/hub/utils"
 )
@@ -38,18 +37,6 @@ func isDir(file string) bool {
 	}
 
 	return fi.IsDir()
-}
-
-func parseUserBranchFromPR(pullRequest *octokit.PullRequest) (user string, branch string) {
-	userBranch := strings.SplitN(pullRequest.Head.Label, ":", 2)
-	user = userBranch[0]
-	if len(userBranch) > 1 {
-		branch = userBranch[1]
-	} else {
-		branch = pullRequest.Head.Ref
-	}
-
-	return
 }
 
 func gitRemoteForProject(project *github.Project) (foundRemote *github.Remote) {

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -13,9 +13,10 @@ Feature: hub checkout <PULLREQ-URL>
       get('/repos/mojombo/jekyll/pulls/77') {
         halt 406 unless request.env['HTTP_ACCEPT'] == 'application/vnd.github.v3+json;charset=utf-8'
         json :head => {
-          :label => 'mislav:fixes',
+          :ref => "fixes",
           :repo => {
-            :name => 'jekyll',
+            :owner => { :name => "mislav" },
+            :name => "jekyll",
             :private => false
           }
         }
@@ -30,9 +31,10 @@ Feature: hub checkout <PULLREQ-URL>
       """
       get('/repos/mojombo/jekyll/pulls/77') {
         json :head => {
-          :label => 'mislav:fixes',
+          :ref => "fixes",
           :repo => {
-            :name => 'jekyll-blog',
+            :owner => { :name => "mislav" },
+            :name => "jekyll-blog",
             :private => false
           }
         }
@@ -47,9 +49,10 @@ Feature: hub checkout <PULLREQ-URL>
       """
       get('/repos/mojombo/jekyll/pulls/77') {
         json :head => {
-          :label => 'mislav:fixes',
+          :ref => "fixes",
           :repo => {
-            :name => 'jekyll',
+            :owner => { :name => "mislav" },
+            :name => "jekyll",
             :private => false
           }
         }
@@ -64,9 +67,10 @@ Feature: hub checkout <PULLREQ-URL>
       """
       get('/repos/mojombo/jekyll/pulls/77') {
         json :head => {
-          :label => 'mislav:fixes',
+          :ref => "fixes",
           :repo => {
-            :name => 'jekyll',
+            :owner => { :name => "mislav" },
+            :name => "jekyll",
             :private => true
           }
         }
@@ -81,9 +85,10 @@ Feature: hub checkout <PULLREQ-URL>
       """
       get('/repos/mojombo/jekyll/pulls/77') {
         json :head => {
-          :label => 'mislav:fixes',
+          :ref => "fixes",
           :repo => {
-            :name => 'jekyll',
+            :owner => { :name => "mislav" },
+            :name => "jekyll",
             :private => false
           }
         }
@@ -98,9 +103,10 @@ Feature: hub checkout <PULLREQ-URL>
       """
       get('/repos/mojombo/jekyll/pulls/77') {
         json :head => {
-          :label => 'mislav:fixes',
+          :ref => "fixes",
           :repo => {
-            :name => 'jekyll',
+            :owner => { :name => "mislav" },
+            :name => "jekyll",
             :private => false
           }
         }

--- a/features/merge.feature
+++ b/features/merge.feature
@@ -7,11 +7,14 @@ Feature: hub merge
   Scenario: Merge pull request
     Given the GitHub API server:
       """
-      require 'json'
       get('/repos/defunkt/hub/pulls/164') { json \
         :head => {
-          :label => 'jfirebaugh:hub_merge',
-          :repo  => {:private => false, :name=>"hub"}
+          :ref => "hub_merge",
+          :repo => {
+            :owner => { :name => "jfirebaugh" },
+            :name => "hub",
+            :private => false
+          }
         },
         :title => "Add `hub merge` command"
       }
@@ -34,8 +37,12 @@ Feature: hub merge
       require 'json'
       get('/repos/defunkt/hub/pulls/164') { json \
         :head => {
-          :label => 'jfirebaugh:hub_merge',
-          :repo  => {:private => false, :name=>"hub"}
+          :ref => "hub_merge",
+          :repo => {
+            :owner => { :name => "jfirebaugh" },
+            :name => "hub",
+            :private => false
+          }
         },
         :title => "Add `hub merge` command"
       }
@@ -56,8 +63,12 @@ Feature: hub merge
       require 'json'
       get('/repos/defunkt/hub/pulls/164') { json \
         :head => {
-          :label => 'jfirebaugh:hub_merge',
-          :repo  => {:private => false, :name=>"hub"}
+          :ref => "hub_merge",
+          :repo => {
+            :owner => { :name => "jfirebaugh" },
+            :name => "hub",
+            :private => false
+          }
         },
         :title => "Add `hub merge` command"
       }
@@ -78,8 +89,12 @@ Feature: hub merge
       require 'json'
       get('/repos/defunkt/hub/pulls/164') { json \
         :head => {
-          :label => 'jfirebaugh:hub_merge',
-          :repo  => {:private => true, :name=>"hub"}
+          :ref => "hub_merge",
+          :repo => {
+            :owner => { :name => "jfirebaugh" },
+            :name => "hub",
+            :private => true
+          }
         },
         :title => "Add `hub merge` command"
       }
@@ -94,8 +109,8 @@ Feature: hub merge
       require 'json'
       get('/repos/defunkt/hub/pulls/164') { json \
         :head => {
-          :label => 'jfirebaugh:hub_merge',
-          :repo  => nil
+          :ref => "hub_merge",
+          :repo => nil
         }
       }
       """
@@ -103,7 +118,7 @@ Feature: hub merge
     Then the exit status should be 1
     And the stderr should contain exactly:
       """
-      Error: jfirebaugh's fork is not available anymore\n
+      Error: that fork is not available anymore\n
       """
 
   Scenario: Renamed repo
@@ -112,8 +127,12 @@ Feature: hub merge
       require 'json'
       get('/repos/defunkt/hub/pulls/164') { json \
         :head => {
-          :label => 'jfirebaugh:hub_merge',
-          :repo  => {:private => false, :name=>"hub-1"}
+          :ref => "hub_merge",
+          :repo => {
+            :owner => { :name => "jfirebaugh" },
+            :name => "hub-1",
+            :private => false
+          }
         }
       }
       """


### PR DESCRIPTION
To obtain the owner/fork-name combo, instead of reading it from "label" field from the PR response simply read from `Head.Ref` and `Head.Repo.Owner.Name` instead. This is because label is meant to be human-readable, isn't well-documented in GitHub API docs, and is unclear when it contains two components (delimited by `:`) or when it contains only one.

Maybe fixes #816