### PR TITLE
useHttpProtocol => useProtocol, allow ssh config

### DIFF
--- a/github/project.go
+++ b/github/project.go
@@ -69,9 +69,9 @@ func (p *Project) GitURL(name, owner string, isSSH bool) (url string) {
 
 	host := rawHost(p.Host)
 
-	if useHttpProtocol() {
+	if preferredProtocol() == "https" {
 		url = fmt.Sprintf("https://%s/%s/%s.git", host, owner, name)
-	} else if isSSH {
+	} else if isSSH || preferredProtocol() == "ssh" {
 		url = fmt.Sprintf("git@%s:%s/%s.git", host, owner, name)
 	} else {
 		url = fmt.Sprintf("git://%s/%s/%s.git", host, owner, name)
@@ -92,13 +92,12 @@ func rawHost(host string) string {
 	}
 }
 
-func useHttpProtocol() bool {
-	https := os.Getenv("HUB_PROTOCOL")
-	if https == "" {
-		https, _ = git.Config("hub.protocol")
+func preferredProtocol() string {
+	userProtocol := os.Getenv("HUB_PROTOCOL")
+	if userProtocol == "" {
+		userProtocol, _ = git.Config("hub.protocol")
 	}
-
-	return https == "https"
+	return userProtocol
 }
 
 func NewProjectFromURL(url *url.URL) (p *Project, err error) {

--- a/github/project_test.go
+++ b/github/project_test.go
@@ -50,6 +50,10 @@ func TestProject_GitURL(t *testing.T) {
 	url = project.GitURL("gh", "jingweno", false)
 	assert.Equal(t, "git://github.com/jingweno/gh.git", url)
 
+	os.Setenv("HUB_PROTOCOL", "ssh")
+	url = project.GitURL("gh", "jingweno", true)
+	assert.Equal(t, "git@github.com:jingweno/gh.git", url)
+
 	url = project.GitURL("gh", "jingweno", true)
 	assert.Equal(t, "git@github.com:jingweno/gh.git", url)
 }
@@ -66,6 +70,10 @@ func TestProject_GitURLEnterprise(t *testing.T) {
 	os.Setenv("HUB_PROTOCOL", "https")
 	url := project.GitURL("gh", "jingweno", false)
 	assert.Equal(t, "https://github.corporate.com/jingweno/gh.git", url)
+
+	os.Setenv("HUB_PROTOCOL", "ssh")
+	url = project.GitURL("gh", "jingweno", false)
+	assert.Equal(t, "git@github.corporate.com:jingweno/gh.git", url)
 
 	os.Setenv("HUB_PROTOCOL", "git")
 	url = project.GitURL("gh", "jingweno", false)


### PR DESCRIPTION
`useHttpProtocol` has been changed to a more generic `useProtocol`
function that can be used to check more than just https. This allows us to
use the SSH protocol in any location, regardless of the repository being
private or public.

```
% git config --global hub.protocol ssh
% ./hub --noop clone github/hub
git clone git@github.com:github/hub.git
% git config --global hub.protocol https
% ./hub --noop clone github/hub
git clone https://github.com/github/hub.git
% git config --global hub.protocol none
% ./hub --noop clone github/hub
git clone git://github.com/github/hub.git
```

(Got tired of waiting for #599 :) )