### PR TITLE
Add installation instructions for zsh tab-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ eval "$(hub alias -s)"
 hub repository contains tab-completion scripts for bash and zsh. These scripts
 complement existing completion scripts that ship with git.
 
+[Installation instructions](etc)
+
 * [hub bash completion](https://github.com/github/hub/blob/master/etc/hub.bash_completion.sh)
 * [hub zsh completion](https://github.com/github/hub/blob/master/etc/hub.zsh_completion)
-
 
 Commands
 --------

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,22 @@
+# Installation instructions
+
+## zsh
+
+Create a new folder for completions:
+
+```sh
+mkdir -p ~/.zsh/completions
+```
+
+Download the file hub.zsh_completion and rename it to `_hub`:
+
+```sh
+curl https://github.com/github/hub/blob/master/etc/hub.zsh_completion >  ~/.zsh/completions/_hub
+```
+
+Then add the following lines to your .zshrc file:
+
+```sh
+fpath=(~/.zsh/completions $fpath) 
+autoload -U compinit && compinit
+```

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,5 +1,28 @@
 # Installation instructions
 
+## bash
+
+Open your `.bashrc` file and add:
+
+> If you want to set up Git to automatically have Bash shell completion for all users, copy the `hub.bash_completion` script to the `/opt/local/etc/bash_completion.d` directory on Mac systems or to the `/etc/bash_completion.d/` directory on Linux systems. ([Source](https://git-scm.com/book/en/v1/Git-Basics-Tips-and-Tricks#Auto-Completion))
+
+* [Link to git auto-completion bash file](https://github.com/git/git/blob/master/contrib/completion/git-completion.bash)
+
+```sh
+# Make sure you've aliased hub to git
+eval "$(hub alias -s)"
+
+# And make sure that the git auto-completion is being loaded
+if [ -f /path/to/git-completion.bash ]; then
+    . /path/to/git-completion.bash
+fi
+
+# Load hub autocompletion
+if [ -f /path/to/hub.bash_completion ]; then
+    . /path/to/hub.bash_completion
+fi
+```
+
 ## zsh
 
 Create a new folder for completions:
@@ -8,13 +31,14 @@ Create a new folder for completions:
 mkdir -p ~/.zsh/completions
 ```
 
-Download the file hub.zsh_completion and rename it to `_hub`:
+Copy the file `/etc/hub.zsh_completion` from the location where you downloaded `hub` to the folder `~/.zsh/completions/` and rename it to `_hub`:
 
 ```sh
-curl https://github.com/github/hub/blob/master/etc/hub.zsh_completion >  ~/.zsh/completions/_hub
+cp /path/to/etc/hub.zsh_completion ~/.zsh/completions/ \
+    mv ~/.zsh/completions/hub.zsh_completion ~/.zsh/completions/_hub
 ```
 
-Then add the following lines to your .zshrc file:
+Then add the following lines to your `.zshrc` file:
 
 ```sh
 fpath=(~/.zsh/completions $fpath) 

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,23 +1,14 @@
 # Installation instructions
 
+## bash + Homebrew
+
+If you're using Homebrew, just run `brew install hub` and you should be all set with auto-completion.
+
 ## bash
 
-Open your `.bashrc` file and add:
-
-> If you want to set up Git to automatically have Bash shell completion for all users, copy the `hub.bash_completion` script to the `/opt/local/etc/bash_completion.d` directory on Mac systems or to the `/etc/bash_completion.d/` directory on Linux systems. ([Source](https://git-scm.com/book/en/v1/Git-Basics-Tips-and-Tricks#Auto-Completion))
-
-* [Link to git auto-completion bash file](https://github.com/git/git/blob/master/contrib/completion/git-completion.bash)
+Open your `.bashrc` file if you're on Linux, or your `.bash_profile` if you're on OS X and add:
 
 ```sh
-# Make sure you've aliased hub to git
-eval "$(hub alias -s)"
-
-# And make sure that the git auto-completion is being loaded
-if [ -f /path/to/git-completion.bash ]; then
-    . /path/to/git-completion.bash
-fi
-
-# Load hub autocompletion
 if [ -f /path/to/hub.bash_completion ]; then
     . /path/to/hub.bash_completion
 fi


### PR DESCRIPTION
Added a README to the folder `etc` containing instructions on how to use the `hub.zsh_completion` file.