### PR TITLE
Improve detecting local clone resources

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -43,6 +43,12 @@ func (cmd *Cmd) CombinedOutput() (string, error) {
 	return string(output), err
 }
 
+func (cmd *Cmd) Success() bool {
+	verboseLog(cmd)
+	err := exec.Command(cmd.Name, cmd.Args...).Run()
+	return err == nil
+}
+
 // Run runs command with `Exec` on platforms except Windows
 // which only supports `Spawn`
 func (cmd *Cmd) Run() error {

--- a/commands/clone.go
+++ b/commands/clone.go
@@ -59,7 +59,7 @@ func transformCloneArgs(args *Args) {
 				i++
 			}
 		} else {
-			if nameWithOwnerRegexp.MatchString(a) && !isDir(a) {
+			if nameWithOwnerRegexp.MatchString(a) && !isCloneable(a) {
 				name, owner := parseCloneNameAndOwner(a)
 				var host *github.Host
 				if owner == "" {

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -53,7 +53,7 @@ func tranformFetchArgs(args *Args) error {
 	projects := make(map[*github.Project]bool)
 	ownerRegexp := regexp.MustCompile(OwnerRe)
 	for _, name := range names {
-		if ownerRegexp.MatchString(name) {
+		if ownerRegexp.MatchString(name) && !isCloneable(name) {
 			_, err := localRepo.RemoteByName(name)
 			if err != nil {
 				project := github.NewProject(name, "", "")

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/github/hub/git"
 	"github.com/github/hub/github"
 	"github.com/github/hub/utils"
 )
@@ -24,7 +25,7 @@ func (l *listFlag) Set(value string) error {
 	return nil
 }
 
-func isDir(file string) bool {
+func isCloneable(file string) bool {
 	f, err := os.Open(file)
 	if err != nil {
 		return false
@@ -36,7 +37,23 @@ func isDir(file string) bool {
 		return false
 	}
 
-	return fi.IsDir()
+	if fi.IsDir() {
+		gitf, err := os.Open(filepath.Join(file, ".git"))
+		if err == nil {
+			gitf.Close()
+			return true
+		} else {
+			return git.IsGitDir(file)
+		}
+	} else {
+		reader := bufio.NewReader(f)
+		line, err := reader.ReadString('\n')
+		if err == nil {
+			return strings.Contains(line, "git bundle")
+		} else {
+			return false
+		}
+	}
 }
 
 func gitRemoteForProject(project *github.Project) (foundRemote *github.Remote) {

--- a/features/clone.feature
+++ b/features/clone.feature
@@ -38,6 +38,19 @@ Feature: hub clone
     Then it should clone "git://github.com/zhuangya/.vim.git"
     And there should be no output
 
+  Scenario: Clone a repo even if same-named directory exists
+    Given the GitHub API server:
+      """
+      get('/repos/rtomayko/ronn') {
+        json :private => false,
+             :permissions => { :push => false }
+      }
+      """
+    And a directory named "rtomayko/ronn"
+    When I successfully run `hub clone rtomayko/ronn`
+    Then it should clone "git://github.com/rtomayko/ronn.git"
+    And there should be no output
+
   Scenario: Clone a public repo with HTTPS
     Given HTTPS is preferred
     Given the GitHub API server:
@@ -89,7 +102,14 @@ Feature: hub clone
     And there should be no output
 
   Scenario: Unchanged local clone with destination
+    Given a directory named ".git"
     When I successfully run `hub clone -l . ../copy`
+    Then the git command should be unchanged
+    And there should be no output
+
+  Scenario: Unchanged local clone from bare repo
+    Given a bare git repo in "rtomayko/ronn"
+    When I successfully run `hub clone rtomayko/ronn`
     Then the git command should be unchanged
     And there should be no output
 
@@ -196,8 +216,14 @@ Feature: hub clone
     And there should be no output
 
   Scenario: Clone from existing directory is a local clone
-    Given a directory named "dotfiles"
+    Given a directory named "dotfiles/.git"
     When I successfully run `hub clone dotfiles`
+    Then the git command should be unchanged
+    And there should be no output
+
+  Scenario: Clone from git bundle is a local clone
+    Given a git bundle named "my-bundle"
+    When I successfully run `hub clone my-bundle`
     Then the git command should be unchanged
     And there should be no output
 

--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -6,8 +6,19 @@ Feature: hub fetch
 
   Scenario: Fetch existing remote
     When I successfully run `hub fetch origin`
-    Then "git fetch origin" should be run
+    Then the git command should be unchanged
     And there should be no output
+
+  Scenario: Fetch from local bundle
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') { json :private => false }
+      """
+    And a git bundle named "mislav"
+    When I successfully run `hub fetch mislav`
+    Then the git command should be unchanged
+    And there should be no output
+    And there should be no "mislav" remote
 
   Scenario: Creates new remote
     Given the GitHub API server:
@@ -95,5 +106,5 @@ Feature: hub fetch
       get('/repos/mislav/dotfiles') { status 404 }
       """
     When I successfully run `hub fetch mislav`
-    Then "git fetch mislav" should be run
+    Then the git command should be unchanged
     And there should be no "mislav" remote

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -53,11 +53,26 @@ Given(/^I am in "([^"]*)" git repo$/) do |dir_name|
   step %(the "origin" remote has url "#{origin_url}") if origin_url
 end
 
-Given(/^a git repo in "([^"]*)"$/) do |dir_name|
+Given(/^a (bare )?git repo in "([^"]*)"$/) do |bare, dir_name|
   step %(a directory named "#{dir_name}")
   dirs << dir_name
-  step %(I successfully run `git init --quiet`)
+  step %(I successfully run `git init --quiet #{"--bare" if bare}`)
   dirs.pop
+end
+
+Given(/^a git bundle named "([^"]*)"$/) do |file|
+  in_current_dir do
+    FileUtils.mkdir_p File.dirname(file)
+    dest = File.expand_path(file)
+
+    Dir.mktmpdir do |tmpdir|
+      dirs << tmpdir
+      run_silent %(git init --quiet)
+      empty_commit
+      run_silent %(git bundle create "#{dest}" master)
+      dirs.pop
+    end
+  end
 end
 
 Given(/^there is a commit named "([^"]+)"$/) do |name|

--- a/git/git.go
+++ b/git/git.go
@@ -250,6 +250,12 @@ func Run(command string, args ...string) error {
 	return cmd.Run()
 }
 
+func IsGitDir(dir string) bool {
+	cmd := cmd.New("git")
+	cmd.WithArgs("--git-dir=" + dir, "rev-parse", "--git-dir")
+	return cmd.Success()
+}
+
 func gitOutput(input ...string) (outputs []string, err error) {
 	cmd := cmd.New("git")
 


### PR DESCRIPTION
In `hub clone NAME`, "NAME" was previously considered a local resource if a directory of the same name existed, and the clone command was left unchanged.

That worked for a while, but some users were surprised that they couldn't clone their repo named "NAME", only to discover that there was an unrelated directory "NAME" in the current working directory.

Also, a git bundle is a valid cloneable resource, but is a file and not a directory.

This refines the detection of cloneable resources. "NAME" is considered to be locally cloneable if one of the following is true:

- `NAME/.git` exists
- `NAME` is a bare git repo
- `NAME` is a file whose first line includes "git bundle"

Fixes #898