### PR TITLE
bashcomp: try to load git comp first (fix #592)

### DIFF
--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -1,6 +1,11 @@
 # hub tab-completion script for bash.
 # This script complements the completion script that ships with git.
 
+# If there is no git tab completion, but we have the _completion loader try to load it
+if ! declare -F _git > /dev/null && declare -F _completion_loader > /dev/null; then
+  _completion_loader git
+fi
+
 # Check that git tab completion is available
 if declare -F _git > /dev/null; then
   # Duplicate and rename the 'list_all_commands' function


### PR DESCRIPTION
Not super portable, but a step forward.