### PR TITLE
Graduate from beta

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -166,8 +166,8 @@ These GitHub commands are provided by hub:
    create         Create this repository on GitHub and add GitHub as origin
    browse         Open a GitHub page in the default browser
    compare        Open a compare page on GitHub
-   release        List or create releases (beta)
-   issue          List or create issues (beta)
+   release        List or create releases
+   issue          List or create issues
    ci-status      Show the CI status of a commit
 `
 


### PR DESCRIPTION
Remove (beta) from help.go for release and issue.

Feature has been in since 2013? Should it graduate from Beta now? :)