### PR TITLE
Enhance `hub ci-status` to consume and display combined statuses

### DIFF
--- a/commands/ci_status.go
+++ b/commands/ci_status.go
@@ -99,7 +99,7 @@ func ciStatus(cmd *Command, args *Args) {
 	}
 }
 
-func verboseFormat(statuses []*github.CIStatus) {
+func verboseFormat(statuses []github.CIStatus) {
 	colorize := github.IsTerminal(os.Stdout)
 
 	contextWidth := 0

--- a/commands/ci_status.go
+++ b/commands/ci_status.go
@@ -128,6 +128,10 @@ func verboseFormat(statuses []*github.CIStatus) {
 			stateMarker = fmt.Sprintf("\033[%dm%s\033[0m", color, stateMarker)
 		}
 
-		ui.Printf("%s\t%-*s\t%s\n", stateMarker, contextWidth, status.Context, status.TargetUrl)
+		if status.TargetUrl == "" {
+			ui.Printf("%s\t%s\n", stateMarker, status.Context)
+		} else {
+			ui.Printf("%s\t%-*s\t%s\n", stateMarker, contextWidth, status.Context, status.TargetUrl)
+		}
 	}
 }

--- a/commands/ci_status.go
+++ b/commands/ci_status.go
@@ -18,7 +18,7 @@ var cmdCiStatus = &Command{
 status. Exits with one of:
 success (0), error (1), failure (1), pending (2), no status (3)
 
-If "-v" is given, additionally print the URL to CI build results.
+If "-v" is given, additionally print detailed report of all checks and their URLs.
 `,
 }
 
@@ -33,19 +33,15 @@ func init() {
 /*
   $ gh ci-status
   > (prints CI state of HEAD and exits with appropriate code)
-  > One of: success (0), error (1), failure (1), pending (2), no status (3)
 
   $ gh ci-status -v
-  > (prints CI state of HEAD, the URL to the CI build results and exits with appropriate code)
-  > One of: success (0), error (1), failure (1), pending (2), no status (3)
+  > (prints CI states and URLs to CI build results for HEAD and exits with appropriate code)
 
   $ gh ci-status BRANCH
   > (prints CI state of BRANCH and exits with appropriate code)
-  > One of: success (0), error (1), failure (1), pending (2), no status (3)
 
   $ gh ci-status SHA
   > (prints CI state of SHA and exits with appropriate code)
-  > One of: success (0), error (1), failure (1), pending (2), no status (3)
 */
 func ciStatus(cmd *Command, args *Args) {
 	ref := "HEAD"
@@ -68,42 +64,70 @@ func ciStatus(cmd *Command, args *Args) {
 	if args.Noop {
 		ui.Printf("Would request CI status for %s\n", sha)
 	} else {
-		state, targetURL, exitCode, err := fetchCiStatus(project, sha)
+		gh := github.NewClient(project.Host)
+		response, err := gh.FetchCIStatus(project, sha)
 		utils.Check(err)
-		if flagCiStatusVerbose && targetURL != "" {
-			ui.Printf("%s: %s\n", state, targetURL)
+
+		state := response.State
+		if len(response.Statuses) == 0 {
+			state = ""
+		}
+
+		var exitCode int
+		switch state {
+		case "success":
+			exitCode = 0
+		case "failure", "error":
+			exitCode = 1
+		case "pending":
+			exitCode = 2
+		default:
+			exitCode = 3
+		}
+
+		if flagCiStatusVerbose && len(response.Statuses) > 0 {
+			verboseFormat(response.Statuses)
 		} else {
-			ui.Println(state)
+			if state != "" {
+				ui.Println(state)
+			} else {
+				ui.Println("no status")
+			}
 		}
 
 		os.Exit(exitCode)
 	}
 }
 
-func fetchCiStatus(p *github.Project, sha string) (state, targetURL string, exitCode int, err error) {
-	gh := github.NewClient(p.Host)
-	status, err := gh.CIStatus(p, sha)
-	if err != nil {
-		return
+func verboseFormat(statuses []*github.CIStatus) {
+	colorize := github.IsTerminal(os.Stdout)
+
+	contextWidth := 0
+	for _, status := range statuses {
+		if len(status.Context) > contextWidth {
+			contextWidth = len(status.Context)
+		}
 	}
 
-	if status == nil {
-		state = "no status"
-	} else {
-		state = status.State
-		targetURL = status.TargetURL
-	}
+	for _, status := range statuses {
+		var color int
+		var stateMarker string
+		switch status.State {
+		case "success":
+			stateMarker = "✔︎"
+			color = 32
+		case "failure", "error":
+			stateMarker = "✖︎"
+			color = 31
+		case "pending":
+			stateMarker = "●"
+			color = 33
+		}
 
-	switch state {
-	case "success":
-		exitCode = 0
-	case "failure", "error":
-		exitCode = 1
-	case "pending":
-		exitCode = 2
-	default:
-		exitCode = 3
-	}
+		if colorize {
+			stateMarker = fmt.Sprintf("\033[%dm%s\033[0m", color, stateMarker)
+		}
 
-	return
+		ui.Printf("%s\t%-*s\t%s\n", stateMarker, contextWidth, status.Context, status.TargetUrl)
+	}
 }

--- a/features/ci_status.feature
+++ b/features/ci_status.feature
@@ -32,10 +32,12 @@ Feature: hub ci-status
             :target_url => "https://travis-ci.org/michiels/pencilbox/builds/1234567" },
           { :state => "pending",
             :context => "continuous-integration/travis-ci/merge",
-            :target_url => "https://travis-ci.org/michiels/pencilbox/builds/1234567" },
+            :target_url => nil },
           { :state => "failure",
             :context => "GitHub CLA",
             :target_url => "https://cla.github.com/michiels/pencilbox/accept/mislav" },
+          { :state => "error",
+            :context => "whatevs!" }
         ]
       }
       """
@@ -43,8 +45,9 @@ Feature: hub ci-status
     Then the output should contain exactly:
       """
       ✔︎	continuous-integration/travis-ci/push 	https://travis-ci.org/michiels/pencilbox/builds/1234567
-      ●	continuous-integration/travis-ci/merge	https://travis-ci.org/michiels/pencilbox/builds/1234567
-      ✖︎	GitHub CLA                            	https://cla.github.com/michiels/pencilbox/accept/mislav\n
+      ●	continuous-integration/travis-ci/merge
+      ✖︎	GitHub CLA                            	https://cla.github.com/michiels/pencilbox/accept/mislav
+      ✖︎	whatevs!\n
       """
     And the exit status should be 2
 

--- a/features/ci_status.feature
+++ b/features/ci_status.feature
@@ -15,19 +15,38 @@ Feature: hub ci-status
     Given there is a commit named "the_sha"
     Given the remote commit state of "michiels/pencilbox" "the_sha" is "success"
     When I run `hub ci-status the_sha -v`
-    Then the output should contain "success: https://travis-ci.org/michiels/pencilbox/builds/1234567"
+    Then the output should contain exactly:
+      """
+      ✔︎	continuous-integration/travis-ci/push	https://travis-ci.org/michiels/pencilbox/builds/1234567\n
+      """
     And the exit status should be 0
 
-  Scenario: Multiple statuses, latest is passing
+  Scenario: Multiple statuses with verbose output
     Given there is a commit named "the_sha"
     Given the remote commit states of "michiels/pencilbox" "the_sha" are:
       """
-      [ { :state => 'success' },
-        { :state => 'pending' }  ]
+      { :state => "pending",
+        :statuses => [
+          { :state => "success",
+            :context => "continuous-integration/travis-ci/push",
+            :target_url => "https://travis-ci.org/michiels/pencilbox/builds/1234567" },
+          { :state => "pending",
+            :context => "continuous-integration/travis-ci/merge",
+            :target_url => "https://travis-ci.org/michiels/pencilbox/builds/1234567" },
+          { :state => "failure",
+            :context => "GitHub CLA",
+            :target_url => "https://cla.github.com/michiels/pencilbox/accept/mislav" },
+        ]
+      }
       """
-    When I run `hub ci-status the_sha`
-    Then the output should contain exactly "success\n"
-    And the exit status should be 0
+    When I run `hub ci-status -v the_sha`
+    Then the output should contain exactly:
+      """
+      ✔︎	continuous-integration/travis-ci/push 	https://travis-ci.org/michiels/pencilbox/builds/1234567
+      ●	continuous-integration/travis-ci/merge	https://travis-ci.org/michiels/pencilbox/builds/1234567
+      ✖︎	GitHub CLA                            	https://cla.github.com/michiels/pencilbox/accept/mislav\n
+      """
+    And the exit status should be 2
 
   Scenario: Exit status 1 for 'error' and 'failure'
     Given the remote commit state of "michiels/pencilbox" "HEAD" is "error"

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -202,8 +202,8 @@ Given(/^the remote commit states of "(.*?)" "(.*?)" are:$/) do |proj, ref, json_
   rev = run_silent %(git rev-parse #{ref})
 
   status_endpoint = <<-EOS
-    get('/repos/#{proj}/statuses/#{rev}') {
-      json #{json_value}
+    get('/repos/#{proj}/commits/#{rev}/status') {
+      json(#{json_value})
     }
     EOS
   step %{the GitHub API server:}, status_endpoint
@@ -211,13 +211,19 @@ end
 
 Given(/^the remote commit state of "(.*?)" "(.*?)" is "(.*?)"$/) do |proj, ref, status|
   step %{the remote commit states of "#{proj}" "#{ref}" are:}, <<-EOS
-    [ { :state => \"#{status}\",
-        :target_url => 'https://travis-ci.org/#{proj}/builds/1234567' } ]
-    EOS
+    { :state => "#{status}",
+      :statuses => [
+        { :state => "#{status}",
+          :context => "continuous-integration/travis-ci/push",
+          :target_url => 'https://travis-ci.org/#{proj}/builds/1234567' }
+      ]
+    }
+  EOS
 end
 
 Given(/^the remote commit state of "(.*?)" "(.*?)" is nil$/) do |proj, ref|
-  step %{the remote commit states of "#{proj}" "#{ref}" are:}, "[ ]"
+  step %{the remote commit states of "#{proj}" "#{ref}" are:},
+    %({ :state => "pending", :statuses => [] })
 end
 
 Given(/^the text editor exits with error status$/) do

--- a/github/client.go
+++ b/github/client.go
@@ -336,8 +336,8 @@ func (client *Client) UploadReleaseAsset(uploadUrl *url.URL, asset *os.File, con
 }
 
 type CIStatusResponse struct {
-	State    string      `json:"state"`
-	Statuses []*CIStatus `json:"statuses"`
+	State    string     `json:"state"`
+	Statuses []CIStatus `json:"statuses"`
 }
 
 type CIStatus struct {
@@ -352,7 +352,7 @@ func (client *Client) FetchCIStatus(project *Project, sha string) (status *CISta
 		return
 	}
 
-	res, err := api.Get("repos/" + project.Owner + "/" + project.Name + "/commits/" + sha + "/status")
+	res, err := api.Get(fmt.Sprintf("repos/%s/%s/commits/%s/status", project.Owner, project.Name, sha))
 	if err != nil {
 		return
 	}
@@ -362,7 +362,7 @@ func (client *Client) FetchCIStatus(project *Project, sha string) (status *CISta
 	}
 
 	status = &CIStatusResponse{}
-	err = res.Parse(status)
+	err = res.Unmarshal(status)
 
 	return
 }

--- a/github/client.go
+++ b/github/client.go
@@ -335,27 +335,34 @@ func (client *Client) UploadReleaseAsset(uploadUrl *url.URL, asset *os.File, con
 	return
 }
 
-func (client *Client) CIStatus(project *Project, sha string) (status *octokit.Status, err error) {
-	url, err := octokit.StatusesURL.Expand(octokit.M{"owner": project.Owner, "repo": project.Name, "ref": sha})
+type CIStatusResponse struct {
+	State    string      `json:"state"`
+	Statuses []*CIStatus `json:"statuses"`
+}
+
+type CIStatus struct {
+	State     string `json:"state"`
+	Context   string `json:"context"`
+	TargetUrl string `json:"target_url"`
+}
+
+func (client *Client) FetchCIStatus(project *Project, sha string) (status *CIStatusResponse, err error) {
+	api, err := client.simpleApi()
 	if err != nil {
 		return
 	}
 
-	api, err := client.api()
+	res, err := api.Get("repos/" + project.Owner + "/" + project.Name + "/commits/" + sha + "/status")
 	if err != nil {
-		err = FormatError("getting CI status", err)
+		return
+	}
+	if res.StatusCode != 200 {
+		err = fmt.Errorf("Unexpected HTTP status code: %d", res.StatusCode)
 		return
 	}
 
-	statuses, result := api.Statuses(client.requestURL(url)).All()
-	if result.HasError() {
-		err = FormatError("getting CI status", result.Err)
-		return
-	}
-
-	if len(statuses) > 0 {
-		status = &statuses[0]
-	}
+	status = &CIStatusResponse{}
+	err = res.Parse(status)
 
 	return
 }
@@ -544,19 +551,42 @@ func (client *Client) FindOrCreateToken(user, password, twoFactorCode string) (t
 	return
 }
 
-func (client *Client) api() (c *octokit.Client, err error) {
+func (client *Client) ensureAccessToken() (err error) {
 	if client.Host.AccessToken == "" {
-		host, e := CurrentConfig().PromptForHost(client.Host.Host)
-		if e != nil {
-			err = e
-			return
+		host, err := CurrentConfig().PromptForHost(client.Host.Host)
+		if err == nil {
+			client.Host = host
 		}
-		client.Host = host
+	}
+	return
+}
+
+func (client *Client) api() (c *octokit.Client, err error) {
+	err = client.ensureAccessToken()
+	if err != nil {
+		return
 	}
 
 	tokenAuth := octokit.TokenAuth{AccessToken: client.Host.AccessToken}
 	c = client.newOctokitClient(tokenAuth)
 
+	return
+}
+
+func (client *Client) simpleApi() (c *simpleClient, err error) {
+	err = client.ensureAccessToken()
+	if err != nil {
+		return
+	}
+
+	httpClient := newHttpClient(os.Getenv("HUB_TEST_HOST"), os.Getenv("HUB_VERBOSE") != "")
+	apiRoot := client.absolute(normalizeHost(client.Host.Host))
+
+	c = &simpleClient{
+		httpClient:  httpClient,
+		rootUrl:     apiRoot,
+		accessToken: client.Host.AccessToken,
+	}
 	return
 }
 
@@ -574,15 +604,11 @@ func (client *Client) newOctokitClient(auth octokit.AuthMethod) *octokit.Client 
 	return c
 }
 
-func (client *Client) absolute(endpoint string) *url.URL {
-	u, _ := url.Parse(endpoint)
-	if u.Scheme == "" && client.Host != nil {
+func (client *Client) absolute(host string) *url.URL {
+	u, _ := url.Parse("https://" + host)
+	if client.Host != nil && client.Host.Protocol != "" {
 		u.Scheme = client.Host.Protocol
 	}
-	if u.Scheme == "" {
-		u.Scheme = "https"
-	}
-
 	return u
 }
 

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -18,10 +18,6 @@ func TestClient_newOctokitClient(t *testing.T) {
 	c = NewClient("github.corporate.com")
 	cc = c.newOctokitClient(nil)
 	assert.Equal(t, "https://github.corporate.com", cc.Endpoint.String())
-
-	c = NewClient("http://github.corporate.com")
-	cc = c.newOctokitClient(nil)
-	assert.Equal(t, "http://github.corporate.com", cc.Endpoint.String())
 }
 
 func TestClient_FormatError(t *testing.T) {

--- a/github/config.go
+++ b/github/config.go
@@ -144,7 +144,7 @@ func (c *Config) PromptForPassword(host, user string) (pass string) {
 	}
 
 	ui.Printf("%s password for %s (never stored): ", host, user)
-	if isTerminal(os.Stdout.Fd()) {
+	if IsTerminal(os.Stdout) {
 		pass = string(gopass.GetPasswd())
 	} else {
 		pass = c.scanLine()

--- a/github/http.go
+++ b/github/http.go
@@ -204,7 +204,7 @@ type simpleResponse struct {
 	*http.Response
 }
 
-func (res *simpleResponse) Parse(dest interface{}) (err error) {
+func (res *simpleResponse) Unmarshal(dest interface{}) (err error) {
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)

--- a/github/http.go
+++ b/github/http.go
@@ -65,10 +65,6 @@ func (t *verboseTransport) dumpRequest(req *http.Request) {
 
 func (t *verboseTransport) dumpResponse(resp *http.Response) {
 	info := fmt.Sprintf("< HTTP %d", resp.StatusCode)
-	location, err := resp.Location()
-	if err == nil {
-		info = fmt.Sprintf("%s\n< Location: %s", info, location.String())
-	}
 	t.verbosePrintln(info)
 	t.dumpHeaders(resp.Header, "<")
 	body := t.dumpBody(resp.Body)
@@ -79,7 +75,7 @@ func (t *verboseTransport) dumpResponse(resp *http.Response) {
 }
 
 func (t *verboseTransport) dumpHeaders(header http.Header, indent string) {
-	dumpHeaders := []string{"Authorization", "X-GitHub-OTP", "Localtion"}
+	dumpHeaders := []string{"Authorization", "X-GitHub-OTP", "Location"}
 	for _, h := range dumpHeaders {
 		v := header.Get(h)
 		if v != "" {

--- a/github/util.go
+++ b/github/util.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"os"
+
 	"github.com/github/hub/Godeps/_workspace/src/github.com/mattn/go-isatty"
 	"github.com/github/hub/git"
 )
@@ -19,6 +21,6 @@ func IsHttpsProtocol() bool {
 	return false
 }
 
-func isTerminal(fd uintptr) bool {
-	return isatty.IsTerminal(fd)
+func IsTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd())
 }

--- a/man/hub.1
+++ b/man/hub.1
@@ -171,7 +171,7 @@ Looks up the SHA for \fICOMMIT\fR in GitHub Status API and displays the latest s
 success (0), error (1), failure (1), pending (2), no status (3)
 .
 .IP
-If \fB\-v\fR is given, additionally print the URL to CI build results\.
+If \fB\-v\fR is given, additionally print detailed report of all checks and their URLs\.
 .
 .SH "CONFIGURATION"
 .

--- a/man/hub.1.html
+++ b/man/hub.1.html
@@ -213,7 +213,7 @@ of both hub and GitHub API.</p></dd>
 status. Exits with one of:<br />
 success (0), error (1), failure (1), pending (2), no status (3)</p>
 
-<p>If <code>-v</code> is given, additionally print the URL to CI build results.</p></dd>
+<p>If <code>-v</code> is given, additionally print detailed report of all checks and their URLs.</p></dd>
 </dl>
 
 

--- a/man/hub.1.ronn
+++ b/man/hub.1.ronn
@@ -174,7 +174,7 @@ hub also adds some custom commands that are otherwise not present in git:
     status. Exits with one of:  
     success (0), error (1), failure (1), pending (2), no status (3)
 
-    If `-v` is given, additionally print the URL to CI build results.
+    If `-v` is given, additionally print detailed report of all checks and their URLs.
 
 ## CONFIGURATION
 


### PR DESCRIPTION
Now `ci-status` consumes the new combined statuses API endpoint designed for when multiple contexts report statuses independently.

The verbose output is now colorized and is in format where each line is:

    ✔︎ <Tab> [CONTEXT] <Tab> [URL]

Fixes #943

@jingweno Since Octokit only supported the old API endpoint and I needed access to the new one, here I did an experiment called "simple client" where I bypassed Octokit and used net/http and JSON parsing directly. I wanted to see how much would be involved, because for some future commands I need to do certain things that Octokit doesn't support and I don't have the bandwidth to maintain both libraries right now. What do you think?