### PR TITLE
Fix git remote when using -C:

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -69,7 +69,7 @@ func create(command *Command, args *Args) {
 
 	var newRepoName string
 	if args.IsParamsEmpty() {
-		newRepoName, err = utils.DirName()
+		newRepoName, err = git.RootDirName()
 		utils.Check(err)
 	} else {
 		reg := regexp.MustCompile("^[^-]")

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/github/hub/git"
 	"github.com/github/hub/github"
 	"github.com/github/hub/utils"
 )
@@ -68,7 +69,7 @@ func transformRemoteArgs(args *Args) {
 			repoName = project.Name
 			host = project.Host
 		} else {
-			repoName, err = utils.DirName()
+			repoName, err = git.RootDirName()
 			utils.Check(err)
 		}
 

--- a/features/remote_add.feature
+++ b/features/remote_add.feature
@@ -9,6 +9,14 @@ Feature: hub remote add
     Then the url for "origin" should be "git@github.com:EvilChelu/dotfiles.git"
     And there should be no output
 
+  Scenario: Add origin remote for my own repo using -C
+    Given there are no remotes
+    And I cd to ".."
+    When I successfully run `hub -C dotfiles remote add origin`
+    And I cd to "dotfiles"
+    Then the url for "origin" should be "git@github.com:EvilChelu/dotfiles.git"
+    And there should be no output
+
   Scenario: Unchanged public remote add
     When I successfully run `hub remote add origin http://github.com/defunkt/resque.git`
     Then the url for "origin" should be "http://github.com/defunkt/resque.git"

--- a/github/project.go
+++ b/github/project.go
@@ -167,7 +167,7 @@ func newProject(owner, name, host, protocol string) *Project {
 	}
 
 	if name == "" {
-		name, _ = utils.DirName()
+		name, _ = git.RootDirName()
 	}
 
 	return &Project{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -74,8 +74,11 @@ func CommandPath(cmd string) (string, error) {
 	return filepath.EvalSymlinks(path)
 }
 
-func DirName() (string, error) {
-	dir, err := os.Getwd()
+// CleanDirName returns the name of an existing dir relative to the current
+// working dir. It makes sure the blank spaces in the dir name are replaced
+// with hyphens.
+func CleanDirName(chdir string) (string, error) {
+	dir, err := filepath.Abs(chdir)
 	if err != nil {
 		return "", err
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"os"
+
 	"github.com/bmizerany/assert"
 	"testing"
 )
@@ -15,4 +17,44 @@ func TestSearchBrowserLauncher(t *testing.T) {
 
 func TestConcatPaths(t *testing.T) {
 	assert.Equal(t, "foo/bar/baz", ConcatPaths("foo", "bar", "baz"))
+}
+
+func TestCleanDirName(t *testing.T) {
+	if err := os.MkdirAll("test-clean-dir-name", 0700); err != nil {
+		t.Fatalf("Impossible to create temp dir for testing: %v", err)
+	}
+	if err := os.Chdir("test-clean-dir-name"); err != nil {
+		t.Fatalf("Impossible to switch to temp dir for testing: %v", err)
+	}
+	dirs := []string{"foo", "with multiple spaces", "with-hyphen"}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatalf("Impossible to create temp dir %q for testing: %v", dir, err)
+		}
+	}
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", "test-clean-dir-name"},
+		{"foo", "foo"},
+		{"with multiple spaces", "with-multiple-spaces"},
+		{"with-hyphen", "with-hyphen"},
+	}
+
+	for _, test := range tests {
+		if got, err := CleanDirName(test.input); err != nil {
+			t.Errorf("CleanDirName(%q) raised %q", test.input, err)
+		} else if want := test.expected; got != want {
+			t.Errorf("CleanDirName(%q) = %q, want %q", test.input, got, want)
+		}
+	}
+
+	if err := os.Chdir(".."); err != nil {
+		t.Fatalf("Impossible to switch back from temp dir after testing: %v", err)
+	}
+	if err := os.RemoveAll("test-clean-dir-nam"); err != nil {
+		t.Fatalf("Impossible to clean up after testing: %v", err)
+	}
 }


### PR DESCRIPTION
 - use Git root dir instead of working dir to pick a repo name.

Fixes #1105.