### PR TITLE
Add hub-pr

### DIFF
--- a/commands/pr.go
+++ b/commands/pr.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/github/hub/github"
+	"github.com/github/hub/utils"
+)
+
+var cmdPr = &Command{
+	Run:          pr,
+	GitExtension: true,
+	Usage:        "pr PULLREQ-NUMBER",
+	Short:        "Treat pullrequest number",
+	Long: `
+`,
+}
+
+var lengthParams int
+var prRegex *regexp.Regexp
+
+const NotPr = "--not-pr"
+const prRegexText = "^#?[1-9][0-9]*$"
+
+func init() {
+	CmdRunner.Use(cmdPr)
+}
+
+func pr(command *Command, args *Args) {
+	if !args.IsParamsEmpty() {
+		transformPrArgs(args)
+	}
+}
+
+func transformPrArgs(args *Args) {
+	//Remove firstParam
+	firstParam := args.FirstParam()
+	args.RemoveParam(0)
+	//Attatch a protection to not pullrequest numbers
+	notPr := false
+	idx := 0
+	prRegex = regexp.MustCompile(prRegexText)
+	for idx < args.ParamsSize() {
+		param := args.GetParam(idx)
+		if param == NotPr {
+			notPr = true
+			args.RemoveParam(idx)
+			continue
+		}
+		if notPr && prRegex.MatchString(param) {
+			args.ReplaceParam(idx, NotPr+param)
+		}
+		idx++
+		notPr = false
+	}
+	//Handle args with firstParam
+	if strings.HasPrefix(firstParam, "--") {
+		action := strings.TrimPrefix(firstParam, "--")
+		switch action {
+		case "apply", "am":
+			convertPrToUrl(args)
+			args.Executable = "hub"
+			args.Command = action
+		case "browse":
+			convertPrToUrl(args)
+			args.Executable = "open"
+			args.Command = ""
+		default:
+			utils.Check(fmt.Errorf("Error: command not found"))
+		}
+	} else {
+		utils.Check(fmt.Errorf("Error: command not found"))
+	}
+	//Detach protections
+	notPrRegex := regexp.MustCompile("^--not-pr#?[1-9][0-9]*$")
+	lengthParams = args.ParamsSize()
+	for i := 0; i < lengthParams; i++ {
+		param := args.GetParam(i)
+		if notPrRegex.MatchString(param) {
+			args.ReplaceParam(i, strings.TrimPrefix(param, "--not-pr"))
+		}
+	}
+}
+
+func convertPrToUrl(args *Args) {
+	localRepo, err := github.LocalRepo()
+	utils.Check(err)
+	remote, err := localRepo.OriginRemote()
+	utils.Check(err)
+	project, err := remote.Project()
+	utils.Check(err)
+	lengthParams = args.ParamsSize()
+	prRegex = regexp.MustCompile(prRegexText)
+	for i := 0; i < lengthParams; i++ {
+		param := args.GetParam(i)
+		if prRegex.MatchString(param) {
+			args.ReplaceParam(i, "https://github.com/"+project.Owner+"/"+project.Name+"/pull/"+strings.TrimPrefix(param, "#"))
+		}
+	}
+}

--- a/commands/pr_test.go
+++ b/commands/pr_test.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/github/hub/Godeps/_workspace/src/github.com/bmizerany/assert"
+)
+
+func TestTransformPrArgs(t *testing.T) {
+	var args *Args
+	args = NewArgs([]string{"pr", "--apply", "-3", "33"})
+	transformPrArgs(args)
+	assert.Equal(t, "hub apply -3 https://github.com/github/hub/pull/33", args.ToCmd().String())
+
+	args = NewArgs([]string{"pr", "--am", "-3", "33"})
+	transformPrArgs(args)
+	assert.Equal(t, "hub am -3 https://github.com/github/hub/pull/33", args.ToCmd().String())
+
+	args = NewArgs([]string{"pr", "--apply", "--not-pr", "33", "-3", "#33"})
+	transformPrArgs(args)
+	assert.Equal(t, "hub apply 33 -3 https://github.com/github/hub/pull/33", args.ToCmd().String())
+
+	args = NewArgs([]string{"pr", "--browse", "#33", "-a", "Safari"})
+	transformPrArgs(args)
+	assert.Equal(t, "open https://github.com/github/hub/pull/33 -a Safari", args.ToCmd().String())
+}

--- a/features/pr.feature
+++ b/features/pr.feature
@@ -1,0 +1,20 @@
+Feature: hub pr
+  Background:
+    Given I am in "git://github.com/mislav/dotfiles.git" git repo
+    And I am "mislav" on github.com with OAuth token "OTOKEN"
+
+  Scenario: Apply commits from pull request
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles/pulls/387') {
+        halt 400 unless request.env['HTTP_ACCEPT'] == 'application/vnd.github.v3.patch;charset=utf-8'
+        generate_patch "Create a README"
+      }
+      """
+    When I successfully run `hub pr --am -q -3 387`
+    Then there should be no output
+    Then the latest commit message should be "Create a README"
+
+  Scenario: Browse
+    When I successfully run `hub pr --browse 1`
+    Then "open https://github.com/mislav/dotfiles/pull/1" should be run


### PR DESCRIPTION
`hub pr` is a command handling pull requests with their numbers and `--*` argument.
It has been already implemented that `--apply`, `--am` and `--browse`.
Please see #981 for reference.
And, can I get your opinion?