### PR TITLE
Add --id option to issue command

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -388,6 +388,27 @@ func (client *Client) ForkRepository(project *Project) (repo *octokit.Repository
 	return
 }
 
+func (client *Client) Issue(project *Project, id string) (issue *octokit.Issue, err error) {
+	url, err := octokit.RepoIssuesURL.Expand(octokit.M{"owner": project.Owner, "repo": project.Name, "number": id})
+	if err != nil {
+		return
+	}
+
+	api, err := client.api()
+	if err != nil {
+		err = FormatError("getting issue", err)
+		return
+	}
+
+	issue, result := api.Issues(client.requestURL(url)).One()
+	if result.HasError() {
+		err = FormatError("getting issue", result.Err)
+		return
+	}
+
+	return
+}
+
 func (client *Client) Issues(project *Project) (issues []octokit.Issue, err error) {
 	url, err := octokit.RepoIssuesURL.Expand(octokit.M{"owner": project.Owner, "repo": project.Name})
 	if err != nil {


### PR DESCRIPTION
This pull request adds `--id` (`-i`) option to the `issue` command. If you set an issue number to this option, you can get that issue information.
```
% hub issue --id=1
      1] hub pages ( https://github.com/github/hub/issues/1 )
```
This would be useful to get an issue title and URL when only an issue number is given.
