### PR TITLE
Don't corrupt the PATH if longer than 1024 characters on Windows

### DIFF
--- a/script/install.bat
+++ b/script/install.bat
@@ -17,7 +17,8 @@ for /f "delims=" %%i in ('%RUNPS% "%OLDPATHPS%"') do (
 )
 
 set "NEWPATH=%OLDPATH%;%1"
-%RUNPS% "[Environment]::SetEnvironmentVariable('PATH', '%NEWPATH%', 'User')" :: Set the new $PATH
+:: Set the new $PATH
+%RUNPS% "[Environment]::SetEnvironmentVariable('PATH', '%NEWPATH%', 'User')"
 goto :eof
 
 :checkPrivileges
@@ -47,7 +48,7 @@ set HUB_BIN_PATH="%LOCALAPPDATA%\GitHubCLI\bin"
 IF EXIST %HUB_BIN_PATH% GOTO DIRECTORY_EXISTS
 mkdir %HUB_BIN_PATH%
 set "path=%PATH%;%HUB_BIN_PATH:"=%"
-call :apppendToUserPath %HUB_BIN_PATH:"=%
+call :appendToUserPath %HUB_BIN_PATH:"=%
 :DIRECTORY_EXISTS
 
 :: Delete any existing programs

--- a/script/install.bat
+++ b/script/install.bat
@@ -1,5 +1,16 @@
 @echo off
 CLS
+goto checkPrivileges
+
+:appendToPath
+set "RUNPS=powershell -NoProfile -ExecutionPolicy Bypass -Command"
+set "OLDPATHPS=[Environment]::GetEnvironmentVariable('PATH', 'User')"
+for /f "delims=" %%i in ('%RUNPS% "%OLDPATHPS%"') do (
+    set OLDPATH=%%i
+)
+set NEWPATH=%OLDPATH%;%1
+%RUNPS% "[Environment]::SetEnvironmentVariable('PATH', '%NEWPATH%', 'User')"
+goto :eof
 
 :checkPrivileges
 NET FILE 1>NUL 2>NUL
@@ -28,7 +39,7 @@ set HUB_BIN_PATH="%LOCALAPPDATA%\GitHubCLI\bin"
 IF EXIST %HUB_BIN_PATH% GOTO DIRECTORY_EXISTS
 mkdir %HUB_BIN_PATH%
 set "path=%PATH%;%HUB_BIN_PATH:"=%"
-1>NUL setx PATH "%PATH%" /M
+call :apppendToPath %HUB_BIN_PATH:"=%
 :DIRECTORY_EXISTS
 
 :: Delete any existing programs


### PR DESCRIPTION
setx automatically truncates the PATH to 1024 characters if it is longer than that, which is no good. It also mucks up the local user's PATH with the machine-wide PATH.

This PR fixes that by using PowerShell to manually alter the PATH.