### PR TITLE
Add support for the `--literal-pathspecs` flag

### DIFF
--- a/commands/args.go
+++ b/commands/args.go
@@ -201,6 +201,9 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string, noop *bool) {
 		noReplaceObjects bool
 		bare             bool
 		literalPathspecs bool
+		globPathspecs    bool
+		noglobPathspecs  bool
+		icasePathspecs   bool
 		version          bool
 		help             bool
 
@@ -216,6 +219,9 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string, noop *bool) {
 	globalFlagSet.BoolVarP(&noReplaceObjects, "no-replace-objects", "", false, "")
 	globalFlagSet.BoolVarP(&bare, "bare", "", false, "")
 	globalFlagSet.BoolVarP(&literalPathspecs, "literal-pathspecs", "", false, "")
+	globalFlagSet.BoolVarP(&globPathspecs, "glob-pathspecs", "", false, "")
+	globalFlagSet.BoolVarP(&noglobPathspecs, "noglob-pathspecs", "", false, "")
+	globalFlagSet.BoolVarP(&icasePathspecs, "icase-pathspecs", "", false, "")
 	globalFlagSet.BoolVarP(&version, "version", "", false, "")
 	globalFlagSet.BoolVarP(&help, "help", "", false, "")
 
@@ -266,6 +272,18 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string, noop *bool) {
 
 	if literalPathspecs {
 		*globalFlags = append(*globalFlags, "--literal-pathspecs")
+	}
+
+	if globPathspecs {
+		*globalFlags = append(*globalFlags, "--glob-pathspecs")
+	}
+
+	if noglobPathspecs {
+		*globalFlags = append(*globalFlags, "--noglob-pathspecs")
+	}
+
+	if icasePathspecs {
+		*globalFlags = append(*globalFlags, "--icase-pathspecs")
 	}
 
 	if execPath != "" {

--- a/commands/args.go
+++ b/commands/args.go
@@ -200,6 +200,7 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string, noop *bool) {
 		noPaginate       bool
 		noReplaceObjects bool
 		bare             bool
+		literalPathspecs bool
 		version          bool
 		help             bool
 
@@ -214,6 +215,7 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string, noop *bool) {
 	globalFlagSet.BoolVarP(&noPaginate, "no-pager", "", false, "")
 	globalFlagSet.BoolVarP(&noReplaceObjects, "no-replace-objects", "", false, "")
 	globalFlagSet.BoolVarP(&bare, "bare", "", false, "")
+	globalFlagSet.BoolVarP(&literalPathspecs, "literal-pathspecs", "", false, "")
 	globalFlagSet.BoolVarP(&version, "version", "", false, "")
 	globalFlagSet.BoolVarP(&help, "help", "", false, "")
 
@@ -260,6 +262,10 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string, noop *bool) {
 
 	if bare {
 		*globalFlags = append(*globalFlags, "--bare")
+	}
+
+	if literalPathspecs {
+		*globalFlags = append(*globalFlags, "--literal-pathspecs")
 	}
 
 	if execPath != "" {


### PR DESCRIPTION
Extend support for other global flags as introduced in 2699a6b718ce8af11cb4f4dc7d069cf09891ff71. `--literal-pathspecs` is fairly rare, but /is/ used by the Emacs porcelain Magit. Without this patch, `hub` falls back to the `git` executable when called via Magit, preventing the use of extended commands like `pull-request` in that context.