### PR TITLE
CreatePullRequest: expect HTTP 201

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -105,7 +105,7 @@ func (client *Client) CreatePullRequest(project *Project, params map[string]inte
 	}
 
 	res, err := api.PostJSON(fmt.Sprintf("repos/%s/%s/pulls", project.Owner, project.Name), params)
-	if err = checkStatus(200, "creating pull request", res, err); err != nil {
+	if err = checkStatus(201, "creating pull request", res, err); err != nil {
 		if res.StatusCode == 404 {
 			projectUrl := strings.SplitN(project.WebURL("", "", ""), "://", 2)[1]
 			err = fmt.Errorf("%s\nAre you sure that %s exists?", err, projectUrl)


### PR DESCRIPTION
Fixes "Error creating pull request: Created (HTTP 201)" when the pull
request has actually succeeded.

Closes #1226.