### PR TITLE
Use `--no-tags` for new remotes in `checkout/cherry-pick`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ superpowers:
 ### git cherry-pick
 
     $ git cherry-pick http://github.com/mislav/REPO/commit/SHA
-    > git remote add -f mislav git://github.com/mislav/REPO.git
+    > git remote add -f --no-tags mislav git://github.com/mislav/REPO.git
     > git cherry-pick SHA
 
     $ git cherry-pick mislav@SHA
-    > git remote add -f mislav git://github.com/mislav/CURRENT_REPO.git
+    > git remote add -f --no-tags mislav git://github.com/mislav/CURRENT_REPO.git
     > git cherry-pick SHA
 
     $ git cherry-pick mislav@SHA
@@ -168,7 +168,7 @@ superpowers:
 ### git checkout
 
     $ git checkout https://github.com/defunkt/hub/pull/73
-    > git remote add -f -t feature mislav git://github.com/mislav/hub.git
+    > git remote add -f --no-tags -t feature mislav git://github.com/mislav/hub.git
     > git checkout --track -B mislav-feature mislav/feature
 
     $ git checkout https://github.com/defunkt/hub/pull/73 custom-branch-name

--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -26,7 +26,7 @@ func init() {
 
 /**
   $ gh checkout https://github.com/jingweno/gh/pull/73
-  > git remote add -f -t feature git://github:com/foo/gh.git
+  > git remote add -f --no-tags -t feature git://github:com/foo/gh.git
   > git checkout --track -B foo-feature foo/feature
 
   $ gh checkout https://github.com/jingweno/gh/pull/73 custom-branch-name
@@ -101,7 +101,7 @@ func transformCheckoutArgs(args *Args) error {
 		args.Before("git", "fetch", user, remoteURL)
 	} else {
 		u := url.Project.GitURL(pullRequest.Head.Repo.Name, user, pullRequest.Head.Repo.Private)
-		args.Before("git", "remote", "add", "-f", "-t", branch, user, u)
+		args.Before("git", "remote", "add", "-f", "--no-tags", "-t", branch, user, u)
 	}
 
 	remoteName := fmt.Sprintf("%s/%s", user, branch)

--- a/commands/cherry_pick.go
+++ b/commands/cherry_pick.go
@@ -25,11 +25,11 @@ func init() {
 
 /*
   $ gh cherry-pick https://github.com/jingweno/gh/commit/a319d88#comments
-  > git remote add -f jingweno git://github.com/jingweno/gh.git
+  > git remote add -f --no-tags jingweno git://github.com/jingweno/gh.git
   > git cherry-pick a319d88
 
   $ gh cherry-pick jingweno@a319d88
-  > git remote add -f jingweno git://github.com/jingweno/gh.git
+  > git remote add -f --no-tags jingweno git://github.com/jingweno/gh.git
   > git cherry-pick a319d88
 
   $ gh cherry-pick jingweno@SHA
@@ -56,7 +56,7 @@ func transformCherryPickArgs(args *Args) {
 		if remote != nil {
 			args.Before("git", "fetch", remote.Name)
 		} else {
-			args.Before("git", "remote", "add", "-f", project.Owner, project.GitURL("", "", false))
+			args.Before("git", "remote", "add", "-f", "--no-tags", project.Owner, project.GitURL("", "", false))
 		}
 	}
 }

--- a/commands/cherry_pick_test.go
+++ b/commands/cherry_pick_test.go
@@ -45,6 +45,6 @@ func TestTransformCherryPickArgs(t *testing.T) {
 
 	cmds = args.Commands()
 	assert.Equal(t, 2, len(cmds))
-	assert.Equal(t, "git remote add -f jingweno git://github.com/jingweno/gh.git", cmds[0].String())
+	assert.Equal(t, "git remote add -f --no-tags jingweno git://github.com/jingweno/gh.git", cmds[0].String())
 	assert.Equal(t, "git cherry-pick a319d88", cmds[1].String())
 }

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -23,7 +23,7 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
-    Then "git remote add -f -t fixes mislav git://github.com/mislav/jekyll.git" should be run
+    Then "git remote add -f --no-tags -t fixes mislav git://github.com/mislav/jekyll.git" should be run
     And "git checkout -f --track -B mislav-fixes mislav/fixes -q" should be run
 
   Scenario: Pull request from a renamed fork
@@ -41,7 +41,7 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77`
-    Then "git remote add -f -t fixes mislav git://github.com/mislav/jekyll-blog.git" should be run
+    Then "git remote add -f --no-tags -t fixes mislav git://github.com/mislav/jekyll-blog.git" should be run
     And "git checkout --track -B mislav-fixes mislav/fixes" should be run
 
   Scenario: Custom name for new branch
@@ -59,7 +59,7 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77 fixes-from-mislav`
-    Then "git remote add -f -t fixes mislav git://github.com/mislav/jekyll.git" should be run
+    Then "git remote add -f --no-tags -t fixes mislav git://github.com/mislav/jekyll.git" should be run
     And "git checkout --track -B fixes-from-mislav mislav/fixes" should be run
 
   Scenario: Private pull request
@@ -77,7 +77,7 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
-    Then "git remote add -f -t fixes mislav git@github.com:mislav/jekyll.git" should be run
+    Then "git remote add -f --no-tags -t fixes mislav git@github.com:mislav/jekyll.git" should be run
     And "git checkout -f --track -B mislav-fixes mislav/fixes -q" should be run
 
   Scenario: Custom name for new branch
@@ -95,7 +95,7 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77 fixes-from-mislav`
-    Then "git remote add -f -t fixes mislav git://github.com/mislav/jekyll.git" should be run
+    Then "git remote add -f --no-tags -t fixes mislav git://github.com/mislav/jekyll.git" should be run
     And "git checkout --track -B fixes-from-mislav mislav/fixes" should be run
 
   Scenario: Remote for user already exists

--- a/features/cherry_pick.feature
+++ b/features/cherry_pick.feature
@@ -40,10 +40,10 @@ Feature: hub cherry-pick
 
   Scenario: Using GitHub owner@SHA notation with remote add
     When I run `hub cherry-pick mislav@a319d88`
-    Then "git remote add -f mislav git://github.com/mislav/ronn.git" should be run
+    Then "git remote add -f --no-tags mislav git://github.com/mislav/ronn.git" should be run
     And "git cherry-pick a319d88" should be run
 
   Scenario: From fork that doesn't have a remote
     When I run `hub cherry-pick https://github.com/jingweno/ronn/commit/a319d88`
-    Then "git remote add -f jingweno git://github.com/jingweno/ronn.git" should be run
+    Then "git remote add -f --no-tags jingweno git://github.com/jingweno/ronn.git" should be run
     And "git cherry-pick a319d88" should be run

--- a/man/hub.1
+++ b/man/hub.1
@@ -282,11 +282,11 @@ $ git fetch mislav,xoebus
 .nf
 
 $ git cherry\-pick http://github\.com/mislav/REPO/commit/SHA
-> git remote add \-f mislav git://github\.com/mislav/REPO\.git
+> git remote add \-f \-\-no\-tags mislav git://github\.com/mislav/REPO\.git
 > git cherry\-pick SHA
 
 $ git cherry\-pick mislav@SHA
-> git remote add \-f mislav git://github\.com/mislav/CURRENT_REPO\.git
+> git remote add \-f \-\-no\-tags mislav git://github\.com/mislav/CURRENT_REPO\.git
 > git cherry\-pick SHA
 
 $ git cherry\-pick mislav@SHA
@@ -342,7 +342,7 @@ $ git pull\-request \-m "Implemented feature X" \-b defunkt:master \-h mislav:fe
 .nf
 
 $ git checkout https://github\.com/defunkt/hub/pull/73
-> git remote add \-f \-t feature mislav git://github\.com/mislav/hub\.git
+> git remote add \-f \-\-no\-tags \-t feature mislav git://github\.com/mislav/hub\.git
 > git checkout \-\-track \-B mislav\-feature mislav/feature
 
 $ git checkout https://github\.com/defunkt/hub/pull/73 custom\-branch\-name

--- a/man/hub.1.html
+++ b/man/hub.1.html
@@ -301,11 +301,11 @@ $ git fetch mislav,xoebus
 <h3 id="git-cherry-pick">git cherry-pick</h3>
 
 <pre><code>$ git cherry-pick http://github.com/mislav/REPO/commit/SHA
-&gt; git remote add -f mislav git://github.com/mislav/REPO.git
+&gt; git remote add -f --no-tags mislav git://github.com/mislav/REPO.git
 &gt; git cherry-pick SHA
 
 $ git cherry-pick mislav@SHA
-&gt; git remote add -f mislav git://github.com/mislav/CURRENT_REPO.git
+&gt; git remote add -f --no-tags mislav git://github.com/mislav/CURRENT_REPO.git
 &gt; git cherry-pick SHA
 
 $ git cherry-pick mislav@SHA
@@ -349,7 +349,7 @@ $ git pull-request -m "Implemented feature X" -b defunkt:master -h mislav:featur
 <h3 id="git-checkout">git checkout</h3>
 
 <pre><code>$ git checkout https://github.com/defunkt/hub/pull/73
-&gt; git remote add -f -t feature mislav git://github.com/mislav/hub.git
+&gt; git remote add -f --no-tags -t feature mislav git://github.com/mislav/hub.git
 &gt; git checkout --track -B mislav-feature mislav/feature
 
 $ git checkout https://github.com/defunkt/hub/pull/73 custom-branch-name


### PR DESCRIPTION
This is so the tags from the automatically-added remote (typically someone's fork) don't spill in and mix with the current tags.

Fixes #879