### PR TITLE
fix non-portable GNU find(1)-ism

### DIFF
--- a/script/build
+++ b/script/build
@@ -28,7 +28,7 @@ setup_gopath() {
 }
 
 find_source_files() {
-  find . -maxdepth 2 -name '*.go' -not -name '*_test.go' "$@"
+  find . -maxdepth 2 -name '*.go' '!' -name '*_test.go' "$@"
 }
 
 count_changed_files() {


### PR DESCRIPTION
GNU find(1)'s -not operator is not POSIX compliant.  Use ! operator
instead in order to work with other find(1) implementations.