### PR TITLE
Restore `go get` installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ $ cd hub
 $ ./script/build -o ~/bin/hub
 ~~~
 
+Or, if you've done Go(1.6 or newer) development before and your $GOPATH/bin
+directory is already in your PATH:
+
+~~~ sh
+$ go get github.com/github/hub
+~~~
+
 Aliasing
 --------
 


### PR DESCRIPTION
According to [Go 1.6 Release Note](https://blog.golang.org/go1.6), 
vendor experiment is enabled by default.