### PR TITLE
Updated etc/hub.bash_completion.sh : fixed issue #592

### DIFF
--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -1,6 +1,11 @@
 # hub tab-completion script for bash.
 # This script complements the completion script that ships with git.
 
+
+# checking if git built-in completion is available and sourcing it for hub tab complition uses.
+[ -f /usr/share/bash-completion/completions/git ] && . /usr/share/bash-completion/completions/git
+
+
 # Check that git tab completion is available
 if declare -F _git > /dev/null; then
   # Duplicate and rename the 'list_all_commands' function


### PR DESCRIPTION
fixed issue #592 :by sourcing the /usr/share/bit-completion/completion/git to terminal whenever hub <tab> is pressed, so that hub can use the git completion"
without which hub was not able to complete on pressing <tab>