### PR TITLE
Alter fork behavior to rename "origin" to "upstream".

### DIFF
--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -300,4 +300,5 @@ Feature: OAuth authentication
     And the file "../home/.config/hub" should contain "git.my.org"
     And the file "../home/.config/hub" should contain "user: mislav"
     And the file "../home/.config/hub" should contain "oauth_token: OTOKEN"
-    And the url for "mislav" should be "git@git.my.org:mislav/dotfiles.git"
+    And the url for "upstream" should be "git@git.my.org:evilchelu/dotfiles.git"
+    And the url for "origin" should be "git@git.my.org:mislav/dotfiles.git"

--- a/github/client.go
+++ b/github/client.go
@@ -381,8 +381,6 @@ func (client *Client) ForkRepository(project *Project) (repo *octokit.Repository
 
 	repo, result := api.Repositories(client.requestURL(url)).Create(nil)
 	if result.HasError() {
-		fmt.Println(client.requestURL(url))
-		fmt.Println("test")
 		err = FormatError("creating fork", result.Err)
 		return
 	}

--- a/github/client.go
+++ b/github/client.go
@@ -381,6 +381,8 @@ func (client *Client) ForkRepository(project *Project) (repo *octokit.Repository
 
 	repo, result := api.Repositories(client.requestURL(url)).Create(nil)
 	if result.HasError() {
+		fmt.Println(client.requestURL(url))
+		fmt.Println("test")
 		err = FormatError("creating fork", result.Err)
 		return
 	}

--- a/man/hub.1
+++ b/man/hub.1
@@ -145,7 +145,7 @@ Open a GitHub compare view page in the system\'s default web browser\. \fISTART\
 .
 .TP
 \fBgit fork\fR [\fB\-\-no\-remote\fR]
-Forks the original project (referenced by "origin" remote) on GitHub and adds a new remote for it under your username\.
+Forks the original project (referenced by "origin" remote) on GitHub and adds a new remote as origin, renaming the original to "upstream"\.
 .
 .TP
 \fBgit pull\-request\fR [\fB\-o\fR|\fB\-\-browse\fR] [\fB\-f\fR] [\fB\-m\fR \fIMESSAGE\fR|\fB\-F\fR \fIFILE\fR|\fB\-i\fR \fIISSUE\fR|\fIISSUE\-URL\fR] [\fB\-b\fR \fIBASE\fR] [\fB\-h\fR \fIHEAD\fR] [\fB\-a\fR \fIUSER\fR] [\fB\-M\fR \fIMILESTONE\fR] [\fB\-l\fR \fILABELS\fR]
@@ -322,7 +322,8 @@ $ git apply https://gist\.github\.com/8da7fb575debd88c54cf
 
 $ git fork
 [ repo forked on GitHub ]
-> git remote add \-f YOUR_USER git@github\.com:YOUR_USER/CURRENT_REPO\.git
+> git remote rename upstream origin
+> git remote add \-f origin git@github\.com:YOUR_USER/CURRENT_REPO\.git
 .
 .fi
 .


### PR DESCRIPTION
This makes a lot more sense in my opinion. Related to #1036.