### PR TITLE
client.Releases() fetches all pages.

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -257,10 +257,21 @@ func (client *Client) Releases(project *Project) (releases []octokit.Release, er
 		return
 	}
 
-	releases, result := api.Releases(client.requestURL(url)).All()
-	if result.HasError() {
-		err = FormatError("getting release", result.Err)
-		return
+	for url != nil {
+		page, result := api.Releases(client.requestURL(url)).All()
+		if result.HasError() {
+			err = FormatError("getting release", result.Err)
+			return
+		}
+		releases = append(releases, page...)
+		if result.NextPage == nil {
+			url = nil
+		} else {
+			url, err = result.NextPage.Expand(nil)
+			if err != nil {
+				return
+			}
+		}
 	}
 
 	return


### PR DESCRIPTION
Currently `hub release` only shows the first page of results from the [GitHub Releases API][api]. It doesn't indicate that results have been truncated, and doesn't provide a way to fetch more/all results.

With this patch, `client.Releases()` (and thus `hub release`) follows the `rel="next"` URL from [GitHub's Link header][link] until all results have been fetched.

---

Some design changes could be made around this — e.g. providing pagination/limit controls to the user, or streaming the results rather than fetching them all up front. However compared to truncation of results, I think this change is an improvement worth merging prior to considering further changes.

[api]: https://developer.github.com/v3/repos/releases/
[link]: https://developer.github.com/v3/#link-header