### PR TITLE
Add -e option to pull request

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -43,7 +43,8 @@ var (
 	flagPullRequestAssignee,
 	flagPullRequestFile string
 	flagPullRequestBrowse,
-	flagPullRequestForce bool
+	flagPullRequestForce,
+	flagPullRequestEdit bool
 )
 
 func init() {
@@ -55,6 +56,7 @@ func init() {
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestForce, "force", "f", false, "FORCE")
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestFile, "file", "F", "", "FILE")
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestAssignee, "assign", "a", "", "USER")
+	cmdPullRequest.Flag.BoolVarP(&flagPullRequestEdit, "edit", "e", false, "EDIT")
 
 	CmdRunner.Use(cmdPullRequest)
 }
@@ -180,6 +182,14 @@ func pullRequest(cmd *Command, args *Args) {
 		utils.Check(err)
 
 		editor, err = github.NewEditor("PULLREQ", "pull request", message)
+		utils.Check(err)
+
+		title, body, err = editor.EditTitleAndBody()
+		utils.Check(err)
+	}
+
+	if flagPullRequestFile != "" && flagPullRequestEdit {
+		editor, err = github.NewEditor("PULLREQ", "pull request", title + "\n\n" + body)
 		utils.Check(err)
 
 		title, body, err = editor.EditTitleAndBody()

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -279,6 +279,35 @@ Feature: hub pull-request
     Then the output should contain exactly "https://github.com/mislav/coral/pull/12\n"
     And the file ".git/PULLREQ_EDITMSG" should not exist
 
+  Scenario: Edit title and body from file
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :title => 'Edit title from file',
+               :body  => "Edit body from file as well.\n\nMultiline, even!"
+        json :html_url => "https://github.com/mislav/coral/pull/12"
+      }
+      """
+    And a file named "pullreq-msg" with:
+      """
+      Title from file
+
+      Body from file as well.
+
+      Multiline, even!
+      """
+    When I run `hub pull-request -F pullreq-msg --edit` interactively
+    And I pass in:
+      """
+      Edit title from file
+
+      Edit body from file as well.
+
+      Multiline, even!
+      """
+    Then the exit status should be 0
+    And the file ".git/PULLREQ_EDITMSG" should not exist
+
   Scenario: Title and body from stdin
     Given the GitHub API server:
       """


### PR DESCRIPTION
Hi. ```-e``` option improves pull-request with template.

For example 
run ```pull-request -F template_file -e``` then open editor and configure a template file. :tada: 


related issue: https://github.com/github/hub/issues/446