### PR TITLE
Fix `compare` crash when used on a non-GitHub repo

### DIFF
--- a/commands/compare.go
+++ b/commands/compare.go
@@ -89,6 +89,11 @@ func compare(command *Command, args *Args) {
 		}
 	}
 
+	if project == nil {
+		project, err = localRepo.CurrentProject()
+		utils.Check(err)
+	}
+
 	subpage := utils.ConcatPaths("compare", rangeQueryEscape(r))
 	url := project.WebURL("", "", subpage)
 	launcher, err := utils.BrowserLauncher()

--- a/features/compare.feature
+++ b/features/compare.feature
@@ -136,3 +136,14 @@ Feature: hub compare
     When I successfully run `hub compare refactor`
     Then there should be no output
     And "open http://git.my.org/mislav/dotfiles/compare/refactor" should be run
+
+  Scenario: Compare in non-GitHub repo
+    Given the "origin" remote has url "git@bitbucket.org:mislav/dotfiles.git"
+    And I am on the "feature" branch
+    When I run `hub compare`
+    Then the stdout should contain exactly ""
+    And the stderr should contain exactly:
+      """
+      Aborted: the origin remote doesn't point to a GitHub repository.\n
+      """
+    And the exit status should be 1


### PR DESCRIPTION
Fixes #1002