### PR TITLE
Avoid depending on a hardcoded list of git global flags

### DIFF
--- a/commands/args.go
+++ b/commands/args.go
@@ -169,7 +169,7 @@ func NewArgs(args []string) *Args {
 	)
 
 	slurpGlobalFlags(&args, &globalFlags)
-	noop = removeValue(&globalFlags, "--noop")
+	noop = removeValue(&globalFlags, noopFlag)
 
 	if len(args) == 0 {
 		params = []string{}
@@ -190,6 +190,7 @@ func NewArgs(args []string) *Args {
 }
 
 const (
+	noopFlag    = "--noop"
 	versionFlag = "--version"
 	helpFlag    = "--help"
 	configFlag  = "-c"
@@ -238,14 +239,13 @@ func removeItem(slice []string, index int) (newSlice []string, item string) {
 }
 
 func removeValue(slice *[]string, value string) (found bool) {
-	var newSlice []string
-	for _, item := range *slice {
-		if item == value {
+	aa := *slice
+	for i := len(aa) - 1; i >= 0; i-- {
+		arg := aa[i]
+		if arg == value {
 			found = true
-		} else {
-			newSlice = append(newSlice, item)
+			*slice, _ = removeItem(*slice, i)
 		}
 	}
-	*slice = newSlice
 	return found
 }

--- a/commands/args.go
+++ b/commands/args.go
@@ -168,7 +168,8 @@ func NewArgs(args []string) *Args {
 		globalFlags []string
 	)
 
-	slurpGlobalFlags(&args, &globalFlags, &noop)
+	slurpGlobalFlags(&args, &globalFlags)
+	noop = removeValue(&globalFlags, "--noop")
 
 	if len(args) == 0 {
 		params = []string{}
@@ -188,7 +189,7 @@ func NewArgs(args []string) *Args {
 	}
 }
 
-func slurpGlobalFlags(args *[]string, globalFlags *[]string, noop *bool) {
+func slurpGlobalFlags(args *[]string, globalFlags *[]string) {
 	slurpNextValue := false
 	commandIndex := 0
 
@@ -208,15 +209,8 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string, noop *bool) {
 
 	if commandIndex > 0 {
 		aa := *args
+		*globalFlags = aa[0:commandIndex]
 		*args = aa[commandIndex:]
-
-		for _, arg := range aa[0:commandIndex] {
-			if arg == "--noop" {
-				*noop = true
-			} else {
-				*globalFlags = append(*globalFlags, arg)
-			}
-		}
 	}
 }
 
@@ -229,4 +223,17 @@ func removeItem(slice []string, index int) (newSlice []string, item string) {
 	newSlice = append(slice[:index], slice[index+1:]...)
 
 	return newSlice, item
+}
+
+func removeValue(slice *[]string, value string) (found bool) {
+	var newSlice []string
+	for _, item := range *slice {
+		if item == value {
+			found = true
+		} else {
+			newSlice = append(newSlice, item)
+		}
+	}
+	*slice = newSlice
+	return found
 }

--- a/commands/args.go
+++ b/commands/args.go
@@ -189,6 +189,13 @@ func NewArgs(args []string) *Args {
 	}
 }
 
+const (
+	versionFlag = "--version"
+	helpFlag    = "--help"
+	configFlag  = "-c"
+	chdirFlag   = "-C"
+)
+
 func slurpGlobalFlags(args *[]string, globalFlags *[]string) {
 	slurpNextValue := false
 	commandIndex := 0
@@ -197,11 +204,11 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string) {
 		if slurpNextValue {
 			commandIndex = i + 1
 			slurpNextValue = false
-		} else if arg == "--version" || arg == "--help" || !strings.HasPrefix(arg, "-") {
+		} else if arg == versionFlag || arg == helpFlag || !strings.HasPrefix(arg, "-") {
 			break
 		} else {
 			commandIndex = i + 1
-			if arg == "-c" || arg == "-C" {
+			if arg == configFlag || arg == chdirFlag {
 				slurpNextValue = true
 			}
 		}

--- a/commands/args.go
+++ b/commands/args.go
@@ -21,7 +21,7 @@ type Args struct {
 func (a *Args) Words() []string {
 	aa := make([]string, 0)
 	for _, p := range a.Params {
-		if !strings.HasPrefix(p, "-") {
+		if !looksLikeFlag(p) {
 			aa = append(aa, p)
 		}
 	}
@@ -194,7 +194,12 @@ const (
 	helpFlag    = "--help"
 	configFlag  = "-c"
 	chdirFlag   = "-C"
+	flagPrefix  = "-"
 )
+
+func looksLikeFlag(value string) bool {
+	return strings.HasPrefix(value, flagPrefix)
+}
 
 func slurpGlobalFlags(args *[]string, globalFlags *[]string) {
 	slurpNextValue := false
@@ -204,7 +209,7 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string) {
 		if slurpNextValue {
 			commandIndex = i + 1
 			slurpNextValue = false
-		} else if arg == versionFlag || arg == helpFlag || !strings.HasPrefix(arg, "-") {
+		} else if arg == versionFlag || arg == helpFlag || !looksLikeFlag(arg) {
 			break
 		} else {
 			commandIndex = i + 1

--- a/commands/args_test.go
+++ b/commands/args_test.go
@@ -89,3 +89,11 @@ func TestArgs_GlobalFlags_Noop(t *testing.T) {
 	assert.Equal(t, []string{"-s", "-b"}, args.Params)
 	assert.Equal(t, true, args.Noop)
 }
+
+func TestArgs_GlobalFlags_Repeated(t *testing.T) {
+	args := NewArgs([]string{"-C", "mydir", "-c", "a=b", "--bare", "-c", "c=d", "-c", "e=f", "status"})
+	assert.Equal(t, "status", args.Command)
+	assert.Equal(t, []string{"-C", "mydir", "-c", "a=b", "--bare", "-c", "c=d", "-c", "e=f"}, args.GlobalFlags)
+	assert.Equal(t, 0, len(args.Params))
+	assert.Equal(t, false, args.Noop)
+}

--- a/commands/args_test.go
+++ b/commands/args_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
@@ -20,34 +19,22 @@ func TestNewArgs(t *testing.T) {
 	assert.Equal(t, "command", args.Command)
 	assert.Equal(t, 1, args.ParamsSize())
 
-	args = NewArgs([]string{"--noop", "command", "args"})
-	assert.Equal(t, "command", args.Command)
-	assert.Equal(t, 1, args.ParamsSize())
-	assert.T(t, args.Noop)
-
 	args = NewArgs([]string{"--version"})
-	assert.Equal(t, "version", args.Command)
+	assert.Equal(t, "--version", args.Command)
 	assert.Equal(t, 0, args.ParamsSize())
 
 	args = NewArgs([]string{"--help"})
-	assert.Equal(t, "help", args.Command)
+	assert.Equal(t, "--help", args.Command)
 	assert.Equal(t, 0, args.ParamsSize())
-
-	args = NewArgs([]string{"--noop", "--version"})
-	assert.T(t, args.Noop)
-	assert.Equal(t, "version", args.Command)
-
-	args = NewArgs([]string{"-c", "foo=bar", "--git-dir=path", "--bare"})
-	assert.Equal(t, 5, len(args.GlobalFlags))
-	assert.Equal(t, "-c foo=bar --bare --git-dir path", strings.Join(args.GlobalFlags, " "))
 }
 
 func TestArgs_Words(t *testing.T) {
-	args := NewArgs([]string{"--no-ff", "master"})
+	args := NewArgs([]string{"merge", "--no-ff", "master", "-m", "message"})
 	a := args.Words()
 
-	assert.Equal(t, 1, len(a))
+	assert.Equal(t, 2, len(a))
 	assert.Equal(t, "master", a[0])
+	assert.Equal(t, "message", a[1])
 }
 
 func TestArgs_Insert(t *testing.T) {
@@ -85,4 +72,20 @@ func TestArgs_Remove(t *testing.T) {
 	assert.Equal(t, 2, args.ParamsSize())
 	assert.Equal(t, "2", args.FirstParam())
 	assert.Equal(t, "4", args.GetParam(1))
+}
+
+func TestArgs_GlobalFlags(t *testing.T) {
+	args := NewArgs([]string{"-c", "key=value", "status", "-s", "-b"})
+	assert.Equal(t, "status", args.Command)
+	assert.Equal(t, []string{"-c", "key=value"}, args.GlobalFlags)
+	assert.Equal(t, []string{"-s", "-b"}, args.Params)
+	assert.Equal(t, false, args.Noop)
+}
+
+func TestArgs_GlobalFlags_Noop(t *testing.T) {
+	args := NewArgs([]string{"-c", "key=value", "--noop", "--literal-pathspecs", "status", "-s", "-b"})
+	assert.Equal(t, "status", args.Command)
+	assert.Equal(t, []string{"-c", "key=value", "--literal-pathspecs"}, args.GlobalFlags)
+	assert.Equal(t, []string{"-s", "-b"}, args.Params)
+	assert.Equal(t, true, args.Noop)
 }

--- a/commands/args_test.go
+++ b/commands/args_test.go
@@ -90,6 +90,14 @@ func TestArgs_GlobalFlags_Noop(t *testing.T) {
 	assert.Equal(t, true, args.Noop)
 }
 
+func TestArgs_GlobalFlags_NoopTwice(t *testing.T) {
+	args := NewArgs([]string{"--noop", "--bare", "--noop", "status"})
+	assert.Equal(t, "status", args.Command)
+	assert.Equal(t, []string{"--bare"}, args.GlobalFlags)
+	assert.Equal(t, 0, len(args.Params))
+	assert.Equal(t, true, args.Noop)
+}
+
 func TestArgs_GlobalFlags_Repeated(t *testing.T) {
 	args := NewArgs([]string{"-C", "mydir", "-c", "a=b", "--bare", "-c", "c=d", "-c", "e=f", "status"})
 	assert.Equal(t, "status", args.Command)

--- a/commands/help.go
+++ b/commands/help.go
@@ -17,7 +17,7 @@ var cmdHelp = &Command{
 func init() {
 	cmdHelp.Run = runHelp
 
-	CmdRunner.Use(cmdHelp)
+	CmdRunner.Use(cmdHelp, "--help")
 }
 
 func runHelp(cmd *Command, args *Args) {

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -54,8 +54,11 @@ func (r *Runner) All() map[string]*Command {
 	return r.commands
 }
 
-func (r *Runner) Use(command *Command) {
+func (r *Runner) Use(command *Command, aliases ...string) {
 	r.commands[command.Name()] = command
+	if len(aliases) > 0 {
+		r.commands[aliases[0]] = command
+	}
 }
 
 func (r *Runner) Lookup(name string) *Command {

--- a/commands/version.go
+++ b/commands/version.go
@@ -19,7 +19,7 @@ var cmdVersion = &Command{
 }
 
 func init() {
-	CmdRunner.Use(cmdVersion)
+	CmdRunner.Use(cmdVersion, "--version")
 }
 
 func runVersion(cmd *Command, args *Args) {


### PR DESCRIPTION
Now, every argument except `--help` and `--version` that starts with a `-` is considered to be a global flag. In the long run, this ensures that hub deals with global flags that git might add in the future.

Alternative to https://github.com/github/hub/pull/942

/cc @whilp