### PR TITLE
Explicitly specify binstub path in scripts/bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -24,7 +24,7 @@ fi
 
 { ruby --version
   bundle install --path vendor/bundle
-  bundle binstub cucumber ronn
+  bundle binstub cucumber ronn --path bin
 } || {
   echo "You need Ruby 1.9 or higher and Bundler to run hub tests" >&2
   STATUS=1


### PR DESCRIPTION
There might be a bundle config that specifies a different path, which
breaks the build. Explicitly specifying the path changes that.