### PR TITLE
docs(website) improve visual style and readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,17 +5,27 @@
 <meta name=viewport content='initial-scale=1.0'>
 
 <style>
+
   body {
     font: 100% Helvetica, Arial, sans-serif;
-    background: #ccc;
+    background: #ced0d8;
     width: 750px;
     margin: 2em auto;
   }
-  a:link, a:visited, a:active {
+
+
+  a:link,
+  a:visited,
+  a:active {
     color: rgb(65, 131, 196);
     -webkit-transition: color .2s ease-out;
   }
-  a:hover { color: rgb(35, 101, 166); }
+
+  a:hover {
+    color: rgb(35, 101, 166);
+  }
+
+
   h1 {
     font: 400 1.3em "Futura", "Lucida Grande", Helvetica, Arial, sans-serif;
     text-transform: uppercase;
@@ -26,6 +36,7 @@
     float: left;
     width: 75%;
   }
+
   h1 a {
     text-decoration: none;
     font-size: 4.5em;
@@ -42,7 +53,12 @@
       #eee -4px -4px 0,
       rgba(65, 131, 196, .3) -5px -5px 0;
   }
-  h1 a:hover { text-decoration: none; }
+
+  h1 a:hover {
+    text-decoration: none;
+  }
+
+
   .man {
     text-align: right;
     float: right;
@@ -52,64 +68,174 @@
     text-transform: lowercase;
     font-size: .9em;
   }
-  h2, .man, .footer { text-shadow: rgba(255,255,255,.8) 0 1px 0; }
-  h2 { margin: 1em 0 0em 0; color: #444; }
-  p code, .man a, pre { font: 15px Monaco, Courier, monospace; }
+
+
+  h2,
+  .man,
+  .footer {
+    text-shadow: rgba(255,255,255,.8) 0 1px 0;
+  }
+
+  h2 {
+    margin: 1em 0 0em 0;
+    color: #444;
+  }
+
+
+  p code,
+  .man a,
+  pre {
+    font: 15px Monaco, Courier, monospace;
+    font-weight: 600;
+  }
+
+
   section {
     clear: both;
     background: white;
     color: #444;
     padding: 1em;
     margin: 12px 0 0 0;
-    -webkit-border-radius: 6px;
-    -moz-border-radius: 6px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
     -webkit-box-shadow: rgba(0,0,0,.4) 1px 1px 4px;
     -moz-box-shadow: rgba(0,0,0,.4) 1px 1px 4px;
     line-height: 1.5;
   }
-  section > *:first-child { margin-top: 0 }
-  section p { font-size: 1.1em; }
+
+  section > *:first-child {
+    margin-top: 0;
+  }
+
+  section p {
+    font-size: 1.1em;
+  }
+
   section p em {
-    font-style: normal; background: #FCF4C1; padding: 1px 4px;
+    font-style: normal;
+    background: #fcf4c1;
+    padding: 1px 4px;
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
   }
+
+
   pre {
     margin: .5em 0 0 0;
     border-top: 1px dotted silver;
     padding-top: 1em;
     line-height: 1.5;
   }
+
   pre .comment {
-    color: #999;
+    color: #505050;
     font: italic 1.2em "Hoefler Text", "Times New Roman", "Georgia", serif;
+    line-height: 1.4;
   }
-  pre .comment .hidden { color: white }
-  pre .result { color: #777; font-style: italic; margin-left: 1em }
-  pre strong { color: #894400; font-weight: normal }
-  .footer { text-align: center; margin-top: 15px; color: gray; }
+
+  pre .comment .hidden {
+    color: white;
+  }
+
+  pre .result {
+    color: #777;
+    font-style: italic;
+    margin-left: 1em;
+  }
+
+  pre strong {
+    color: #894400;
+    font-weight: 600;
+  }
+
+
+  .footer {
+    text-align: center;
+    margin-top: 15px;
+    color: gray;
+  }
+
+
 
   @media only screen and (max-width: 768px) {
-    body { width: auto; margin: 0; padding: 16px; padding-top: 0 }
-    section { margin-top: 16px }
-  }
-  @media only screen and (max-width: 480px) {
-    body { padding: 6px; font-size: 14px }
-    h1 { margin-top: 0 }
-    h1, .man { width: auto; text-align: center; float: none }
-    .man { padding-top: 0; padding-right: 10px }
-    h1 a { display: block; margin: 0 auto }
-    section {
-      margin-top: 6px; padding: .5em 8px;
-      line-height: 1.3; overflow: hidden;
+    body {
+      width: auto;
+      margin: 0;
+      padding: 16px;
+      padding-top: 0;
     }
-    section h2 { font-size: 16px; margin-bottom: 0 }
-    section p { font-size: 1em; line-height: 1.5 }
-    section p em { padding: 0; -webkit-border-radius: 0 }
-    pre { font-size: 13px; line-height: 1.2; white-space: pre-wrap }
-    pre .comment { font-size: 1em }
-    pre .result { font-size: .9em; margin-left: 0 }
+
+    section {
+      margin-top: 16px;
+    }
   }
+
+
+  @media only screen and (max-width: 480px) {
+    body {
+      padding: 6px;
+      font-size: 14px;
+    }
+
+    h1 {
+      margin-top: 0;
+    }
+
+    h1,
+    .man {
+      width: auto;
+      text-align: center;
+      float: none;
+    }
+
+    .man {
+      padding-top: 0;
+      padding-right: 10px;
+    }
+
+    h1 a {
+      display: block;
+      margin: 0 auto;
+    }
+
+    section {
+      margin-top: 6px;
+      padding: .5em 8px;
+      line-height: 1.3;
+      overflow: hidden;
+    }
+
+    section h2 {
+      font-size: 16px;
+      margin-bottom: 0;
+    }
+
+    section p {
+      font-size: 1em;
+      line-height: 1.5;
+    }
+
+    section p em {
+      padding: 0;
+      -webkit-border-radius: 0;
+    }
+
+    pre {
+      font-size: 13px;
+      line-height: 1.2;
+      white-space: pre-wrap;
+    }
+
+    pre .comment {
+      font-size: 1em;
+    }
+
+    pre .result {
+      font-size: .9em;
+      margin-left: 0;
+    }
+  }
+
 </style>
 
 <body>
@@ -261,7 +387,7 @@ $ git <strong>push production,staging</strong>
 
 <p class=footer>
 Found a bug, have an idea? Contribute to
-<a href="https://github.com/github/hub">this project on github</a>.
+<a href="https://github.com/github/hub">this project on GitHub</a>.
 </p>
 
 <script>


### PR DESCRIPTION
- Improve readability by improving color palette.
- Increase visual contrast between colors.
- Improve readability of the CSS source code.
- Increase line-height for comments.
- Change footer text from github to GitHub.
- Change background color to match logo color palette.
- Change section border-radius from 6px to 4px.
- Add missing semicolons to reduce potential for errors.

Main goal of the changes is to improve the visual style.

*New visual style*
![screenshot from 2016-01-23 21 17 03 hub github com new](https://cloud.githubusercontent.com/assets/135053/12532274/acdf8c2a-c218-11e5-863a-2aac16e426e1.png)


*Old visual style (for comparison)*
![screenshot from 2016-01-23 21 16 35 hub github com old](https://cloud.githubusercontent.com/assets/135053/12532289/fa81c84e-c218-11e5-93cb-57c00ef78e82.png)

