### PR TITLE
document that clone directory is optional

### DIFF
--- a/commands/clone.go
+++ b/commands/clone.go
@@ -11,7 +11,7 @@ import (
 var cmdClone = &Command{
 	Run:          clone,
 	GitExtension: true,
-	Usage:        "clone [-p] OPTIONS [USER/]REPOSITORY DIRECTORY",
+	Usage:        "clone [-p] OPTIONS [USER/]REPOSITORY [DIRECTORY]",
 	Short:        "Clone a remote repository into a new directory",
 	Long: `Clone repository "git://github.com/USER/REPOSITORY.git" into
 DIRECTORY as with git-clone(1). When USER/ is omitted, assumes
@@ -36,6 +36,9 @@ func init() {
 
   $ gh clone -p jekyll_and_hyde
   > git clone git@github.com:YOUR_LOGIN/jekyll_and_hyde.git
+
+  $ gh clone jekyll_and_hyde jekyll
+  > git clone git://github.com/YOUR_LOGIN/jekyll_and_hyde.git jekyll
 */
 func clone(command *Command, args *Args) {
 	if !args.IsParamsEmpty() {


### PR DESCRIPTION
`hub clone` doesn't need the directory parameter.

Felt that changing the long description became too much text. Let me know if you want it.

e.g.:

```go
	Long: `Clone repository "git://github.com/USER/REPOSITORY.git" into
DIRECTORY as with git-clone(1). When USER/ is omitted, assumes
your GitHub login. When [DIRECTORY] is omitted assumes REPOSITORY.
With -p, clone private repositories over SSH.
For repositories under your GitHub login, -p is implicit.
`,
```