### PR TITLE
Fix password insertion more than 15 characters on Windows

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -26,7 +26,7 @@
 		},
 		{
 			"ImportPath": "github.com/howeyc/gopass",
-			"Rev": "62ab5a80502a82291f265e6980d72310b8f480d5"
+			"Rev": "2c70fa70727c953c51695f800f25d6b44abb368e"
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/go-update",

--- a/Godeps/_workspace/src/github.com/howeyc/gopass/pass.go
+++ b/Godeps/_workspace/src/github.com/howeyc/gopass/pass.go
@@ -22,7 +22,7 @@ func getPasswd(masked bool) []byte {
 			}
 		} else if v == 13 || v == 10 {
 			break
-		} else {
+		} else if v != 0 {
 			pass = append(pass, v)
 			os.Stdout.Write(mask)
 		}

--- a/Godeps/_workspace/src/github.com/howeyc/gopass/win.go
+++ b/Godeps/_workspace/src/github.com/howeyc/gopass/win.go
@@ -29,12 +29,7 @@ func getch() byte {
 	var n uint16
 	procReadConsole.Call(uintptr(syscall.Stdin), uintptr(unsafe.Pointer(pLine)), uintptr(len(line)), uintptr(unsafe.Pointer(&n)))
 
-	// For some reason n returned seems to big by 2 (Null terminated maybe?)
-	if n > 2 {
-		n -= 2
-	}
-
-	b := []byte(string(utf16.Decode(line[:n])))
+	b := []byte(string(utf16.Decode(line)))
 
 	procSetConsoleMode.Call(uintptr(syscall.Stdin), uintptr(mode))
 


### PR DESCRIPTION
Bumping to the latest gopass. This fixes https://github.com/github/hub/issues/837.