### PR TITLE
Added `upstream` option to `browse`

### DIFF
--- a/commands/browse.go
+++ b/commands/browse.go
@@ -47,6 +47,9 @@ func init() {
 
   $ gh browse gh wiki
   > open https://github.com/YOUR_LOGIN/gh/wiki
+
+  $ gh browse upstream
+  > open https://github.com/UPSTREAM_REMOTE_REPO
 */
 func browse(command *Command, args *Args) {
 	var (
@@ -72,7 +75,13 @@ func browse(command *Command, args *Args) {
 	}
 
 	localRepo, _ := github.LocalRepo()
-	if dest != "" {
+	if dest == "upstream" {
+		remotes, _ := github.Remotes()
+		if remotes[0].Name == "upstream" {
+			project, _ = github.NewProjectFromURL(remotes[0].URL)
+			branch = localRepo.MasterBranch()
+		}
+	} else if dest != "" && dest != "upstream" {
 		project = github.NewProject("", dest, "")
 		branch = localRepo.MasterBranch()
 	} else if subpage != "" && subpage != "commits" && subpage != "tree" && subpage != "blob" && subpage != "settings" {


### PR DESCRIPTION
I constantly want to be able to go directly to the remote upstream webpage for
the repo I am currently working on. This normally enters my workflow when I am
working on a fork, push to a feature branch, and want to PR to the remote repo
upstream. I would run `gh browse`, then click on the upstream link on the website,
then start the PR process. Having `gh browse upstream` will make this much easier.

This can be extended to deal with other remotes as well, perhaps using a subpage
like system: `git browse remote upstream`. I am happy to do this change, as well,
but figured a smaller fix like this would open discussion easier.