### PR TITLE
[Readme/git clone] Fix typo in git url for one argument usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ superpowers:
     > git clone git@github.com:schacon/ticgit.git
 
     $ git clone resque
-    > git clone git@github.com/YOUR_USER/resque.git
+    > git clone git@github.com:YOUR_USER/resque.git
 
 ### git remote add
 


### PR DESCRIPTION
As noticed here: https://github.com/github/hub/issues/868#issuecomment-93594398

/cc @mislav 