### PR TITLE
Allow to set pull request milestone and labels.

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -41,9 +41,11 @@ var (
 	flagPullRequestIssue,
 	flagPullRequestMessage,
 	flagPullRequestAssignee,
+	flagPullRequestLabels,
 	flagPullRequestFile string
 	flagPullRequestBrowse,
 	flagPullRequestForce bool
+	flagPullRequestMilestone uint64
 )
 
 func init() {
@@ -55,6 +57,8 @@ func init() {
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestForce, "force", "f", false, "FORCE")
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestFile, "file", "F", "", "FILE")
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestAssignee, "assign", "a", "", "USER")
+	cmdPullRequest.Flag.Uint64VarP(&flagPullRequestMilestone, "milestone", "M", 0, "MILESTONE")
+	cmdPullRequest.Flag.StringVarP(&flagPullRequestLabels, "labels", "l", "", "LABELS")
 
 	CmdRunner.Use(cmdPullRequest)
 }
@@ -215,8 +219,16 @@ func pullRequest(cmd *Command, args *Args) {
 
 		pullRequestURL = pr.HTMLURL
 
-		if flagPullRequestAssignee != "" {
-			err = client.UpdateIssueAssignee(baseProject, pr.Number, flagPullRequestAssignee)
+		if flagPullRequestAssignee != "" || flagPullRequestMilestone > 0 ||
+			flagPullRequestLabels != "" {
+
+			params := octokit.IssueParams{
+				Assignee:  flagPullRequestAssignee,
+				Milestone: flagPullRequestMilestone,
+				Labels:    strings.Split(flagPullRequestLabels, ","),
+			}
+
+			err = client.UpdateIssue(baseProject, pr.Number, params)
 			utils.Check(err)
 		}
 	}

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -13,7 +13,7 @@ import (
 
 var cmdPullRequest = &Command{
 	Run:   pullRequest,
-	Usage: "pull-request [-f] [-m <MESSAGE>|-F <FILE>|-i <ISSUE>|<ISSUE-URL>] [-o] [-b <BASE>] [-h <HEAD>] [-a <USER>]",
+	Usage: "pull-request [-f] [-m <MESSAGE>|-F <FILE>|-i <ISSUE>|<ISSUE-URL>] [-o] [-b <BASE>] [-h <HEAD>] [-a <USER>] [-M <MILESTONE>] [-l <LABELS>]",
 	Short: "Open a pull request on GitHub",
 	Long: `Opens a pull request on GitHub for the project that the "origin" remote
 points to. The default head of the pull request is the current branch.
@@ -31,7 +31,8 @@ If instead of normal <TITLE> an issue number is given with "-i", the pull
 request will be attached to an existing GitHub issue. Alternatively, instead
 of title you can paste a full URL to an issue on GitHub.
 
-You can assign the new pull request to a user with "-a <USER>".
+You can assign the new pull request to a user with "-a <USER>",
+add it to a milestone with "-M <MILESTONE>" and apply labels with "-l <LABELS>".
 `,
 }
 

--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -225,13 +225,13 @@ EOF
     fi
   }
 
-  # hub pull-request [-f] [-m <MESSAGE>|-F <FILE>|-i <ISSUE>|<ISSUE-URL>] [-b <BASE>] [-h <HEAD>]
+  # hub pull-request [-f] [-m <MESSAGE>|-F <FILE>|-i <ISSUE>|<ISSUE-URL>] [-b <BASE>] [-h <HEAD>] [-a <USER>] [-M <MILESTONE>] [-l <LABELS>]
   _git_pull_request() {
-    local i c=2 flags="-f -m -F -i -b -h"
+    local i c=2 flags="-f -m -F -i -b -h -a -M -l"
     while [ $c -lt $cword ]; do
       i="${words[c]}"
       case "$i" in
-        -m|-F|-i|-b|-h)
+        -m|-F|-i|-b|-h|-a|-M|-l)
           ((c++))
           flags=${flags/$i/}
           ;;
@@ -245,7 +245,7 @@ EOF
       -i)
         COMPREPLY=()
         ;;
-      -b|-h)
+      -b|-h|-a|-M|-l)
         # (Doesn't seem to need this...)
         # Uncomment the following line when 'owner/repo:[TAB]' misbehaved
         #_get_comp_words_by_ref -n : cur

--- a/etc/hub.zsh_completion
+++ b/etc/hub.zsh_completion
@@ -58,6 +58,9 @@ __hub_setup_zsh_fns () {
       - set1 \
         '-m[message]' \
         '-F[file]' \
+        '-a[user]' \
+        '-M[milestone]' \
+        '-l[labels]' \
       - set2 \
         '-i[issue]:issue number:' \
       - set3 \

--- a/features/bash_completion.feature
+++ b/features/bash_completion.feature
@@ -18,12 +18,12 @@ Feature: bash tab-completion
   Scenario: Offers pull-request flags
     When I type "git pull-request -" and press <Tab>
     When I press <Tab> again
-    Then the completion menu should offer "-F -b -f -h -i -m" unsorted
+    Then the completion menu should offer "-F -b -f -h -i -m -a -M -l" unsorted
 
   Scenario: Doesn't offer already used pull-request flags
     When I type "git pull-request -F myfile -h mybranch -" and press <Tab>
     When I press <Tab> again
-    Then the completion menu should offer "-b -f -i -m" unsorted
+    Then the completion menu should offer "-b -f -i -m -a -M -l" unsorted
 
   Scenario: Browse to issues
     When I type "git browse -- i" and press <Tab>

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -611,3 +611,35 @@ Feature: hub pull-request
       """
     When I successfully run `hub pull-request -m hereyougo -a mislav`
     Then the output should contain exactly "the://url\n"
+
+  Scenario: Pull request with milestone
+    Given I am on the "feature" branch with upstream "origin/feature"
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :head  => "mislav:feature"
+        json :html_url => "the://url", :number => 1234
+      }
+      patch('/repos/mislav/coral/issues/1234') {
+        assert :milestone => 1234
+        json :html_url => "the://url"
+      }
+      """
+    When I successfully run `hub pull-request -m hereyougo -M 1234`
+    Then the output should contain exactly "the://url\n"
+
+  Scenario: Pull request with labels
+    Given I am on the "feature" branch with upstream "origin/feature"
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :head  => "mislav:feature"
+        json :html_url => "the://url", :number => 1234
+      }
+      patch('/repos/mislav/coral/issues/1234') {
+        assert :labels => ["feature", "release"]
+        json :html_url => "the://url"
+      }
+      """
+    When I successfully run `hub pull-request -m hereyougo -l feature,release`
+    Then the output should contain exactly "the://url\n"

--- a/features/zsh_completion.feature
+++ b/features/zsh_completion.feature
@@ -26,6 +26,9 @@ Feature: zsh tab-completion
       | -F | file                                 |
       | -i | issue                                |
       | -f | force (skip check for local commits) |
+      | -a | user                                 |
+      | -M | milestone                            |
+      | -l | labels                               |
 
   Scenario: Completion of fork arguments
     When I type "git fork -" and press <Tab>

--- a/github/client.go
+++ b/github/client.go
@@ -428,7 +428,7 @@ func (client *Client) CreateIssue(project *Project, title, body string, labels [
 	return
 }
 
-func (client *Client) UpdateIssueAssignee(project *Project, issueNumber int, assignee string) (err error) {
+func (client *Client) UpdateIssue(project *Project, issueNumber int, params octokit.IssueParams) (err error) {
 	url, err := octokit.RepoIssuesURL.Expand(octokit.M{"owner": project.Owner, "repo": project.Name, "number": issueNumber})
 	if err != nil {
 		return
@@ -440,9 +440,6 @@ func (client *Client) UpdateIssueAssignee(project *Project, issueNumber int, ass
 		return
 	}
 
-	params := octokit.IssueParams{
-		Assignee: assignee,
-	}
 	_, result := api.Issues(client.requestURL(url)).Update(params)
 	if result.HasError() {
 		err = FormatError("updating issue", result.Err)

--- a/man/hub.1
+++ b/man/hub.1
@@ -148,7 +148,7 @@ Open a GitHub compare view page in the system\'s default web browser\. \fISTART\
 Forks the original project (referenced by "origin" remote) on GitHub and adds a new remote for it under your username\.
 .
 .TP
-\fBgit pull\-request\fR [\fB\-o\fR|\fB\-\-browse\fR] [\fB\-f\fR] [\fB\-m\fR \fIMESSAGE\fR|\fB\-F\fR \fIFILE\fR|\fB\-i\fR \fIISSUE\fR|\fIISSUE\-URL\fR] [\fB\-b\fR \fIBASE\fR] [\fB\-h\fR \fIHEAD\fR] [\fB\-a\fR \fIUSER\fR]
+\fBgit pull\-request\fR [\fB\-o\fR|\fB\-\-browse\fR] [\fB\-f\fR] [\fB\-m\fR \fIMESSAGE\fR|\fB\-F\fR \fIFILE\fR|\fB\-i\fR \fIISSUE\fR|\fIISSUE\-URL\fR] [\fB\-b\fR \fIBASE\fR] [\fB\-h\fR \fIHEAD\fR] [\fB\-a\fR \fIUSER\fR] [\fB\-M\fR \fIMILESTONE\fR] [\fB\-l\fR \fILABELS\fR]
 Opens a pull request on GitHub for the project that the "origin" remote points to\. The default head of the pull request is the current branch\. Both base and head of the pull request can be explicitly given in one of the following formats: "branch", "owner:branch", "owner/repo:branch"\. This command will abort operation if it detects that the current topic branch has local commits that are not yet pushed to its upstream branch on the remote\. To skip this check, use \fB\-f\fR\.
 .
 .IP

--- a/man/hub.1.html
+++ b/man/hub.1.html
@@ -100,7 +100,7 @@
 <code>git browse</code> [<code>-u</code>] [[<var>USER</var><code>/</code>]<var>REPOSITORY</var>] [SUBPAGE]<br />
 <code>git compare</code> [<code>-u</code>] [<var>USER</var>] [[<var>START</var>...]<var>END</var>]<br />
 <code>git fork</code> [<code>--no-remote</code>]<br />
-<code>git pull-request</code> [<code>-o</code>|<code>--browse</code>] [<code>-f</code>] [<code>-m</code> <var>MESSAGE</var>|<code>-F</code> <var>FILE</var>|<code>-i</code> <var>ISSUE</var>|<var>ISSUE-URL</var>] [<code>-b</code> <var>BASE</var>] [<code>-h</code> <var>HEAD</var>] [<code>-a</code> <var>USER</var>]:<br />
+<code>git pull-request</code> [<code>-o</code>|<code>--browse</code>] [<code>-f</code>] [<code>-m</code> <var>MESSAGE</var>|<code>-F</code> <var>FILE</var>|<code>-i</code> <var>ISSUE</var>|<var>ISSUE-URL</var>] [<code>-b</code> <var>BASE</var>] [<code>-h</code> <var>HEAD</var>] [<code>-a</code> <var>USER</var>] [<code>-M</code> <var>MILESTONE</var>] [<code>-l</code> <var>LABELS</var>]:<br />
 <code>git ci-status</code> [<code>-v</code>] [<var>COMMIT</var>]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>

--- a/man/hub.1.ronn
+++ b/man/hub.1.ronn
@@ -27,7 +27,7 @@ hub(1) -- git + hub = github
 `git browse` [`-u`] [[<USER>`/`]<REPOSITORY>] [SUBPAGE]  
 `git compare` [`-u`] [<USER>] [[<START>...]<END>]  
 `git fork` [`--no-remote`]  
-`git pull-request` [`-o`|`--browse`] [`-f`] [`-m` <MESSAGE>|`-F` <FILE>|`-i` <ISSUE>|<ISSUE-URL>] [`-b` <BASE>] [`-h` <HEAD>] [`-a` <USER>]:  
+`git pull-request` [`-o`|`--browse`] [`-f`] [`-m` <MESSAGE>|`-F` <FILE>|`-i` <ISSUE>|<ISSUE-URL>] [`-b` <BASE>] [`-h` <HEAD>] [`-a` <USER>] [`-M` <MILESTONE>] [`-l` <LABELS>]:
 `git ci-status` [`-v`] [<COMMIT>]
 
 ## DESCRIPTION


### PR DESCRIPTION
Add the `-M/--milestone` and `-l/--labels` flags to `hub pull-request` to
set the milestone or tags when a pull request is created.

Signed-off-by: David Calavera <david.calavera@gmail.com>