### PR TITLE
Cache result of `git rev-parse --git-dir`

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -21,7 +21,13 @@ func Version() (string, error) {
 	return output[0], nil
 }
 
+var cachedDir string
+
 func Dir() (string, error) {
+	if cachedDir != "" {
+		return cachedDir, nil
+	}
+
 	output, err := gitOutput("rev-parse", "-q", "--git-dir")
 	if err != nil {
 		return "", fmt.Errorf("Not a git repository (or any of the parent directories): .git")
@@ -54,6 +60,7 @@ func Dir() (string, error) {
 		gitDir = filepath.Clean(gitDir)
 	}
 
+	cachedDir = gitDir
 	return gitDir, nil
 }
 


### PR DESCRIPTION
It's invoked often from different methods, but always has the same results. Cache it after the 1st run so subsequent runs are no-ops.

Before:

    HUB_VERBOSE=1 git browse
    $ git config alias.browse
    $ git rev-parse -q --git-dir
    $ git rev-parse -q --git-dir
    $ git remote -v
    $ git rev-parse -q --git-dir
    $ git config hub.host
    $ git rev-parse -q --git-dir
    $ git config push.default
    $ git rev-parse -q --git-path refs/remotes/origin/no-angular
    $ git rev-parse -q --git-dir
    $ git rev-parse -q --git-dir
    $ git rev-parse -q --git-dir

After (6 fewer invocations):

    HUB_VERBOSE=1 git browse
    $ git config alias.browse
    $ git rev-parse -q --git-dir
    $ git remote -v
    $ git config hub.host
    $ git config push.default
    $ git rev-parse -q --git-path refs/remotes/origin/no-angular