### PR TITLE
Use `.Login` instead of `.Name` for generating a remote or branch name.

### DIFF
--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -85,7 +85,7 @@ func transformCheckoutArgs(args *Args) error {
 	if headRepo == nil {
 		return fmt.Errorf("Error: that fork is not available anymore")
 	}
-	user := headRepo.Owner.Name
+	user := headRepo.Owner.Login
 
 	if newBranchName == "" {
 		newBranchName = fmt.Sprintf("%s-%s", user, branch)

--- a/commands/merge.go
+++ b/commands/merge.go
@@ -65,8 +65,8 @@ func transformMergeArgs(args *Args) error {
 		return fmt.Errorf("Error: that fork is not available anymore")
 	}
 
-	u := url.GitURL(headRepo.Name, headRepo.Owner.Name, headRepo.Private)
-	mergeHead := fmt.Sprintf("%s/%s", headRepo.Owner.Name, branch)
+	u := url.GitURL(headRepo.Name, headRepo.Owner.Login, headRepo.Private)
+	mergeHead := fmt.Sprintf("%s/%s", headRepo.Owner.Login, branch)
 	ref := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s", branch, mergeHead)
 	args.Before("git", "fetch", u, ref)
 

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -15,7 +15,7 @@ Feature: hub checkout <PULLREQ-URL>
         json :head => {
           :ref => "fixes",
           :repo => {
-            :owner => { :name => "mislav" },
+            :owner => { :login => "mislav" },
             :name => "jekyll",
             :private => false
           }
@@ -33,7 +33,7 @@ Feature: hub checkout <PULLREQ-URL>
         json :head => {
           :ref => "fixes",
           :repo => {
-            :owner => { :name => "mislav" },
+            :owner => { :login => "mislav" },
             :name => "jekyll-blog",
             :private => false
           }
@@ -51,7 +51,7 @@ Feature: hub checkout <PULLREQ-URL>
         json :head => {
           :ref => "fixes",
           :repo => {
-            :owner => { :name => "mislav" },
+            :owner => { :login => "mislav" },
             :name => "jekyll",
             :private => false
           }
@@ -69,7 +69,7 @@ Feature: hub checkout <PULLREQ-URL>
         json :head => {
           :ref => "fixes",
           :repo => {
-            :owner => { :name => "mislav" },
+            :owner => { :login => "mislav" },
             :name => "jekyll",
             :private => true
           }
@@ -87,7 +87,7 @@ Feature: hub checkout <PULLREQ-URL>
         json :head => {
           :ref => "fixes",
           :repo => {
-            :owner => { :name => "mislav" },
+            :owner => { :login => "mislav" },
             :name => "jekyll",
             :private => false
           }
@@ -105,7 +105,7 @@ Feature: hub checkout <PULLREQ-URL>
         json :head => {
           :ref => "fixes",
           :repo => {
-            :owner => { :name => "mislav" },
+            :owner => { :login => "mislav" },
             :name => "jekyll",
             :private => false
           }

--- a/features/merge.feature
+++ b/features/merge.feature
@@ -11,7 +11,7 @@ Feature: hub merge
         :head => {
           :ref => "hub_merge",
           :repo => {
-            :owner => { :name => "jfirebaugh" },
+            :owner => { :login => "jfirebaugh" },
             :name => "hub",
             :private => false
           }
@@ -39,7 +39,7 @@ Feature: hub merge
         :head => {
           :ref => "hub_merge",
           :repo => {
-            :owner => { :name => "jfirebaugh" },
+            :owner => { :login => "jfirebaugh" },
             :name => "hub",
             :private => false
           }
@@ -65,7 +65,7 @@ Feature: hub merge
         :head => {
           :ref => "hub_merge",
           :repo => {
-            :owner => { :name => "jfirebaugh" },
+            :owner => { :login => "jfirebaugh" },
             :name => "hub",
             :private => false
           }
@@ -91,7 +91,7 @@ Feature: hub merge
         :head => {
           :ref => "hub_merge",
           :repo => {
-            :owner => { :name => "jfirebaugh" },
+            :owner => { :login => "jfirebaugh" },
             :name => "hub",
             :private => true
           }
@@ -129,7 +129,7 @@ Feature: hub merge
         :head => {
           :ref => "hub_merge",
           :repo => {
-            :owner => { :name => "jfirebaugh" },
+            :owner => { :login => "jfirebaugh" },
             :name => "hub-1",
             :private => false
           }


### PR DESCRIPTION
It is `headRepo.Owner.Login` that holds the unix account name of the
owner, and `headRepo.Owner.Name` is omitted from the embedded owner
information, resulting in the following failure:

```
% hub checkout https://github.com/github/hub/issues/{number}
fatal: '' is not a valid remote name
```