### PR TITLE
Add user command

### DIFF
--- a/commands/user.go
+++ b/commands/user.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/github/hub/github"
+	"github.com/github/hub/utils"
+)
+
+var cmdUser = &Command{
+	Run:   user,
+	Usage: "user",
+	Short: "Show the default user name",
+	Long: `Show which user name will be used by hub commands.`,
+}
+
+func init() {
+	CmdRunner.Use(cmdUser)
+}
+
+/*
+  $ gh user
+  YOUR_USER
+*/
+func user(cmd *Command, args *Args) {
+    var host *github.Host
+    config := github.CurrentConfig()
+    host, err := config.DefaultHost()
+    if err != nil {
+            utils.Check(github.FormatError("reading config", err))
+    }
+    fmt.Print(host.User + "\n")
+    os.Exit(0)
+}


### PR DESCRIPTION
This new command writes the default user from hub config to stdout with a
trailing newline. For example, if you are me you get:

```sh
$ hub user
sbp
```

This is useful for automating contribution scripts. Say, for example, that you
want to write a script that pushes your contributions to some feature branch.
Using this command, you can do:

```sh
$ hub push `hub user` `git rev-parse --abbrev-ref HEAD`
```

Whereas otherwise you would have to manually fill in the user name, even though
hub knows what user name it would normally use from config.