### PR TITLE
Updated hub alias for Fish to suggest defining a function instead of an alias

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,3 +52,6 @@ DEPENDENCIES
   cucumber (~> 1.3.9)
   ronn
   sinatra
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,3 @@ DEPENDENCIES
   cucumber (~> 1.3.9)
   ronn
   sinatra
-
-BUNDLED WITH
-   1.11.2

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -86,7 +86,7 @@ func alias(command *Command, args *Args) {
 		case "ksh":
 			profile = "~/.profile"
 		case "fish":
-			profile = "~/.config/fish/config.fish"
+			profile = "~/.config/fish/features/git.fish"
 		case "csh":
 			profile = "~/.cshrc"
 		case "tcsh":
@@ -101,7 +101,9 @@ func alias(command *Command, args *Args) {
 		var eval string
 		switch shell {
 		case "fish":
-			eval = `eval (hub alias -s)`
+			eval = `function git --description 'Alias for Github wrapper for git called hub, that adds some Github sugar to git.'
+	hub $argv
+end`
 		case "csh", "tcsh":
 			eval = "eval \"`hub alias -s`\""
 		default:

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -101,7 +101,7 @@ func alias(command *Command, args *Args) {
 		var eval string
 		switch shell {
 		case "fish":
-			eval = `function git --description 'Alias for Github wrapper for git called hub, that adds some Github sugar to git.'
+			eval = `function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
 	hub $argv
 end`
 		case "csh", "tcsh":

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -102,7 +102,7 @@ func alias(command *Command, args *Args) {
 		switch shell {
 		case "fish":
 			eval = `function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
-	hub $argv
+  hub $argv
 end`
 		case "csh", "tcsh":
 			eval = "eval \"`hub alias -s`\""

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -103,7 +103,7 @@ func alias(command *Command, args *Args) {
 		case "fish":
 			eval = `function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
 	hub $argv
-end\n`
+end`
 		case "csh", "tcsh":
 			eval = "eval \"`hub alias -s`\""
 		default:

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -102,7 +102,7 @@ func alias(command *Command, args *Args) {
 		switch shell {
 		case "fish":
 			eval = `function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
-	hub $argv
+hub $argv
 end`
 		case "csh", "tcsh":
 			eval = "eval \"`hub alias -s`\""

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -102,8 +102,8 @@ func alias(command *Command, args *Args) {
 		switch shell {
 		case "fish":
 			eval = `function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
-  hub $argv
-end`
+	hub $argv
+end\n`
 		case "csh", "tcsh":
 			eval = "eval \"`hub alias -s`\""
 		default:

--- a/features/alias.feature
+++ b/features/alias.feature
@@ -18,7 +18,7 @@ Feature: hub alias
       # Wrap git automatically by adding the following to ~/.config/fish/features/git.fish:
 
 function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
-	hub $argv
+\t  hub $argv
 end\n
       """
 

--- a/features/alias.feature
+++ b/features/alias.feature
@@ -18,7 +18,7 @@ Feature: hub alias
       # Wrap git automatically by adding the following to ~/.config/fish/features/git.fish:
 
 function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
-	hub $argv
+  hub $argv
 end\n
       """
 

--- a/features/alias.feature
+++ b/features/alias.feature
@@ -18,7 +18,7 @@ Feature: hub alias
       # Wrap git automatically by adding the following to ~/.config/fish/features/git.fish:
 
 function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
-  hub $argv
+	hub $argv
 end\n
       """
 

--- a/features/alias.feature
+++ b/features/alias.feature
@@ -17,9 +17,9 @@ Feature: hub alias
       """
       # Wrap git automatically by adding the following to ~/.config/fish/features/git.fish:
 
-function git --description 'Alias for Github wrapper for git called hub, that adds some Github sugar to git.'
+function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
 	hub $argv
-end#
+end\n
       """
 
   Scenario: zsh instructions

--- a/features/alias.feature
+++ b/features/alias.feature
@@ -18,7 +18,7 @@ Feature: hub alias
       # Wrap git automatically by adding the following to ~/.config/fish/features/git.fish:
 
 function git --description 'Alias for hub, which wraps git to provide extra functionality with GitHub.'
-\t  hub $argv
+hub $argv
 end\n
       """
 

--- a/features/alias.feature
+++ b/features/alias.feature
@@ -15,9 +15,11 @@ Feature: hub alias
     When I successfully run `hub alias`
     Then the output should contain exactly:
       """
-      # Wrap git automatically by adding the following to ~/.config/fish/config.fish:
+      # Wrap git automatically by adding the following to ~/.config/fish/features/git.fish:
 
-      eval (hub alias -s)\n
+function git --description 'Alias for Github wrapper for git called hub, that adds some Github sugar to git.'
+	hub $argv
+end#
       """
 
   Scenario: zsh instructions


### PR DESCRIPTION
I also updated the test but am not sure how to run them.  The formating looks wrong but outputs correctly when the commands are run. 

This is a response to create a pull request in comments on commit  [ fix hub alias for fish](https://github.com/github/hub/commit/df0e8293f1c2f5ee4f3be70462c69d65eb47f39c)