### PR TITLE
Add default host as configuration option (hub.defaultHost)

### DIFF
--- a/features/clone.feature
+++ b/features/clone.feature
@@ -215,6 +215,21 @@ Feature: hub clone
     Then it should clone "git@git.my.org:myorg/myrepo.git"
     And there should be no output
 
+  Scenario: Clone my Enterprise repo using git config
+    Given I am "mifi" on git.my.org with OAuth token "FITOKEN"
+    And $GITHUB_HOST is ""
+    And default GitHub host is "git.my.org"
+    Given the GitHub API server:
+      """
+      get('/api/v3/repos/myorg/myrepo') {
+        json :private => true,
+             :permissions => { :push => false }
+      }
+      """
+    When I successfully run `hub clone myorg/myrepo`
+    Then it should clone "git@git.my.org:myorg/myrepo.git"
+    And there should be no output
+
   Scenario: Clone from existing directory is a local clone
     Given a directory named "dotfiles/.git"
     When I successfully run `hub clone dotfiles`

--- a/features/init.feature
+++ b/features/init.feature
@@ -19,3 +19,11 @@ Feature: hub init
     And "git.my.org" is a whitelisted Enterprise host
     When I successfully run `hub init -g`
     Then the url for "origin" should be "git@git.my.org:mislav/dotfiles.git"
+
+  Scenario: Enterprise host via git config
+    Given $GITHUB_HOST is ""
+    And default GitHub host is "git.my.org"
+    And I am "mislav" on git.my.org with OAuth token "FITOKEN"
+    And "git.my.org" is a whitelisted Enterprise host
+    When I successfully run `hub init -g`
+    Then the url for "origin" should be "git@git.my.org:mislav/dotfiles.git"

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -9,6 +9,10 @@ Given(/^there are no remotes$/) do
   expect(result).to be_empty
 end
 
+Given(/^default GitHub host is "([^"]*)"$/) do |host|
+  run_silent %(git config --global hub.defaultHost "#{host}")
+end
+
 Given(/^"([^"]*)" is a whitelisted Enterprise host$/) do |host|
   run_silent %(git config --global --add hub.host "#{host}")
 end

--- a/github/hosts.go
+++ b/github/hosts.go
@@ -52,7 +52,10 @@ func knownGitHubHosts() (hosts GitHubHosts) {
 func DefaultGitHubHost() string {
 	defaultHost := GitHubHostEnv
 	if defaultHost == "" {
-		defaultHost = GitHubHost
+		defaultHost, _ = git.Config("hub.defaultHost")
+		if defaultHost == "" {
+			defaultHost = GitHubHost
+		}
 	}
 
 	return defaultHost

--- a/man/hub.1.ronn
+++ b/man/hub.1.ronn
@@ -109,6 +109,10 @@ this can be affected with the `GITHUB_HOST` environment variable:
 
     $ GITHUB_HOST=my.git.org git clone myproject
 
+Alternatively, the GitHub Enterprise host can be specified in the git configuration:
+
+    $ git config --global hub.defaultHost my.git.org
+
 ## BUGS
 
 <https://github.com/github/hub/issues>


### PR DESCRIPTION
This adds a git configuration option to set the default GitHub host.  We are deploying GitHub Enterprise, and our developers will use our GitHub Enterprise server the *vast* majority of the time (99+%, etc.), with access to github.com probably limited to a very few select situation.  As such, we'd prefer a more "sticky", uniform way to nearly always use our GitHub Enterprise server.

I've tried to model this off of what I see other code doing, etc.  I have had trouble running some of the tests, though, even without this case.  Therefore, it's highly likely that these tests need some work.  I'd really appreciate it if someone could work with me on that.  We really need this simple functionality, and would really like to have it in the official hub source.