### PR TITLE
Fix bash_completion double reading bug

### DIFF
--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -4,12 +4,13 @@
 # Check that git tab completion is available
 if declare -F _git > /dev/null; then
   # Duplicate and rename the 'list_all_commands' function
-  eval "$(declare -f __git_list_all_commands | \
-        sed 's/__git_list_all_commands/__git_list_all_commands_without_hub/')"
+  if ! declare -F __git_list_all_commands_without_hub > /dev/null; then
+    eval "$(declare -f __git_list_all_commands | \
+          sed 's/__git_list_all_commands/__git_list_all_commands_without_hub/')"
 
-  # Wrap the 'list_all_commands' function with extra hub commands
-  __git_list_all_commands() {
-    cat <<-EOF
+    # Wrap the 'list_all_commands' function with extra hub commands
+    __git_list_all_commands() {
+      cat <<-EOF
 alias
 pull-request
 fork
@@ -18,11 +19,12 @@ browse
 compare
 ci-status
 EOF
-    __git_list_all_commands_without_hub
-  }
+      __git_list_all_commands_without_hub
+    }
 
-  # Ensure cached commands are cleared
-  __git_all_commands=""
+    # Ensure cached commands are cleared
+    __git_all_commands=""
+  fi
 
   ##########################
   # hub command completions


### PR DESCRIPTION
```console
$ # When first read, it is no ploblem.
$ . hub/etc/hub.bash_completion.sh
$ hub [tab][tab]
add                  describe             pull-request
alias                diff                 push
am                   difftool             rebase
:
$ # When read again, it is problem.
$ . hub/etc/hub.bash_completion.sh
$ hub [tab]-bash: __git_list_all_commands_without_hub_without_hub: command not found
```

This pull request correct the problem.