### PR TITLE
Have `HUB_VERBOSE` also log externally run commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/github/hub/Godeps/_workspace/src/github.com/kballard/go-shellquote"
+	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
@@ -36,6 +37,7 @@ func (cmd *Cmd) WithArgs(args ...string) *Cmd {
 }
 
 func (cmd *Cmd) CombinedOutput() (string, error) {
+	verboseLog(cmd)
 	output, err := exec.Command(cmd.Name, cmd.Args...).CombinedOutput()
 
 	return string(output), err
@@ -53,6 +55,7 @@ func (cmd *Cmd) Run() error {
 
 // Spawn runs command with spawn(3)
 func (cmd *Cmd) Spawn() error {
+	verboseLog(cmd)
 	c := exec.Command(cmd.Name, cmd.Args...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
@@ -72,6 +75,7 @@ func (cmd *Cmd) Exec() error {
 	args := []string{binary}
 	args = append(args, cmd.Args...)
 
+	verboseLog(cmd)
 	return syscall.Exec(binary, args, os.Environ())
 }
 
@@ -89,4 +93,14 @@ func New(cmd string) *Cmd {
 
 func NewWithArray(cmd []string) *Cmd {
 	return &Cmd{Name: cmd[0], Args: cmd[1:]}
+}
+
+func verboseLog(cmd *Cmd) {
+	if os.Getenv("HUB_VERBOSE") != "" {
+		msg := fmt.Sprintf("$ %s %s", cmd.Name, strings.Join(cmd.Args, " "))
+		if ui.IsTerminal(os.Stderr) {
+			msg = fmt.Sprintf("\033[35m%s\033[0m", msg)
+		}
+		ui.Errorln(msg)
+	}
 }

--- a/commands/ci_status.go
+++ b/commands/ci_status.go
@@ -100,7 +100,7 @@ func ciStatus(cmd *Command, args *Args) {
 }
 
 func verboseFormat(statuses []github.CIStatus) {
-	colorize := github.IsTerminal(os.Stdout)
+	colorize := ui.IsTerminal(os.Stdout)
 
 	contextWidth := 0
 	for _, status := range statuses {

--- a/github/config.go
+++ b/github/config.go
@@ -144,7 +144,7 @@ func (c *Config) PromptForPassword(host, user string) (pass string) {
 	}
 
 	ui.Printf("%s password for %s (never stored): ", host, user)
-	if IsTerminal(os.Stdout) {
+	if ui.IsTerminal(os.Stdout) {
 		pass = string(gopass.GetPasswd())
 	} else {
 		pass = c.scanLine()

--- a/github/http.go
+++ b/github/http.go
@@ -133,7 +133,7 @@ func newHttpClient(testHost string, verbose bool) *http.Client {
 		Verbose:     verbose,
 		OverrideURL: testURL,
 		Out:         ui.Stderr,
-		Colorized:   IsTerminal(os.Stderr),
+		Colorized:   ui.IsTerminal(os.Stderr),
 	}
 	return &http.Client{Transport: tr}
 }

--- a/github/util.go
+++ b/github/util.go
@@ -1,9 +1,6 @@
 package github
 
 import (
-	"os"
-
-	"github.com/github/hub/Godeps/_workspace/src/github.com/mattn/go-isatty"
 	"github.com/github/hub/git"
 )
 
@@ -19,8 +16,4 @@ func IsHttpsProtocol() bool {
 	}
 
 	return false
-}
-
-func IsTerminal(f *os.File) bool {
-	return isatty.IsTerminal(f.Fd())
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -3,8 +3,10 @@ package ui
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/github/hub/Godeps/_workspace/src/github.com/mattn/go-colorable"
+	"github.com/github/hub/Godeps/_workspace/src/github.com/mattn/go-isatty"
 )
 
 type UI interface {
@@ -34,6 +36,10 @@ func Errorf(format string, a ...interface{}) (n int, err error) {
 
 func Errorln(a ...interface{}) (n int, err error) {
 	return Default.Errorln(a...)
+}
+
+func IsTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd())
 }
 
 type Console struct {


### PR DESCRIPTION
Previously, HUB_VERBOSE only logged HTTP interactions. Now, it also logs any external command invocations (typically to `git`) to stderr as well, although in a color different from HTTP.