### PR TITLE
Help text improvements

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -42,7 +42,7 @@ func runHelp(cmd *Command, args *Args) {
 func customCommands() []string {
 	cmds := []string{}
 	for n, c := range CmdRunner.All() {
-		if !c.GitExtension {
+		if !c.GitExtension && !strings.HasPrefix(n, "--") {
 			cmds = append(cmds, n)
 		}
 	}

--- a/commands/help.go
+++ b/commands/help.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/github/hub/git"
+	"github.com/github/hub/utils"
 )
 
 var cmdHelp = &Command{
@@ -52,45 +55,9 @@ func customCommands() []string {
 	return cmds
 }
 
-var helpText = `usage: git [--version] [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
-           [-p|--paginate|--no-pager] [--no-replace-objects] [--bare]
-           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
-           [-c name=value] [--help]
-           <command> [<args>]
+var helpText = `
+These GitHub commands are provided by hub:
 
-Basic Commands:
-   init       Create an empty git repository or reinitialize an existing one
-   add        Add new or modified files to the staging area
-   rm         Remove files from the working directory and staging area
-   mv         Move or rename a file, a directory, or a symlink
-   status     Show the status of the working directory and staging area
-   commit     Record changes to the repository
-
-History Commands:
-   log        Show the commit history log
-   diff       Show changes between commits, commit and working tree, etc
-   show       Show information about commits, tags or files
-
-Branching Commands:
-   branch     List, create, or delete branches
-   checkout   Switch the active branch to another branch
-   merge      Join two or more development histories (branches) together
-   tag        Create, list, delete, sign or verify a tag object
-
-Remote Commands:
-   clone      Clone a remote repository into a new directory
-   fetch      Download data, tags and branches from a remote repository
-   pull       Fetch from and merge with another repository or a local branch
-   push       Upload data, tags and branches to a remote repository
-   remote     View and manage a set of remote repositories
-
-Advanced Commands:
-   reset      Reset your staging area or working directory to another point
-   rebase     Re-apply a series of patches in one branch onto another
-   bisect     Find by binary search the change that introduced a bug
-   grep       Print files with lines matching a pattern in your codebase
-
-GitHub Commands:
    pull-request   Open a pull request on GitHub
    fork           Make a fork of a remote repository on GitHub and add as remote
    create         Create this repository on GitHub and add GitHub as origin
@@ -99,10 +66,10 @@ GitHub Commands:
    release        List or create releases (beta)
    issue          List or create issues (beta)
    ci-status      Show the CI status of a commit
-
-See 'git help <command>' for more information on a specific command.
 `
 
 func printUsage() {
+	err := git.ForwardGitHelp()
+	utils.Check(err)
 	fmt.Print(helpText)
 }

--- a/commands/help.go
+++ b/commands/help.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/github/hub/cmd"
 	"github.com/github/hub/git"
 	"github.com/github/hub/utils"
 )
@@ -23,13 +24,25 @@ func init() {
 	CmdRunner.Use(cmdHelp, "--help")
 }
 
-func runHelp(cmd *Command, args *Args) {
+func runHelp(helpCmd *Command, args *Args) {
 	if args.IsParamsEmpty() {
 		printUsage()
 		os.Exit(0)
 	}
 
 	command := args.FirstParam()
+
+	if command == "hub" {
+		man := cmd.New("man")
+		man.WithArg("hub")
+		err := man.Run()
+		if err == nil {
+			os.Exit(0)
+		} else {
+			os.Exit(1)
+		}
+	}
+
 	c := CmdRunner.Lookup(command)
 	if c != nil && !c.GitExtension {
 		c.PrintUsage()

--- a/features/help.feature
+++ b/features/help.feature
@@ -1,0 +1,14 @@
+Feature: hub help
+  Scenario: Appends hub help to regular help text
+    When I successfully run `hub help`
+    Then the output should contain:
+      """
+      These GitHub commands are provided by hub:
+
+         pull-request   Open a pull request on GitHub
+      """
+    And the output should contain "usage: git "
+
+  Scenario: Appends hub commands to `--all` output
+    When I successfully run `hub help -a`
+    Then the output should contain "pull-request"

--- a/features/help.feature
+++ b/features/help.feature
@@ -12,3 +12,7 @@ Feature: hub help
   Scenario: Appends hub commands to `--all` output
     When I successfully run `hub help -a`
     Then the output should contain "pull-request"
+
+  Scenario: Opens man page
+    When I successfully run `hub help hub`
+    Then "man hub" should be run

--- a/features/support/fakebin/man
+++ b/features/support/fakebin/man
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo man "$@" >> "$HOME"/.history

--- a/git/git.go
+++ b/git/git.go
@@ -277,3 +277,9 @@ func gitOutput(input ...string) (outputs []string, err error) {
 
 	return outputs, err
 }
+
+func ForwardGitHelp() error {
+	cmd := cmd.New("git")
+	cmd.WithArgs("help")
+	return cmd.Spawn()
+}


### PR DESCRIPTION
- We no longer hardcode git help text within hub, risking it to fall out of date. Instead, regular `git help` is displayed, and hub just appends its own bit to it.

- `hub help hub` now executes `man hub`. Fixes #977