### PR TITLE
Fix #1100: Append /api/v3/ to request when using GHE

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -274,7 +274,12 @@ func (client *Client) FetchReleases(project *Project) (response []Release, err e
 		return
 	}
 
-	res, err := api.Get(fmt.Sprintf("repos/%s/%s/releases", project.Owner, project.Name))
+	request_url, err := url.Parse(fmt.Sprintf("repos/%s/%s/releases", project.Owner, project.Name))
+	if err != nil {
+		return
+	}
+
+	res, err := api.Get(client.requestURL(request_url).String())
 	if err = checkStatus(200, "fetching releases", res, err); err != nil {
 		return
 	}
@@ -402,7 +407,12 @@ func (client *Client) FetchCIStatus(project *Project, sha string) (status *CISta
 		return
 	}
 
-	res, err := api.Get(fmt.Sprintf("repos/%s/%s/commits/%s/status", project.Owner, project.Name, sha))
+	request_url, err := url.Parse(fmt.Sprintf("repos/%s/%s/commits/%s/status", project.Owner, project.Name, sha))
+	if err != nil {
+		return
+	}
+
+	res, err := api.Get(client.requestURL(request_url).String())
 	if err = checkStatus(200, "fetching statuses", res, err); err != nil {
 		return
 	}

--- a/github/client.go
+++ b/github/client.go
@@ -274,12 +274,12 @@ func (client *Client) FetchReleases(project *Project) (response []Release, err e
 		return
 	}
 
-	request_url, err := url.Parse(fmt.Sprintf("repos/%s/%s/releases", project.Owner, project.Name))
+	requestUrl, err := url.Parse(fmt.Sprintf("repos/%s/%s/releases", project.Owner, project.Name))
 	if err != nil {
 		return
 	}
 
-	res, err := api.Get(client.requestURL(request_url).String())
+	res, err := api.Get(client.requestURL(requestUrl).String())
 	if err = checkStatus(200, "fetching releases", res, err); err != nil {
 		return
 	}
@@ -407,12 +407,12 @@ func (client *Client) FetchCIStatus(project *Project, sha string) (status *CISta
 		return
 	}
 
-	request_url, err := url.Parse(fmt.Sprintf("repos/%s/%s/commits/%s/status", project.Owner, project.Name, sha))
+	requestUrl, err := url.Parse(fmt.Sprintf("repos/%s/%s/commits/%s/status", project.Owner, project.Name, sha))
 	if err != nil {
 		return
 	}
 
-	res, err := api.Get(client.requestURL(request_url).String())
+	res, err := api.Get(client.requestURL(requestUrl).String())
 	if err = checkStatus(200, "fetching statuses", res, err); err != nil {
 		return
 	}


### PR DESCRIPTION
Git Hub Enterprise requests should always include /api/v3 in the URL in order to hit the correct API endpoint. The ci-status and release commands were producing the wrong request URL.

```
> GET https://[GHE URL]/repos/[ORG]/[REPO]/commits/[SHA]/status
```
rather than:
```
> GET https://[GHE URL]/api/v3/repos/[ORG]/[REPO]/commits/[SHA]/status
```

As result, an LDAP authentication page was returned rather than the expected JSON. A parsing error could be seen:

```
invalid character '<' looking for beginning of value
```

This commit changes the construction of the request URL for the ci-status and release commands, making sure the existing client.requestURL function is called. This makes sure the API request always hits the right endpoint in Git Hub Enterprise.