### PR TITLE
git ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp/
 *.test
 target
 .vagrant
+*.log


### PR DESCRIPTION
Running make test-all generates tmux-related log files. I'm not entirely
sure if this is expected (all the tests pass), but I figure it doesn't
hurt to ignore any that might be generated.

Example tmux log files:
  tmux-client-6655.log
  tmux-server-6657.log