### PR TITLE
commands/fork: handle missing "origin" remote

### DIFF
--- a/commands/fork.go
+++ b/commands/fork.go
@@ -71,7 +71,10 @@ func fork(cmd *Command, args *Args) {
 	if flagForkNoRemote {
 		os.Exit(0)
 	} else {
-		originRemote, _ := localRepo.OriginRemote()
+		originRemote, err := localRepo.OriginRemote()
+		if err != nil {
+			utils.Check(fmt.Errorf("Error creating fork: %s", err))
+		}
 		originURL := originRemote.URL.String()
 		url := forkProject.GitURL("", "", true)
 		args.Replace("git", "remote", "add", "-f", forkProject.Owner, originURL)

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -48,6 +48,11 @@ func fork(cmd *Command, args *Args) {
 		utils.Check(github.FormatError("forking repository", err))
 	}
 
+	originRemote, err := localRepo.OriginRemote()
+	if err != nil {
+		utils.Check(fmt.Errorf("Error creating fork: %s", err))
+	}
+
 	forkProject := github.NewProject(host.User, project.Name, project.Host)
 	client := github.NewClient(project.Host)
 	existingRepo, err := client.Repository(forkProject)
@@ -71,10 +76,6 @@ func fork(cmd *Command, args *Args) {
 	if flagForkNoRemote {
 		os.Exit(0)
 	} else {
-		originRemote, err := localRepo.OriginRemote()
-		if err != nil {
-			utils.Check(fmt.Errorf("Error creating fork: %s", err))
-		}
 		originURL := originRemote.URL.String()
 		url := forkProject.GitURL("", "", true)
 		args.Replace("git", "remote", "add", "-f", forkProject.Owner, originURL)

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -113,11 +113,7 @@ Scenario: Related fork already exists
     And the stderr should contain "fatal: Not a git repository"
 
   Scenario: Origin remote doesn't exist
-    Given the GitHub API server:
-      """
-      post('/repos/mislav/dotfiles/forks') { '' }
-      """
-    And I run `git remote rm origin`
+    Given I run `git remote rm origin`
     And the "mislav" remote has url "https://github.com/mislav/dotfiles.git"
     When I run `hub fork`
     Then the exit status should be 1

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -112,6 +112,21 @@ Scenario: Related fork already exists
     Then the exit status should be 1
     And the stderr should contain "fatal: Not a git repository"
 
+  Scenario: Origin remote doesn't exist
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/dotfiles/forks') { '' }
+      """
+    And I run `git remote rm origin`
+    And the "mislav" remote has url "https://github.com/mislav/dotfiles.git"
+    When I run `hub fork`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      Error creating fork: No git remote with name origin\n
+      """
+    And there should be no "origin" remote
+
   Scenario: Unknown host
     Given the "origin" remote has url "git@git.my.org:evilchelu/dotfiles.git"
     When I run `hub fork`


### PR DESCRIPTION
Fixes nil reference crash. Fixes #1042.