### PR TITLE
Issue and Pull Request Templates, with addendums

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -108,13 +108,18 @@ func createIssue(cmd *Command, args *Args) {
 }
 
 func writeIssueTitleAndBody(project *github.Project) (string, string, error) {
-	message := `
+	message := `%s
 # Creating issue for %s.
 #
 # Write a message for this issue. The first block of
 # text is the title and the rest is the description.
 `
-	message = fmt.Sprintf(message, project.Name)
+
+	if template := github.GetIssueTempalte(); template == "" {
+		message = fmt.Sprintf(message, "", project.Name)
+	} else {
+		message = fmt.Sprintf(message, template, project.Name)
+	}
 
 	editor, err := github.NewEditor("ISSUE", "issue", message)
 	if err != nil {

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -115,11 +115,8 @@ func writeIssueTitleAndBody(project *github.Project) (string, string, error) {
 # text is the title and the rest is the description.
 `
 
-	if template := github.GetIssueTemplate(); template == "" {
-		message = fmt.Sprintf(message, "", project.Name)
-	} else {
-		message = fmt.Sprintf(message, template, project.Name)
-	}
+	template := github.GetIssueTemplate()
+	message = fmt.Sprintf(message, template, project.Name)
 
 	editor, err := github.NewEditor("ISSUE", "issue", message)
 	if err != nil {

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -115,7 +115,7 @@ func writeIssueTitleAndBody(project *github.Project) (string, string, error) {
 # text is the title and the rest is the description.
 `
 
-	if template := github.GetIssueTempalte(); template == "" {
+	if template := github.GetIssueTemplate(); template == "" {
 		message = fmt.Sprintf(message, "", project.Name)
 	} else {
 		message = fmt.Sprintf(message, template, project.Name)

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -278,7 +278,7 @@ func createPullRequestMessage(base, head, fullBase, fullHead string) (string, er
 		}
 	}
 
-	if tmplate := github.GetPullRequestTempalte(); tmplate != "" {
+	if tmplate := github.GetPullRequestTemplate(); tmplate != "" {
 		if defaultMsg != "" {
 			defaultMsg = defaultMsg + tmplate
 		} else {

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -278,7 +278,7 @@ func createPullRequestMessage(base, head, fullBase, fullHead string) (string, er
 		}
 	}
 
-	if tmplate := github.GetPullRequestTemplate(); tmplate != "" {
+	if template := github.GetPullRequestTemplate(); template != "" {
 		defaultMsg = github.GeneratePRTemplate(defaultMsg)
 	}
 

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -184,7 +184,7 @@ func pullRequest(cmd *Command, args *Args) {
 			headTracking = fmt.Sprintf("%s/%s", remote.Name, head)
 		}
 
-		message, err := pullRequestChangesMessage(baseTracking, headTracking, fullBase, fullHead)
+		message, err := createPullRequestMessage(baseTracking, headTracking, fullBase, fullHead)
 		utils.Check(err)
 
 		editor, err = github.NewEditor("PULLREQ", "pull request", message)
@@ -258,7 +258,7 @@ func pullRequest(cmd *Command, args *Args) {
 	}
 }
 
-func pullRequestChangesMessage(base, head, fullBase, fullHead string) (string, error) {
+func createPullRequestMessage(base, head, fullBase, fullHead string) (string, error) {
 	var (
 		defaultMsg string
 		commitLogs string
@@ -275,6 +275,14 @@ func pullRequestChangesMessage(base, head, fullBase, fullHead string) (string, e
 		commitLogs, err = git.Log(base, head)
 		if err != nil {
 			return "", err
+		}
+	}
+
+	if tmplate := github.GetPullRequestTempalte(); tmplate != "" {
+		if defaultMsg != "" {
+			defaultMsg = defaultMsg + tmplate
+		} else {
+			defaultMsg = tmplate
 		}
 	}
 

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -279,11 +279,7 @@ func createPullRequestMessage(base, head, fullBase, fullHead string) (string, er
 	}
 
 	if tmplate := github.GetPullRequestTemplate(); tmplate != "" {
-		if defaultMsg != "" {
-			defaultMsg = defaultMsg + tmplate
-		} else {
-			defaultMsg = tmplate
-		}
+		defaultMsg = github.GeneratePRTemplate(defaultMsg)
 	}
 
 	cs := git.CommentChar()

--- a/commands/pull_request_tpl.go
+++ b/commands/pull_request_tpl.go
@@ -16,8 +16,8 @@ const pullRequestTmpl = `{{if .InitMsg}}{{.InitMsg}}
 {{.CS}} of text is the title and the rest is the description.{{if .HasCommitLogs}}
 {{.CS}}
 {{.CS}} Changes:
-{{.CS}}{{if .HasCommitLogs}}
-{{.FormattedCommitLogs}}{{end}}{{end}}`
+{{.CS}}
+{{.FormattedCommitLogs}}{{end}}`
 
 type pullRequestMsg struct {
 	InitMsg    string

--- a/fixtures/test_repo.go
+++ b/fixtures/test_repo.go
@@ -59,6 +59,31 @@ func (r *TestRepo) AddRemote(name, url, pushURL string) {
 	}
 }
 
+func (r *TestRepo) AddGithubTemplatesDir() {
+	github_dir := filepath.Join(r.dir, "test.git", ".github")
+	pr_template_path := filepath.Join(github_dir, "PULL_REQUEST_TEMPLATE.md")
+	issue_template_path := filepath.Join(github_dir, "ISSUE_TEMPLATE")
+
+	// Make `.github` dir in root of test repo
+	err := os.MkdirAll(filepath.Dir(issue_template_path), 0771)
+	if err != nil {
+		panic(err)
+	}
+
+	// Switch to the root of the project dir
+	err = os.Chdir(filepath.Join(r.dir, "test.git"))
+	if err != nil {
+		panic(err)
+	}
+
+	content := `Description
+-----------
+[Enter your pull request description here]
+`
+	ioutil.WriteFile(pr_template_path, []byte(content), os.ModePerm)
+	ioutil.WriteFile(issue_template_path, []byte(content), os.ModePerm)
+}
+
 func (r *TestRepo) clone(repo, dir string) error {
 	cmd := cmd.New("git").WithArgs("clone", repo, dir)
 	output, err := cmd.CombinedOutput()

--- a/fixtures/test_repo.go
+++ b/fixtures/test_repo.go
@@ -59,29 +59,14 @@ func (r *TestRepo) AddRemote(name, url, pushURL string) {
 	}
 }
 
-func (r *TestRepo) AddGithubTemplatesDir() {
-	github_dir := filepath.Join(r.dir, "test.git", ".github")
-	pr_template_path := filepath.Join(github_dir, "PULL_REQUEST_TEMPLATE.md")
-	issue_template_path := filepath.Join(github_dir, "ISSUE_TEMPLATE")
-
-	// Make `.github` dir in root of test repo
-	err := os.MkdirAll(filepath.Dir(issue_template_path), 0771)
+func (r *TestRepo) AddFile(filePath string, content string) {
+	path := filepath.Join(r.dir, filePath)
+	err := os.MkdirAll(filepath.Dir(path), 0771)
 	if err != nil {
 		panic(err)
 	}
 
-	// Switch to the root of the project dir
-	err = os.Chdir(filepath.Join(r.dir, "test.git"))
-	if err != nil {
-		panic(err)
-	}
-
-	content := `Description
------------
-[Enter your pull request description here]
-`
-	ioutil.WriteFile(pr_template_path, []byte(content), os.ModePerm)
-	ioutil.WriteFile(issue_template_path, []byte(content), os.ModePerm)
+	ioutil.WriteFile(path, []byte(content), os.ModePerm)
 }
 
 func (r *TestRepo) clone(repo, dir string) error {

--- a/github/template.go
+++ b/github/template.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	pullRequestTempalte = "PULL_REQUEST_TEMPLATE"
-	issueTempalte       = "ISSUE_TEMPLATE"
+	issueTemplate       = "ISSUE_TEMPLATE"
 	githubTemplateDir   = ".github"
 )
 

--- a/github/template.go
+++ b/github/template.go
@@ -10,13 +10,13 @@ import (
 )
 
 const (
-	pullRequestTempalte = "PULL_REQUEST_TEMPLATE"
+	pullRequestTemplate = "PULL_REQUEST_TEMPLATE"
 	issueTemplate       = "ISSUE_TEMPLATE"
 	githubTemplateDir   = ".github"
 )
 
 func GetPullRequestTemplate() string {
-	return getGithubTemplate(pullRequestTempalte)
+	return getGithubTemplate(pullRequestTemplate)
 }
 
 func GetIssueTemplate() string {

--- a/github/template.go
+++ b/github/template.go
@@ -24,7 +24,7 @@ func GetIssueTemplate() string {
 }
 
 func GeneratePRTemplate(defaultMsg string) string {
-	return "\n\n" + GetPullRequestTemplate()
+	return strings.Split(defaultMsg, "\n")[0] + "\n\n" + GetPullRequestTemplate()
 }
 
 func getGithubTemplate(pat string) (body string) {

--- a/github/template.go
+++ b/github/template.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	pullRequestTemplate = "PULL_REQUEST_TEMPLATE"
-	issueTemplate       = "ISSUE_TEMPLATE"
+	pullRequestTemplate = "pull_request_template"
+	issueTemplate       = "issue_template"
 	githubTemplateDir   = ".github"
 )
 
@@ -61,7 +61,11 @@ func getFilePath(dir, pattern string) string {
 
 		if ext := filepath.Ext(fileName); ext == ".md" {
 			path = strings.TrimRight(fileName, ".md")
+		} else if ext == ".txt" {
+			path = strings.TrimRight(fileName, ".txt")
 		}
+
+		path = strings.ToLower(path)
 
 		if ok, _ := filepath.Match(pattern, path); ok {
 			return filepath.Join(dir, fileName)

--- a/github/template.go
+++ b/github/template.go
@@ -20,7 +20,11 @@ func GetPullRequestTemplate() string {
 }
 
 func GetIssueTemplate() string {
-	return getGithubTemplate(issueTempalte)
+	return getGithubTemplate(issueTemplate)
+}
+
+func GeneratePRTemplate(defaultMsg string) string {
+	return "\n\n" + GetPullRequestTemplate()
 }
 
 func getGithubTemplate(pat string) (body string) {

--- a/github/template.go
+++ b/github/template.go
@@ -15,11 +15,11 @@ const (
 	githubTemplateDir   = ".github"
 )
 
-func GetPullRequestTempalte() string {
+func GetPullRequestTemplate() string {
 	return getGithubTemplate(pullRequestTempalte)
 }
 
-func GetIssueTempalte() string {
+func GetIssueTemplate() string {
 	return getGithubTemplate(issueTempalte)
 }
 

--- a/github/template.go
+++ b/github/template.go
@@ -1,0 +1,77 @@
+package github
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/github/hub/utils"
+)
+
+const (
+	pullRequestTempalte = "PULL_REQUEST_TEMPLATE"
+	issueTempalte       = "ISSUE_TEMPLATE"
+	githubTemplateDir   = ".github"
+)
+
+func GetPullRequestTempalte() string {
+	return getGithubTemplate(pullRequestTempalte)
+}
+
+func GetIssueTempalte() string {
+	return getGithubTemplate(issueTempalte)
+}
+
+func getGithubTemplate(pat string) (body string) {
+	var path string
+
+	if _, err := os.Stat(githubTemplateDir); err == nil {
+		if p := getFilePath(githubTemplateDir, pat); p != "" {
+			path = p
+		}
+	}
+
+	if path == "" {
+		if p := getFilePath(".", pat); p != "" {
+			path = p
+		}
+	}
+
+	if path == "" {
+		return
+	}
+
+	body, err := readContentsFromFile(path)
+	utils.Check(err)
+	return
+}
+
+func getFilePath(dir, pattern string) string {
+	files, err := ioutil.ReadDir(dir)
+	utils.Check(err)
+
+	for _, file := range files {
+		fileName := file.Name()
+		path := fileName
+
+		if ext := filepath.Ext(fileName); ext == ".md" {
+			path = strings.TrimRight(fileName, ".md")
+		}
+
+		if ok, _ := filepath.Match(pattern, path); ok {
+			return filepath.Join(dir, fileName)
+		}
+	}
+	return ""
+}
+
+func readContentsFromFile(filename string) (contents string, err error) {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return
+	}
+
+	contents = strings.Replace(string(content), "\r\n", "\n", -1)
+	return
+}

--- a/github/template_test.go
+++ b/github/template_test.go
@@ -42,8 +42,8 @@ func TestGithubTemplate_WithMarkdown(t *testing.T) {
 
 	addGithubTemplates(repo,
 		map[string]string{
-			"prTempalte":    pullRequestTemplate + ".md",
-			"issueTempalte": issueTemplate + ".md",
+			"prTemplate":    pullRequestTemplate + ".md",
+			"issueTemplate": issueTemplate + ".md",
 		})
 
 	assert.Equal(t, prContent, GetPullRequestTemplate())
@@ -76,8 +76,8 @@ func TestGithubTemplate_WithTemplateInGithubDirAndMarkdown(t *testing.T) {
 
 	addGithubTemplates(repo,
 		map[string]string{
-			"prTempalte":    pullRequestTemplate + ".md",
-			"issueTempalte": issueTemplate + ".md",
+			"prTemplate":    pullRequestTemplate + ".md",
+			"issueTemplate": issueTemplate + ".md",
 			"dir":           githubTemplateDir,
 		})
 
@@ -157,12 +157,12 @@ func addGithubTemplates(r *fixtures.TestRepo, config map[string]string) {
 
 	prTemplatePath := filepath.Join(repoDir, pullRequestTemplate)
 	if prTmplPath := config["prTemplate"]; prTmplPath != "" {
-		prTemplatePath = prTmplPath
+		prTemplatePath = filepath.Join(repoDir, prTmplPath)
 	}
 
 	issueTemplatePath := filepath.Join(repoDir, issueTemplate)
 	if issueTmplPath := config["issueTemplate"]; issueTmplPath != "" {
-		issueTemplatePath = issueTmplPath
+		issueTemplatePath = filepath.Join(repoDir, issueTmplPath)
 	}
 
 	r.AddFile(prTemplatePath, prContent)

--- a/github/template_test.go
+++ b/github/template_test.go
@@ -25,3 +25,48 @@ Description
 
 	assert.Equal(t, expectedOutput, GeneratePRTemplate(defaultMessage))
 }
+
+// When a single line commit message is provided, the commit message should
+// encompass the first line, then a empty new line, then the template.
+func TestGeneratePRTemplate_SingleLineDefaultMessage(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	repo.AddGithubTemplatesDir()
+
+	defaultMessage := "Add Pull Request Templates to Hub"
+	expectedOutput := `Add Pull Request Templates to Hub
+
+Description
+-----------
+[Enter your pull request description here]
+`
+
+	assert.Equal(t, expectedOutput, GeneratePRTemplate(defaultMessage))
+}
+
+// When a multi line commit message is provided, the first line of the commit
+// message should be the first line, then a empty new line, then the template.
+//
+// TODO (maybe):  Allow for templates to support auto filling the description
+// section with the rest of the commit message.
+func TestGeneratePRTemplate_MultiLineDefaultMessage(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	repo.AddGithubTemplatesDir()
+
+	defaultMessage := `Add Pull Request Templates to Hub
+
+Allow repo maintainers to set a default template and allow developers to
+continue to use hub!
+`
+	expectedOutput := `Add Pull Request Templates to Hub
+
+Description
+-----------
+[Enter your pull request description here]
+`
+
+	assert.Equal(t, expectedOutput, GeneratePRTemplate(defaultMessage))
+}

--- a/github/template_test.go
+++ b/github/template_test.go
@@ -1,11 +1,89 @@
 package github
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/bmizerany/assert"
 	"github.com/github/hub/fixtures"
 )
+
+var prContent = `Description
+-----------
+[Enter your pull request description here]
+`
+
+var issueContent = `Description
+-----------
+[Enter your issue description here]
+`
+
+func TestGithubTemplate_withoutTemplate(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	assert.Equal(t, "", GetPullRequestTemplate())
+	assert.Equal(t, "", GetIssueTemplate())
+}
+
+func TestGithubTemplate_withInvalidTemplate(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	addGithubTemplates(repo, map[string]string{"dir": "invalidPath"})
+
+	assert.Equal(t, "", GetPullRequestTemplate())
+	assert.Equal(t, "", GetIssueTemplate())
+}
+
+func TestGithubTemplate_WithMarkdown(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	addGithubTemplates(repo,
+		map[string]string{
+			"prTempalte":    pullRequestTemplate + ".md",
+			"issueTempalte": issueTemplate + ".md",
+		})
+
+	assert.Equal(t, prContent, GetPullRequestTemplate())
+	assert.Equal(t, issueContent, GetIssueTemplate())
+}
+
+func TestGithubTemplate_WithTemplateInHome(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	addGithubTemplates(repo, map[string]string{})
+
+	assert.Equal(t, prContent, GetPullRequestTemplate())
+	assert.Equal(t, issueContent, GetIssueTemplate())
+}
+
+func TestGithubTemplate_WithTemplateInGithubDir(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	addGithubTemplates(repo, map[string]string{"dir": githubTemplateDir})
+
+	assert.Equal(t, prContent, GetPullRequestTemplate())
+	assert.Equal(t, issueContent, GetIssueTemplate())
+}
+
+func TestGithubTemplate_WithTemplateInGithubDirAndMarkdown(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	addGithubTemplates(repo,
+		map[string]string{
+			"prTempalte":    pullRequestTemplate + ".md",
+			"issueTempalte": issueTemplate + ".md",
+			"dir":           githubTemplateDir,
+		})
+
+	assert.Equal(t, prContent, GetPullRequestTemplate())
+	assert.Equal(t, issueContent, GetIssueTemplate())
+}
 
 // When no default message is provided, two blank lines should be added
 // (representing the pull request title), and the left should be template.
@@ -13,7 +91,7 @@ func TestGeneratePRTemplate_NoDefaultMessage(t *testing.T) {
 	repo := fixtures.SetupTestRepo()
 	defer repo.TearDown()
 
-	repo.AddGithubTemplatesDir()
+	addGithubTemplates(repo, map[string]string{})
 
 	defaultMessage := ""
 	expectedOutput := `
@@ -32,7 +110,7 @@ func TestGeneratePRTemplate_SingleLineDefaultMessage(t *testing.T) {
 	repo := fixtures.SetupTestRepo()
 	defer repo.TearDown()
 
-	repo.AddGithubTemplatesDir()
+	addGithubTemplates(repo, map[string]string{})
 
 	defaultMessage := "Add Pull Request Templates to Hub"
 	expectedOutput := `Add Pull Request Templates to Hub
@@ -54,7 +132,7 @@ func TestGeneratePRTemplate_MultiLineDefaultMessage(t *testing.T) {
 	repo := fixtures.SetupTestRepo()
 	defer repo.TearDown()
 
-	repo.AddGithubTemplatesDir()
+	addGithubTemplates(repo, map[string]string{})
 
 	defaultMessage := `Add Pull Request Templates to Hub
 
@@ -69,4 +147,24 @@ Description
 `
 
 	assert.Equal(t, expectedOutput, GeneratePRTemplate(defaultMessage))
+}
+
+func addGithubTemplates(r *fixtures.TestRepo, config map[string]string) {
+	repoDir := "test.git"
+	if dir := config["dir"]; dir != "" {
+		repoDir = filepath.Join(repoDir, dir)
+	}
+
+	prTemplatePath := filepath.Join(repoDir, pullRequestTemplate)
+	if prTmplPath := config["prTemplate"]; prTmplPath != "" {
+		prTemplatePath = prTmplPath
+	}
+
+	issueTemplatePath := filepath.Join(repoDir, issueTemplate)
+	if issueTmplPath := config["issueTemplate"]; issueTmplPath != "" {
+		issueTemplatePath = issueTmplPath
+	}
+
+	r.AddFile(prTemplatePath, prContent)
+	r.AddFile(issueTemplatePath, issueContent)
 }

--- a/github/template_test.go
+++ b/github/template_test.go
@@ -1,0 +1,27 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+	"github.com/github/hub/fixtures"
+)
+
+// When no default message is provided, two blank lines should be added
+// (representing the pull request title), and the left should be template.
+func TestGeneratePRTemplate_NoDefaultMessage(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	repo.AddGithubTemplatesDir()
+
+	defaultMessage := ""
+	expectedOutput := `
+
+Description
+-----------
+[Enter your pull request description here]
+`
+
+	assert.Equal(t, expectedOutput, GeneratePRTemplate(defaultMessage))
+}


### PR DESCRIPTION
This pull request includes all the changes from #1145, including changes
made by @ganmacs and @NickLaMuro, with two small additional fixes on top
of those.

The reviewer is encouraged to see the conversation in #1145.

This pull request itself includes changes that

- Allow for hub to populate the EDITOR with pull request and issue
  templates
- Correctly search for such templates, considering things like
  case-insensitivity and file extension. See [the GitHub docs][1] for
  more information.
- Test that the above features work as intended.

Supercedes #1145.
Closes #446, #937, #964, #1118.

[1]: https://help.github.com/articles/helping-people-contribute-to-your-project/