### PR TITLE
Properly support `-C` git global flag

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -27,10 +27,31 @@ func Dir() (string, error) {
 		return "", fmt.Errorf("Not a git repository (or any of the parent directories): .git")
 	}
 
+	var chdir string
+	for i, flag := range GlobalFlags {
+		if (flag == "-C") {
+			dir := GlobalFlags[i+1]
+			if (filepath.IsAbs(dir)) {
+				chdir = dir
+			} else {
+				chdir = filepath.Join(chdir, dir)
+			}
+		}
+	}
+
 	gitDir := output[0]
-	gitDir, err = filepath.Abs(gitDir)
-	if err != nil {
-		return "", err
+
+	if (!filepath.IsAbs(gitDir)) {
+		if (chdir != "") {
+			gitDir = filepath.Join(chdir, gitDir)
+		}
+
+		gitDir, err = filepath.Abs(gitDir)
+		if err != nil {
+			return "", err
+		}
+
+		gitDir = filepath.Clean(gitDir)
 	}
 
 	return gitDir, nil


### PR DESCRIPTION
From git documentation:

    -C <path> : Run as if git was started in <path> instead of the
                current working directory. When multiple -C options are
                given, each subsequent non-absolute -C <path> is
                interpreted relative to the preceding -C <path>.

We correctly forwarded the `-C <path>` values as git global flags to git invocations such as `git rev-parse --git-dir`, but that command is designed to return the result as a relative path to the value computed from `-C`. This adds an extra step to transform this relative path to an absolute one by applying values of `-C` as the base directory.

Fixes #1020