### PR TITLE
add command to list pull requests in the current main project, or optionally main project organisation

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -162,6 +162,7 @@ var helpText = `
 These GitHub commands are provided by hub:
 
    pull-request   Open a pull request on GitHub
+   pull-requests  List open pull requests on the project or organisation on GitHub
    fork           Make a fork of a remote repository on GitHub and add as remote
    create         Create this repository on GitHub and add GitHub as origin
    browse         Open a GitHub page in the default browser

--- a/commands/list_pull_requests.go
+++ b/commands/list_pull_requests.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"github.com/github/hub/github"
+	"github.com/github/hub/utils"
+	"github.com/github/hub/ui"
+	"strings"
+	"strconv"
+	"time"
+	"math"
+	"fmt"
+)
+
+var cmdListPullRequest = &Command{
+	Key:   "list",
+	Run: listPullRequest,
+	Usage: `
+pull-request list [-c] [-o <ORG>]
+`,
+	Long: `List GitHub pull requests.
+
+## Options:
+	-a, --all
+		To list all pull requests for all repositories in the current organisation
+
+	-o, --org <ORG>
+		To list pull requests for all repositories in the given github organisation
+`,
+}
+
+var (
+	flagPullRequestOrganisation string
+	flagPullRequestAll bool
+)
+
+func init() {
+	cmdListPullRequest.Flag.StringVarP(&flagPullRequestOrganisation, "org", "o", "", "ORG")
+	cmdListPullRequest.Flag.BoolVarP(&flagPullRequestAll, "all", "a", false, "ALL")
+
+	cmdPullRequest.Use(cmdListPullRequest)
+}
+
+func listPullRequest(cmd *Command, args *Args) {
+	runInMainOrCurrentProject(func(localRepo *github.GitHubRepo, project *github.Project, gh *github.Client) {
+		organisation := flagPullRequestOrganisation
+		if flagPullRequestAll && len(organisation) == 0 {
+			organisation = project.Owner
+		}
+
+		if len(organisation) == 0 {
+			pullRequests, err := gh.PullRequests(project)
+			utils.Check(err)
+			for _, pr := range pullRequests {
+				url := pr.HTMLURL
+				if flagIssueAssignee == "" ||
+					strings.EqualFold(pr.Assignee.Login, flagIssueAssignee) {
+					ui.Printf("% 7d] %s ( %s ) age: %s\n", pr.Number, pr.Title, url, durationText(pr.CreatedAt))
+				}
+			}
+		} else {
+			ui.Printf("Pull requests for organisation: %s\n", organisation)
+			repos, err := gh.OrgRepositories(organisation)
+			utils.Check(err)
+			maxLen := 1
+			for _, repo := range repos {
+				l := len(repo.Name)
+				if l > maxLen {
+					maxLen = l
+				}
+			}
+			for _, repo := range repos {
+				name := repo.Name
+				repoProject := &github.Project{
+					Owner: organisation,
+					Name: name,
+					Protocol: project.Protocol,
+					Host: project.Host,
+				}
+				pullRequests, err := gh.PullRequests(repoProject)
+				utils.Check(err)
+				for _, pr := range pullRequests {
+					url := pr.HTMLURL
+					if flagIssueAssignee == "" ||
+						strings.EqualFold(pr.Assignee.Login, flagIssueAssignee) {
+						ui.Printf("%" + strconv.Itoa(maxLen) + "s | % 7d] %s ( %s ) age: %s\n", name, pr.Number, pr.Title, url, durationText(pr.CreatedAt))
+					}
+				}
+			}
+		}
+	})
+}
+
+func durationText(t time.Time) string {
+	s := time.Since(t)
+	hours := math.Floor(s.Hours())
+	mins := s.Minutes() - (hours * 60)
+	days := math.Floor(hours / 24)
+	hours = hours - (days * 24)
+	return fmt.Sprintf("%0.0f days %0.0f:%02.1f hours", days, hours, mins)
+}

--- a/commands/pull_requests.go
+++ b/commands/pull_requests.go
@@ -12,10 +12,9 @@ import (
 )
 
 var cmdListPullRequest = &Command{
-	Key:   "list",
 	Run: listPullRequest,
 	Usage: `
-pull-request list [-c] [-o <ORG>]
+pull-requests [-a] [-o <ORG>]
 `,
 	Long: `List GitHub pull requests.
 
@@ -25,6 +24,10 @@ pull-request list [-c] [-o <ORG>]
 
 	-o, --org <ORG>
 		To list pull requests for all repositories in the given github organisation
+
+## See also:
+
+hub(1), hub-pull-request(1), hub-merge(1), hub-checkout(1)
 `,
 }
 
@@ -37,7 +40,7 @@ func init() {
 	cmdListPullRequest.Flag.StringVarP(&flagPullRequestOrganisation, "org", "o", "", "ORG")
 	cmdListPullRequest.Flag.BoolVarP(&flagPullRequestAll, "all", "a", false, "ALL")
 
-	cmdPullRequest.Use(cmdListPullRequest)
+	CmdRunner.Use(cmdListPullRequest)
 }
 
 func listPullRequest(cmd *Command, args *Args) {

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -124,3 +124,20 @@ func runInLocalRepo(fn func(localRepo *github.GitHubRepo, project *github.Projec
 
 	os.Exit(0)
 }
+
+func runInMainOrCurrentProject(fn func(localRepo *github.GitHubRepo, project *github.Project, client *github.Client)) {
+	localRepo, err := github.LocalRepo()
+	utils.Check(err)
+
+	// there may not be a main project so default to current project if not
+	project, err := localRepo.MainProject()
+	if err != nil {
+		project, err = localRepo.CurrentProject()
+	}
+	utils.Check(err)
+
+	client := github.NewClient(project.Host)
+	fn(localRepo, project, client)
+
+	os.Exit(0)
+}

--- a/features/bash_completion.feature
+++ b/features/bash_completion.feature
@@ -9,7 +9,7 @@ Feature: bash tab-completion
     When I type "git pu" and press <Tab>
     Then the command should not expand
     When I press <Tab> again
-    Then the completion menu should offer "pull pull-request push"
+    Then the completion menu should offer "pull pull-request pull-requests push"
 
   Scenario: "ci-" expands to "ci-status"
     When I type "git ci-" and press <Tab>

--- a/github/client.go
+++ b/github/client.go
@@ -218,6 +218,10 @@ func (client *Client) OrgRepositories(owner string) (repos []octokit.Repository,
 		return
 	}
 
+	// lets ensure we get up to 100 results
+	url.RawQuery = "per_page=100"
+
+	// TODO handle pagination!
 	repos, result := api.Repositories(client.requestURL(url)).All()
 	if result.HasError() {
 		err = FormatError("getting repository", result.Err)

--- a/github/client.go
+++ b/github/client.go
@@ -49,6 +49,27 @@ type Client struct {
 	Host *Host
 }
 
+func (client *Client) PullRequests(project *Project) (pullRequests []octokit.PullRequest, err error) {
+	url, err := octokit.PullRequestsURL.Expand(octokit.M{"owner": project.Owner, "repo": project.Name})
+	if err != nil {
+		return
+	}
+	api, err := client.api()
+	if err != nil {
+		err = FormatError("getting issues", err)
+		return
+	}
+
+	pullRequests, result := api.PullRequests(client.requestURL(url)).All()
+	if result.HasError() {
+		err = FormatError("getting issues", result.Err)
+		return
+	}
+
+	return
+}
+
+
 func (client *Client) PullRequest(project *Project, id string) (pr *octokit.PullRequest, err error) {
 	url, err := octokit.PullRequestsURL.Expand(octokit.M{"owner": project.Owner, "repo": project.Name, "number": id})
 	if err != nil {
@@ -179,6 +200,27 @@ func (client *Client) GistPatch(id string) (patch io.ReadCloser, err error) {
 	patch, result := api.Gists(client.requestURL(url)).Raw()
 	if result.HasError() {
 		err = FormatError("getting pull request", result.Err)
+		return
+	}
+
+	return
+}
+
+func (client *Client) OrgRepositories(owner string) (repos []octokit.Repository, err error) {
+	url, err := octokit.OrgRepositoriesURL.Expand(octokit.M{"org": owner})
+	if err != nil {
+		return
+	}
+
+	api, err := client.api()
+	if err != nil {
+		err = FormatError("getting repository", err)
+		return
+	}
+
+	repos, result := api.Repositories(client.requestURL(url)).All()
+	if result.HasError() {
+		err = FormatError("getting repository", result.Err)
 		return
 	}
 


### PR DESCRIPTION
it'd be handy to view all open pull requests on the current main project; or on the organisation of the current project (or a given organisation).

I particularly want this to quickly see what pending PRs are open in an organisation of many projects (its kinda hard to look one by one in the web UI).

This PR fixes issue #1223 

here's an example of it in action - viewing PRs on the current main project (or current if not in a fork)

``` sh
$ hub pull-requests
      3] add integration test and apache snapshot repo ( https://github.com/fabric8-quickstarts/cassandra-client/pull/3 ) age: 2 days 0:28.1 hours
      2] Populate cql ( https://github.com/fabric8-quickstarts/cassandra-client/pull/2 ) age: 8 days 2:13.3 hours
```

Then to see all the PRs in the organisation of the main/current project:

``` sh
$ hub pull-requests -a
Pull requests for organisation: fabric8-quickstarts
            spring-camel |       4] Update pom property versions ( https://github.com/fabric8-quickstarts/spring-camel/pull/4 ) age: 25 days 21:5.6 hours
      spring-boot-webmvc |      11] Update pom property versions ( https://github.com/fabric8-quickstarts/spring-boot-webmvc/pull/11 ) age: 0 days 13:41.4 hours
 spring-boot-camel-teiid |      12] Update pom property versions ( https://github.com/fabric8-quickstarts/spring-boot-camel-teiid/pull/12 ) age: 0 days 12:51.0 hours
 spring-boot-camel-teiid |      11] Update pom property versions ( https://github.com/fabric8-quickstarts/spring-boot-camel-teiid/pull/11 ) age: 0 days 12:59.9 hours
 spring-boot-camel-teiid |      10] Update pom property versions ( https://github.com/fabric8-quickstarts/spring-boot-camel-teiid/pull/10 ) age: 0 days 13:35.5 hours
```

Or to view the PRs in a specific organisation (whatever the current project)

``` sh
$ hub pull-requests -o fabric8io
Pull requests for organisation: fabric8io
                fabric8-docker |      12] configure karaf.name/runtime.id from docker env, and fix users.properties ( https://github.com/fabric8io/fabric8-docker/pull/12 ) age: 693 days 21:19.6 hours
                fabric8-docker |       6] Skeleton for a simple examples/tutorials.  ( https://github.com/fabric8io/fabric8-docker/pull/6 ) age: 870 days 22:44.3 hours
                fabric8-docker |       4] Moved chown to the end of the file to be sure all files created in previ... ( https://github.com/fabric8io/fabric8-docker/pull/4 ) age: 870 days 23:5.9 hours
           docker-maven-plugin |     536] Fixes for stop mojo ( https://github.com/fabric8io/docker-maven-plugin/pull/536 ) age: 0 days 18:18.0 hours
           docker-maven-plugin |     532] Add support for "Docker for Windows" ( https://github.com/fabric8io/docker-maven-plugin/pull/532 ) age: 7 days 20:33.4 hours
           docker-maven-plugin |     531] - parallel StartMojo ( https://github.com/fabric8io/docker-maven-plugin/pull/531 ) age: 10 days 7:30.7 hours
           docker-maven-plugin |     375] #374 Use assembly baseDirectory if it is provided ( https://github.com/fabric8io/docker-maven-plugin/pull/375 ) age: 187 days 11:0.2 hours
        sandbox-fabric8-devops |       7] Minor documentation fix ( https://github.com/fabric8io/sandbox-fabric8-devops/pull/7 ) age: 634 days 6:57.9 hours
                          jube |     294] #275: Just for fun using v2 hawtio console. ( https://github.com/fabric8io/jube/pull/294 ) age: 446 days 18:29.8 hours
             ipaas-quickstarts |    1386] [CD] Update release dependencies ( https://github.com/fabric8io/ipaas-quickstarts/pull/1386 ) age: 0 days 0:53.6 hours
             ipaas-quickstarts |    1098] More work on Vert.x quickstarts ( https://github.com/fabric8io/ipaas-quickstarts/pull/1098 ) age: 213 days 23:12.7 hours
```
