### PR TITLE
Use a formatter to choose the display of issues like `git log --format`.

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -135,12 +135,14 @@ func listIssues(cmd *Command, args *Args) {
 	os.Exit(0)
 }
 
-func formatIssue(issue github.Issue, format string, colorize bool) string {
-	var assigneeLogin string
-	if a := issue.Assignee; a != nil {
-		assigneeLogin = a.Login
+func maybeUserLogin(u *github.User) string {
+	if u == nil {
+		return ""
 	}
+	return u.Login
+}
 
+func formatIssue(issue github.Issue, format string, colorize bool) string {
 	var stateColorSwitch string
 	if colorize {
 		issueColor := 32
@@ -177,8 +179,8 @@ func formatIssue(issue github.Issue, format string, colorize bool) string {
 		"t":  issue.Title,
 		"l":  strings.Join(labelStrings, " "),
 		"b":  issue.Body,
-		"u":  issue.User.Login,
-		"a":  assigneeLogin,
+		"u":  maybeUserLogin(issue.User),
+		"a":  maybeUserLogin(issue.Assignee),
 	}
 
 	return ui.Expand(format, placeholders, colorize)

--- a/commands/issue_test.go
+++ b/commands/issue_test.go
@@ -1,0 +1,203 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/github/hub/github"
+)
+
+type formatIssueTest struct {
+	name     string
+	issue    github.Issue
+	format   string
+	colorize bool
+	expect   string
+}
+
+func testFormatIssue(t *testing.T, tests []formatIssueTest) {
+	for _, test := range tests {
+		if got := formatIssue(test.issue, test.format, test.colorize); got != test.expect {
+			t.Errorf("%s: formatIssue(..., %q, %t) = %q, want %q", test.name, test.format, test.colorize, got, test.expect)
+		}
+	}
+}
+
+func TestFormatIssue(t *testing.T) {
+	format := "%sC%>(8)%ih%Creset  %t%  l%n"
+	testFormatIssue(t, []formatIssueTest{
+		{
+			name: "standard usage",
+			issue: github.Issue{
+				Number:   42,
+				Title:    "Just an Issue",
+				State:    "open",
+				User:     &github.User{Login: "pcorpet"},
+				Body:     "Body of the\nissue",
+				Assignee: &github.User{Login: "mislav"},
+			},
+			format:   format,
+			colorize: true,
+			expect:   "\033[32m     #42\033[m  Just an Issue\n",
+		},
+		{
+			name: "closed issue colored differently",
+			issue: github.Issue{
+				Number: 42,
+				Title:  "Just an Issue",
+				State:  "closed",
+				User:   &github.User{Login: "pcorpet"},
+			},
+			format:   format,
+			colorize: true,
+			expect:   "\033[31m     #42\033[m  Just an Issue\n",
+		},
+		{
+			name: "labels",
+			issue: github.Issue{
+				Number: 42,
+				Title:  "An issue with labels",
+				State:  "open",
+				User:   &github.User{Login: "pcorpet"},
+				Labels: []github.IssueLabel{
+					{Name: "bug", Color: "800000"},
+					{Name: "reproduced", Color: "55ff55"},
+				},
+			},
+			format:   format,
+			colorize: true,
+			expect:   "\033[32m     #42\033[m  An issue with labels  \033[38;5;15;48;2;128;0;0m bug \033[m \033[38;5;16;48;2;85;255;85m reproduced \033[m\n",
+		},
+		{
+			name: "not colorized",
+			issue: github.Issue{
+				Number: 42,
+				Title:  "Just an Issue",
+				State:  "open",
+				User:   &github.User{Login: "pcorpet"},
+			},
+			format:   format,
+			colorize: false,
+			expect:   "     #42  Just an Issue\n",
+		},
+		{
+			name: "labels not colorized",
+			issue: github.Issue{
+				Number: 42,
+				Title:  "An issue with labels",
+				State:  "open",
+				User:   &github.User{Login: "pcorpet"},
+				Labels: []github.IssueLabel{
+					{Name: "bug", Color: "880000"},
+					{Name: "reproduced", Color: "55ff55"},
+				},
+			},
+			format:   format,
+			colorize: false,
+			expect:   "     #42  An issue with labels   bug   reproduced \n",
+		},
+	})
+}
+
+func TestFormatIssue_customFormatString(t *testing.T) {
+	issue := github.Issue{
+		Number:   42,
+		Title:    "Just an Issue",
+		State:    "open",
+		User:     &github.User{Login: "pcorpet"},
+		Body:     "Body of the\nissue",
+		Assignee: &github.User{Login: "mislav"},
+		Labels: []github.IssueLabel{
+			{Name: "bug", Color: "880000"},
+		},
+	}
+
+	testFormatIssue(t, []formatIssueTest{
+		{
+			name:     "number",
+			issue:    issue,
+			format:   "%in",
+			colorize: true,
+			expect:   "42",
+		},
+		{
+			name:     "hashed number",
+			issue:    issue,
+			format:   "%ih",
+			colorize: true,
+			expect:   "#42",
+		},
+		{
+			name:     "state as text",
+			issue:    issue,
+			format:   "%st",
+			colorize: true,
+			expect:   "open",
+		},
+		{
+			name:     "state as color switch",
+			issue:    issue,
+			format:   "%sC",
+			colorize: true,
+			expect:   "\033[32m",
+		},
+		{
+			name:     "state as color switch non colorized",
+			issue:    issue,
+			format:   "%sC",
+			colorize: false,
+			expect:   "",
+		},
+		{
+			name:     "title",
+			issue:    issue,
+			format:   "%t",
+			colorize: true,
+			expect:   "Just an Issue",
+		},
+		{
+			name:     "label colorized",
+			issue:    issue,
+			format:   "%l",
+			colorize: true,
+			expect:   "\033[38;5;15;48;2;136;0;0m bug \033[m",
+		},
+		{
+			name:     "label not colorized",
+			issue:    issue,
+			format:   "%l",
+			colorize: false,
+			expect:   " bug ",
+		},
+		{
+			name:     "body",
+			issue:    issue,
+			format:   "%b",
+			colorize: true,
+			expect:   "Body of the\nissue",
+		},
+		{
+			name:     "user login",
+			issue:    issue,
+			format:   "%u",
+			colorize: true,
+			expect:   "pcorpet",
+		},
+		{
+			name:     "assignee login",
+			issue:    issue,
+			format:   "%a",
+			colorize: true,
+			expect:   "mislav",
+		},
+		{
+			name: "assignee login but not assigned",
+			issue: github.Issue{
+				State: "open",
+				User:  &github.User{Login: "pcorpet"},
+			},
+			format:   "%a",
+			colorize: true,
+			expect:   "",
+		},
+	})
+}

--- a/commands/issue_test.go
+++ b/commands/issue_test.go
@@ -45,7 +45,6 @@ func TestFormatIssue(t *testing.T) {
 				Number: 42,
 				Title:  "Just an Issue",
 				State:  "closed",
-				User:   &github.User{Login: "pcorpet"},
 			},
 			format:   format,
 			colorize: true,
@@ -57,7 +56,6 @@ func TestFormatIssue(t *testing.T) {
 				Number: 42,
 				Title:  "An issue with labels",
 				State:  "open",
-				User:   &github.User{Login: "pcorpet"},
 				Labels: []github.IssueLabel{
 					{Name: "bug", Color: "800000"},
 					{Name: "reproduced", Color: "55ff55"},
@@ -73,7 +71,6 @@ func TestFormatIssue(t *testing.T) {
 				Number: 42,
 				Title:  "Just an Issue",
 				State:  "open",
-				User:   &github.User{Login: "pcorpet"},
 			},
 			format:   format,
 			colorize: false,
@@ -85,7 +82,6 @@ func TestFormatIssue(t *testing.T) {
 				Number: 42,
 				Title:  "An issue with labels",
 				State:  "open",
-				User:   &github.User{Login: "pcorpet"},
 				Labels: []github.IssueLabel{
 					{Name: "bug", Color: "880000"},
 					{Name: "reproduced", Color: "55ff55"},

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -24,8 +24,34 @@ Feature: hub issue
     When I run `hub issue -a Cornwe19`
     Then the output should contain exactly:
       """
-      #102  First issue
-       #13  Second issue\n
+          #102  First issue
+           #13  Second issue\n
+      """
+    And the exit status should be 0
+
+  Scenario: Custom format for issues list
+    Given the GitHub API server:
+    """
+    get('/repos/github/hub/issues') {
+      json [
+        { :number => 102,
+          :title => "First issue",
+          :state => "open",
+          :user => { :login => "lascap" },
+        },
+        { :number => 13,
+          :title => "Second issue",
+          :state => "closed",
+          :user => { :login => "mislav" },
+        },
+      ]
+    }
+    """
+    When I run `hub issue -f "%in,%u%n" -a Cornwe19`
+    Then the output should contain exactly:
+      """
+      102,lascap
+      13,mislav\n
       """
     And the exit status should be 0
 

--- a/ui/format.go
+++ b/ui/format.go
@@ -7,18 +7,21 @@ import (
 )
 
 // Expand expands a format string using `git log` message syntax.
-func Expand(format string, values map[string]string) string {
-	f := &expander{values: values}
+func Expand(format string, values map[string]string, colorize bool) string {
+	f := &expander{values: values, colorize: colorize}
 	return f.Expand(format)
 }
 
 // An expander is a stateful helper to expand a format string.
 type expander struct {
-	// formatted holds the
+	// formatted holds the parts of the string that have already been formatted.
 	formatted []string
 
 	// values is the map of values that should be expanded.
 	values map[string]string
+
+	// colorize is a flag to indiciate whether to use colors.
+	colorize bool
 
 	// skipNext is true if the next placeholder is not a placeholder and can be
 	// output directly as such.
@@ -100,7 +103,10 @@ func (f *expander) expandSpecialChar(firstChar byte, format string) (expand stri
 	case 'C':
 		for k, v := range colorMap {
 			if strings.HasPrefix(format, k) {
-				return "\033[" + v + "m", format[len(k):], true
+				if f.colorize {
+					return "\033[" + v + "m", format[len(k):], true
+				}
+				return "", format[len(k):], true
 			}
 		}
 		// TODO: Add custom color as specified in color.branch.* options.

--- a/ui/format.go
+++ b/ui/format.go
@@ -50,10 +50,15 @@ func (f *expander) crush() string {
 }
 
 var colorMap = map[string]string{
-	"red":   "31",
-	"green": "32",
-	"blue":  "34",
-	"reset": "",
+	"black":   "30",
+	"red":     "31",
+	"green":   "32",
+	"yellow":  "33",
+	"blue":    "34",
+	"magenta": "35",
+	"cyan":    "36",
+	"white":   "37",
+	"reset":   "",
 }
 
 func (f *expander) expandOneVar(format string) (expand string, untouched string) {

--- a/ui/format.go
+++ b/ui/format.go
@@ -1,0 +1,119 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Expand expands a format string using `git log` message syntax.
+func Expand(format string, values map[string]string) string {
+	f := &expander{values: values}
+	return f.Expand(format)
+}
+
+// An expander is a stateful helper to expand a format string.
+type expander struct {
+	// formatted holds the
+	formatted []string
+
+	// values is the map of values that should be expanded.
+	values map[string]string
+
+	// skipNext is true if the next placeholder is not a place holder and can be
+	// output directly as such.
+	skipNext bool
+}
+
+func (f *expander) Expand(format string) string {
+	parts := strings.Split(format, "%")
+	f.formatted = make([]string, 0, len(parts))
+	f.append(parts[0])
+	for _, p := range parts[1:] {
+		v, t := f.expandOneVar(p)
+		f.append(v, t)
+	}
+	return f.crush()
+}
+
+func (f *expander) append(formattedText ...string) {
+	f.formatted = append(f.formatted, formattedText...)
+}
+
+func (f *expander) crush() string {
+	s := strings.Join(f.formatted, "")
+	f.formatted = nil
+	return s
+}
+
+var colorMap = map[string]string{
+	"red":   "31",
+	"green": "32",
+	"blue":  "34",
+	"reset": "",
+}
+
+func (f *expander) expandOneVar(format string) (expand string, untouched string) {
+	if f.skipNext {
+		f.skipNext = false
+		return "", format
+	}
+	if format == "" {
+		f.skipNext = true
+		return "", "%"
+	}
+
+	if e, u, ok := f.expandSpecialChar(format[0], format[1:]); ok {
+		return e, u
+	}
+
+	if f.values != nil {
+		for i := 1; i <= len(format); i++ {
+			if v, exists := f.values[format[0:i]]; exists {
+				return v, format[i:]
+			}
+		}
+	}
+
+	return "", "%" + format
+}
+
+func (f *expander) expandSpecialChar(firstChar byte, format string) (expand string, untouched string, wasExpanded bool) {
+	switch firstChar {
+	case 'n':
+		return "\n", format, true
+	case 'C':
+		for k, v := range colorMap {
+			if strings.HasPrefix(format, k) {
+				return "\033[" + v + "m", format[len(k):], true
+			}
+		}
+		// TODO: Add custom color as specified in color.branch.* options.
+    // TODO: Handle auto-coloring.
+	case 'x':
+		if len(format) >= 2 {
+			if v, err := strconv.ParseInt(format[:2], 16, 32); err == nil {
+				return string(v), format[2:], true
+			}
+		}
+	case '+':
+		if e, u := f.expandOneVar(format); e != "" {
+			return "\n" + e, u, true
+		} else {
+			return "", u, true
+		}
+	case ' ':
+		if e, u := f.expandOneVar(format); e != "" {
+			return " " + e, u, true
+		} else {
+			return "", u, true
+		}
+	case '-':
+		if e, u := f.expandOneVar(format); e != "" {
+			return e, u, true
+		} else {
+			f.append(strings.TrimRight(f.crush(), "\n"))
+			return "", u, true
+		}
+	}
+	return "", "", false
+}

--- a/ui/format_test.go
+++ b/ui/format_test.go
@@ -1,0 +1,67 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestExpand(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		values map[string]string
+		expect string
+	}{
+		{
+			name:   "Simple example",
+			format: "The author of %h was %an, %ar%nThe title was >>%s<<%n",
+			values: map[string]string{
+				"h":  "fe6e0ee",
+				"an": "Junio C Hamano",
+				"ar": "23 hours ago",
+				"s":  "t4119: test autocomputing -p<n> for traditional diff input.",
+			},
+			expect: "The author of fe6e0ee was Junio C Hamano, 23 hours ago\nThe title was >>t4119: test autocomputing -p<n> for traditional diff input.<<\n",
+		},
+		{
+			name:   "Percent sign, middle and trailing",
+			format: "%%a %%b %",
+			values: map[string]string{"a": "A variable that should not be used."},
+			expect: "%a %b %",
+		},
+		{
+			name:   "Colors",
+			format: "%Cred%r %Cgreen%g %Cblue%b%Creset normal",
+			values: map[string]string{"r": "RED", "g": "GREEN", "b": "BLUE"},
+			expect: "\033[31mRED \033[32mGREEN \033[34mBLUE\033[m normal",
+		},
+		{
+			name:   "Byte from hex code",
+			format: "%x00 %x3712%x61 %x%x1%xga",
+			expect: "\x00 \x3712a %x%x1%xga",
+		},
+		{
+			name:   "plus modifier, conditional line",
+			format: "line1%+a line2%+b line3",
+			values: map[string]string{"a": "A", "b": ""},
+			expect: "line1\nA line2 line3",
+		},
+		{
+			name:   "blank modifier, conditional blank",
+			format: "word1% a word2% b word3",
+			values: map[string]string{"a": "A", "b": ""},
+			expect: "word1 A word2 word3",
+		},
+		{
+			name:   "minus modifier, crush preceding line-feeds",
+			format: "word1%n%n%-a",
+			values: map[string]string{"a": ""},
+			expect: "word1",
+		},
+	}
+
+	for _, test := range tests {
+		if got := Expand(test.format, test.values); got != test.expect {
+			t.Errorf("%s: Expand(%q, ...) = %q, want %q", test.name, test.format, got, test.expect)
+		}
+	}
+}

--- a/ui/format_test.go
+++ b/ui/format_test.go
@@ -5,15 +5,16 @@ import (
 )
 
 type expanderTest struct {
-	name   string
-	format string
-	values map[string]string
-	expect string
+	name     string
+	format   string
+	values   map[string]string
+	colorize bool
+	expect   string
 }
 
 func testExpander(t *testing.T, tests []expanderTest) {
 	for _, test := range tests {
-		if got := Expand(test.format, test.values); got != test.expect {
+		if got := Expand(test.format, test.values, test.colorize); got != test.expect {
 			t.Errorf("%s: Expand(%q, ...) = %q, want %q", test.name, test.format, got, test.expect)
 		}
 	}
@@ -39,10 +40,18 @@ func TestExpand(t *testing.T) {
 			expect: "%a %b %",
 		},
 		{
-			name:   "Colors",
-			format: "%Cred%r %Cgreen%g %Cblue%b%Creset normal",
-			values: map[string]string{"r": "RED", "g": "GREEN", "b": "BLUE"},
-			expect: "\033[31mRED \033[32mGREEN \033[34mBLUE\033[m normal",
+			name:     "Colors",
+			format:   "%Cred%r %Cgreen%g %Cblue%b%Creset normal",
+			values:   map[string]string{"r": "RED", "g": "GREEN", "b": "BLUE"},
+			colorize: true,
+			expect:   "\033[31mRED \033[32mGREEN \033[34mBLUE\033[m normal",
+		},
+		{
+			name:     "Colors not colorized",
+			format:   "%Cred%r %Cgreen%g %Cblue%b%Creset normal",
+			values:   map[string]string{"r": "RED", "g": "GREEN", "b": "BLUE"},
+			colorize: false,
+			expect:   "RED GREEN BLUE normal",
 		},
 		{
 			name:   "Byte from hex code",

--- a/ui/format_test.go
+++ b/ui/format_test.go
@@ -57,6 +57,84 @@ func TestExpand(t *testing.T) {
 			values: map[string]string{"a": ""},
 			expect: "word1",
 		},
+		{
+			name:   "padding",
+			format: "%<(10)%a",
+			values: map[string]string{"a": "012"},
+			expect: "012       ",
+		},
+		{
+			name:   "padding, wrong number",
+			format: "%<(1a)%a",
+			values: map[string]string{"a": "012"},
+			expect: "%<(1a)012",
+		},
+		{
+			name:   "padding left",
+			format: "%>(10)%a",
+			values: map[string]string{"a": "012"},
+			expect: "       012",
+		},
+		{
+			name:   "padding middle",
+			format: "%><(10)%a",
+			values: map[string]string{"a": "0123"},
+			expect: "   0123   ",
+		},
+		{
+			name:   "padding middle (odd # of blanks)",
+			format: "%><(10)%a",
+			values: map[string]string{"a": "012"},
+			expect: "   012    ",
+		},
+		{
+			name:   "padding uses extra blank on the left",
+			format: "%>>(5)|    %a",
+			values: map[string]string{"a": "0123456"},
+			expect: "|  0123456",
+		},
+		{
+			name:   "padding until column N",
+			format: "%>|(10)abcdef%a",
+			values: map[string]string{"a": "012"},
+			expect: "abcdef 012",
+		},
+		{
+			name:   "truncing",
+			format: "%>(5,trunc)%a",
+			values: map[string]string{"a": "0123456"},
+			expect: "012..",
+		},
+		{
+			name:   "truncing on the right",
+			format: "%>(5,rtrunc)%a",
+			values: map[string]string{"a": "0123456"},
+			expect: "..456",
+		},
+		{
+			name:   "truncing in the middle",
+			format: "%>(6,mtrunc)%a",
+			values: map[string]string{"a": "0123456"},
+			expect: "01..56",
+		},
+		{
+			name:   "truncing in the middle (odd # of chars)",
+			format: "%>(5,mtrunc)%a",
+			values: map[string]string{"a": "0123456"},
+			expect: "0..56",
+		},
+		{
+			name:   "truncing not enough space",
+			format: "%>(1,trunc)%a",
+			values: map[string]string{"a": "0123456"},
+			expect: "..",
+		},
+		{
+			name:   "truncing but use extra blanks on the left",
+			format: "%>>(3,trunc)|   %a",
+			values: map[string]string{"a": "0123456"},
+			expect: "|0123..",
+		},
 	}
 
 	for _, test := range tests {

--- a/ui/format_test.go
+++ b/ui/format_test.go
@@ -4,13 +4,23 @@ import (
 	"testing"
 )
 
+type expanderTest struct {
+	name   string
+	format string
+	values map[string]string
+	expect string
+}
+
+func testExpander(t *testing.T, tests []expanderTest) {
+	for _, test := range tests {
+		if got := Expand(test.format, test.values); got != test.expect {
+			t.Errorf("%s: Expand(%q, ...) = %q, want %q", test.name, test.format, got, test.expect)
+		}
+	}
+}
+
 func TestExpand(t *testing.T) {
-	tests := []struct {
-		name   string
-		format string
-		values map[string]string
-		expect string
-	}{
+	testExpander(t, []expanderTest{
 		{
 			name:   "Simple example",
 			format: "The author of %h was %an, %ar%nThe title was >>%s<<%n",
@@ -39,6 +49,11 @@ func TestExpand(t *testing.T) {
 			format: "%x00 %x3712%x61 %x%x1%xga",
 			expect: "\x00 \x3712a %x%x1%xga",
 		},
+	})
+}
+
+func TestExpand_Modifiers(t *testing.T) {
+	testExpander(t, []expanderTest{
 		{
 			name:   "plus modifier, conditional line",
 			format: "line1%+a line2%+b line3",
@@ -57,6 +72,11 @@ func TestExpand(t *testing.T) {
 			values: map[string]string{"a": ""},
 			expect: "word1",
 		},
+	})
+}
+
+func TestExpand_Padding(t *testing.T) {
+	testExpander(t, []expanderTest{
 		{
 			name:   "padding",
 			format: "%<(10)%a",
@@ -99,6 +119,11 @@ func TestExpand(t *testing.T) {
 			values: map[string]string{"a": "012"},
 			expect: "abcdef 012",
 		},
+	})
+}
+
+func TestExpand_Truncing(t *testing.T) {
+	testExpander(t, []expanderTest{
 		{
 			name:   "truncing",
 			format: "%>(5,trunc)%a",
@@ -135,11 +160,5 @@ func TestExpand(t *testing.T) {
 			values: map[string]string{"a": "0123456"},
 			expect: "|0123..",
 		},
-	}
-
-	for _, test := range tests {
-		if got := Expand(test.format, test.values); got != test.expect {
-			t.Errorf("%s: Expand(%q, ...) = %q, want %q", test.name, test.format, got, test.expect)
-		}
-	}
+	})
 }


### PR DESCRIPTION
This will be used to choose the formatting of issues (in `hub issue`) or pull requests (in `hub pr`).