### PR TITLE
config: if GITHUB_TOKEN is set, do not attempt to create one

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,9 @@ the API and exchange it for an OAuth token, which it saves in "~/.config/hub".
 To avoid being prompted, use **GITHUB_USER** and **GITHUB_PASSWORD** environment
 variables.
 
+Alternatively, you may provide **GITHUB_TOKEN**, an access token with
+**repo** permissions. This will not be written to `~/.config/hub`.
+
 ### HTTPS instead of git protocol
 
 If you prefer the HTTPS protocol for GitHub repositories, you can set

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -117,6 +117,25 @@ Feature: OAuth authentication
     Then the output should not contain "github.com password for mislav"
     And the file "../home/.config/hub" should contain "oauth_token: OTOKEN"
 
+  Scenario: Credentials from GITHUB_TOKEN
+    Given the GitHub API server:
+      """
+      get('/user') {
+        halt 401 unless request.env["HTTP_AUTHORIZATION"] == "token OTOKEN"
+        json :login => 'mislav'
+      }
+      post('/user/repos') {
+        halt 401 unless request.env["HTTP_AUTHORIZATION"] == "token OTOKEN"
+        p request.env
+        json :full_name => 'mislav/dotfiles'
+      }
+      """
+    Given $GITHUB_TOKEN is "OTOKEN"
+    When I successfully run `hub create`
+    Then the output should not contain "github.com password"
+    And the output should not contain "github.com username"
+    And the file "../home/.config/hub" should not exist
+
   Scenario: Wrong password
     Given the GitHub API server:
       """

--- a/features/clone.feature
+++ b/features/clone.feature
@@ -113,6 +113,24 @@ Feature: hub clone
     Then it should clone "git@github.com:mislav/dotfiles.git"
     And there should be no output
 
+  Scenario: Clone my repo with GITHUB_TOKEN env var
+    Given the GitHub API server:
+      """
+      get('/user') {
+        halt 401 unless request.env["HTTP_AUTHORIZATION"] == "token OTOKEN"
+        json :login => 'mislav2'
+      }
+      get('/repos/mislav2/dotfiles') {
+        halt 401 unless request.env["HTTP_AUTHORIZATION"] == "token OTOKEN"
+        json :private => false,
+             :permissions => { :push => true }
+      }
+      """
+    And $GITHUB_TOKEN is "OTOKEN"
+    When I successfully run `hub clone dotfiles`
+    Then it should clone "git@github.com:mislav2/dotfiles.git"
+    And there should be no output
+
   Scenario: Clone my repo with arguments
     Given the GitHub API server:
       """


### PR DESCRIPTION
Fixes #463 and #948.

I looked for tests, but couldn't find any for config.

/cc @jingweno @mislav 