### PR TITLE
Improve crash report with command and version

### DIFF
--- a/commands/updater.go
+++ b/commands/updater.go
@@ -18,6 +18,7 @@ import (
 	"github.com/github/hub/github"
 	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
+	"github.com/github/hub/version"
 )
 
 const (
@@ -27,15 +28,15 @@ const (
 var EnableAutoUpdate = false
 
 func NewUpdater() *Updater {
-	version := os.Getenv("HUB_VERSION")
-	if version == "" {
-		version = Version
+	ver := os.Getenv("HUB_VERSION")
+	if ver == "" {
+		ver = version.Version
 	}
 
 	timestampPath := filepath.Join(os.Getenv("HOME"), ".config", "hub-update")
 	return &Updater{
 		Host:           github.DefaultGitHubHost(),
-		CurrentVersion: version,
+		CurrentVersion: ver,
 		timestampPath:  timestampPath,
 	}
 }

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,15 +1,11 @@
 package commands
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/github/hub/git"
 	"github.com/github/hub/ui"
-	"github.com/github/hub/utils"
+	"github.com/github/hub/version"
 )
-
-var Version = "2.2.1"
 
 var cmdVersion = &Command{
 	Run:   runVersion,
@@ -23,13 +19,6 @@ func init() {
 }
 
 func runVersion(cmd *Command, args *Args) {
-	gitVersion, err := git.Version()
-	utils.Check(err)
-
-	ghVersion := fmt.Sprintf("hub version %s", Version)
-
-	ui.Println(gitVersion)
-	ui.Println(ghVersion)
-
+	ui.Println(version.FullVersion())
 	os.Exit(0)
 }

--- a/github/crash_report.go
+++ b/github/crash_report.go
@@ -12,6 +12,7 @@ import (
 	"github.com/github/hub/git"
 	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
+	"github.com/github/hub/version"
 )
 
 const (
@@ -74,19 +75,31 @@ func report(reportedError error, stack string) {
 	ui.Println(issue.HTMLURL)
 }
 
-func reportTitleAndBody(reportedError error, stack string) (title, body string, err error) {
-	message := "Crash report - %v\n\nError (%s): `%v`\n\nStack:\n\n```\n%s\n```\n\nRuntime:\n\n```\n%s\n```\n\n"
-	message += `
+const crashReportTmpl = "Crash report - %v\n\n" +
+	"Error (%s): `%v`\n\n" +
+	"Stack:\n\n```\n%s\n```\n\n" +
+	"Runtime:\n\n```\n%s\n```\n\n" +
+	"Version:\n\n```\n%s\n```\n" +
+	`
 # Creating crash report:
 #
-# This information will be posted as a new issue under jingweno/gh.
+# This information will be posted as a new issue under github/hub.
 # We're NOT including any information about the command that you were executing,
 # but knowing a little bit more about it would really help us to solve this problem.
 # Feel free to modify the title and the description for this issue.
 `
 
+func reportTitleAndBody(reportedError error, stack string) (title, body string, err error) {
 	errType := reflect.TypeOf(reportedError).String()
-	message = fmt.Sprintf(message, reportedError, errType, reportedError, stack, runtimeInfo())
+	message := fmt.Sprintf(
+		crashReportTmpl,
+		reportedError,
+		errType,
+		reportedError,
+		stack,
+		runtimeInfo(),
+		version.FullVersion(),
+	)
 
 	editor, err := NewEditor("CRASH_REPORT", "crash report", message)
 	if err != nil {

--- a/script/build
+++ b/script/build
@@ -41,7 +41,7 @@ up_to_date() {
 
 build_hub() {
   setup_gopath
-  [ -n "$1" ] && (up_to_date "$1" || go build -ldflags "-X github.com/github/hub/commands.Version `./script/version`" -o "$1")
+  [ -n "$1" ] && (up_to_date "$1" || go build -ldflags "-X github.com/github/hub/version.Version `./script/version`" -o "$1")
 }
 
 test_hub() {

--- a/script/package
+++ b/script/package
@@ -100,7 +100,7 @@ class Packer
   end
 
   def parse_version!
-    content = File.read root_path("commands", "version.go")
+    content = File.read root_path("version", "version.go")
     match = /var Version = "(.+)"/.match content
     raise "Fail to parse Hub version" unless match
 
@@ -137,7 +137,7 @@ class Packer
     # specifying osarch for Windows
     # see https://github.com/mitchellh/gox/issues/19#issuecomment-68117016
     osarch = OS.windows? ? "windows/#{OS.windows_64? ? "amd64" : "386"}" : ""
-    cmd = "gox -os=#{OS.type} -output=#{output} -ldflags \"-X github.com/github/hub/commands.Version #{release_version}\""
+    cmd = "gox -os=#{OS.type} -output=#{output} -ldflags \"-X github.com/github/hub/version.Version #{release_version}\""
     cmd += " -osarch=#{osarch}" unless osarch.empty?
     exec!(cmd)
   end

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,16 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/github/hub/git"
+	"github.com/github/hub/utils"
+)
+
+var Version = "2.2.0"
+
+func FullVersion() string {
+	gitVersion, err := git.Version()
+	utils.Check(err)
+	return fmt.Sprintf("%s\nhub version %s", gitVersion, Version)
+}


### PR DESCRIPTION
This adds running command and hub version to crash report. It includes refactoring of hub version to the `version` package for reusability in `commands` package and `github` package.