### PR TITLE
Uptade rack to 1.4.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     multi_json (1.10.1)
     multi_test (0.1.1)
     mustache (0.99.4)
-    rack (1.4.1)
+    rack (1.4.6)
     rack-protection (1.2.0)
       rack
     rdiscount (1.6.8)


### PR DESCRIPTION
Rack `1.4.1` is vulnerable to `CVE-2015-3225`, `CVE-2012-6109`, `CVE-2013-0183`, `CVE-2013-0184`, `CVE-2013-0262`, `CVE-2013-0263`.