### PR TITLE
Make the ssh config reader case-insensitive

### DIFF
--- a/git/ssh_config.go
+++ b/git/ssh_config.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	hostReStr = "^[ \t]*(Host|HostName|Hostname)[ \t]+(.+)$"
+	hostReStr = "(?i)^[ \t]*(host|hostname)[ \t]+(.+)$"
 )
 
 type SSHConfig map[string]string
@@ -56,7 +56,7 @@ func (r *SSHConfigReader) readFile(c SSHConfig, re *regexp.Regexp, f string) err
 		}
 
 		names := strings.Fields(match[2])
-		if match[1] == "Host" {
+		if strings.EqualFold(match[1], "host") {
 			hosts = names
 		} else {
 			for _, host := range hosts {

--- a/git/ssh_config_test.go
+++ b/git/ssh_config_test.go
@@ -13,6 +13,9 @@ func TestSSHConfigReader_Read(t *testing.T) {
 	c := `Host github.com
   Hostname ssh.github.com
   Port 443
+
+	host other
+	Hostname 10.0.0.1
 	`
 
 	ioutil.WriteFile(f.Name(), []byte(c), os.ModePerm)


### PR DESCRIPTION
I had a cryptic problem because the ssh config reader is case-sensitive, while ssh itself is not:
> [servconf.c@520](http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/servconf.c?annotate=1.260):
> ``` c
if (strcasecmp(cp, keywords[i].name) == 0) {
	*flags = keywords[i].flags;
	return keywords[i].opcode;
}
```

In my case, I had something like the following in my ssh config (note the lowercase "h" in `host other`):
```
Host github.com
  HostName ssl.github.com
  Port 443

host other
  HostName 10.0.0.1
```

This caused the url to be written with 10.0.0.1 used as the host replacement. This was, subsequently, causing operations like `pull-request` to fail because remotes with `github.com` were no longer being recognized as being github (because of the rewrite). 