### PR TITLE
Added release flag to exclude prereleases.

### DIFF
--- a/commands/release.go
+++ b/commands/release.go
@@ -17,7 +17,7 @@ var (
 	cmdRelease = &Command{
 		Run: listReleases,
 		Usage: `
-release [--include-drafts]
+release [--include-drafts, --exclude-prerelease]
 release show <TAG>
 release create [-dp] [-a <FILE>] [-m <MESSAGE>|-F <FILE>] [-c <TARGET>] <TAG>
 release edit [<options>] <TAG>
@@ -29,6 +29,7 @@ release edit [<options>] <TAG>
 With no arguments, shows a list of existing releases.
 
 With '--include-drafts', include draft releases in the listing.
+With '--exclude-prerelease', exclude prerelease releases in the listing.
 
 	* _show_:
 		Show GitHub release notes for <TAG>.
@@ -102,6 +103,7 @@ hub(1), git-tag(1)
 	}
 
 	flagReleaseIncludeDrafts,
+	flagReleaseExcludePrerelease,
 	flagReleaseShowDownloads,
 	flagReleaseDraft,
 	flagReleasePrerelease bool
@@ -115,6 +117,7 @@ hub(1), git-tag(1)
 
 func init() {
 	cmdRelease.Flag.BoolVarP(&flagReleaseIncludeDrafts, "include-drafts", "d", false, "DRAFTS")
+	cmdRelease.Flag.BoolVarP(&flagReleaseExcludePrerelease, "exclude-prerelease", "p", false, "PRERELEASE")
 
 	cmdShowRelease.Flag.BoolVarP(&flagReleaseShowDownloads, "show-downloads", "d", false, "DRAFTS")
 
@@ -155,7 +158,8 @@ func listReleases(cmd *Command, args *Args) {
 		utils.Check(err)
 
 		for _, release := range releases {
-			if !release.Draft || flagReleaseIncludeDrafts {
+			if (!release.Draft || flagReleaseIncludeDrafts) &&
+			   (!release.Prerelease || !flagReleaseExcludePrerelease) {
 				ui.Println(release.TagName)
 			}
 		}

--- a/features/release.feature
+++ b/features/release.feature
@@ -34,6 +34,35 @@ Feature: hub release
       v1.0.2\n
       """
 
+  Scenario: List non-prerelease releases
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/will_paginate/releases') {
+        json [
+          { tag_name: 'v1.2.0',
+            name: 'will_paginate 1.2.0',
+            draft: true,
+            prerelease: false,
+          },
+          { tag_name: 'v1.2.0-pre',
+            name: 'will_paginate 1.2.0-pre',
+            draft: false,
+            prerelease: true,
+          },
+          { tag_name: 'v1.0.2',
+            name: 'will_paginate 1.0.2',
+            draft: false,
+            prerelease: false,
+          },
+        ]
+      }
+      """
+    When I successfully run `hub release --exclude-prerelease`
+    Then the output should contain exactly:
+      """
+      v1.0.2\n
+      """
+
   Scenario: List all releases
     Given the GitHub API server:
       """


### PR DESCRIPTION
`hub release` currently list all non-draft releases, with an optional flag to include drafts. However, there is no way to list only full releases. This adds an `--exclude-prerelease` flag which omits all prerelease release from the output.
