### PR TITLE
Handle git worktrees when computing the head repo

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -37,6 +37,17 @@ func Dir() (string, error) {
 }
 
 func HasFile(segments ...string) bool {
+	// The blessed way to resolve paths in git dir, since Git 1.5.0
+	// Needed when working with git worktrees.
+	output, err := gitOutput("rev-parse", "-q", "--git-path", filepath.Join(segments...))
+	if err == nil {
+		_, err := os.Stat(output[0])
+		if err == nil {
+			return true
+		}
+	}
+
+	// Fallback to $(git rev-parse --git-dir)/segment1/segment2 for older git versions
 	dir, err := Dir()
 	if err != nil {
 		return false


### PR DESCRIPTION
Git 1.5.0 introduces support for worktrees. A worktree has a
.git file, rather than a folder. (The file contents points to to a
.git folder buried underneath the .git folder of the main repository.)

A new option has been added to resolve paths within the git dir,
`git rev-parse --git-path foo/bar`.

The commit uses this new facility, but falls back to the old approach
for backwards compability.

Fixes #969