### PR TITLE
Add option for creating PR using the web interface

### DIFF
--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -560,6 +560,13 @@ Feature: hub pull-request
     When I successfully run `hub pull-request -m hereyougo`
     Then the output should contain exactly "the://url\n"
 
+  Scenario: Open GH web interface to create the new pull request
+    Given the "origin" remote has url "git://github.com/github/coral.git"
+    And the "doge" remote has url "git://github.com/mislav/coral.git"
+    And I am on the "feature" branch pushed to "doge/feature"
+    When I successfully run `hub pull-request --web`
+    Then "open https://github.com/github/coral/compare/master...mislav:feature?expand=1" should be run
+
   Scenario: Open pull request in web browser
     Given the GitHub API server:
       """


### PR DESCRIPTION
Adds a new flag `-w`/`--web` to the pull-request command. When creating
a new pull-request, you can use the `--web` flag for filling out the
PR's details using GitHub's web interface, instead of using the default editor
for git.

Closes #688.

I wasn't sure about the flag's name. There's already a `--browse` one, so `--browser` was quite a no-no. The `--new` one suggested in the issue's original title seemed ambiguous to me.

Also, I must mention that the contribution process has been quite smooth – way more than I expected. :smile:

Let me know your thoughts, any kind of feedback is welcome!