### PR TITLE
Reimplement hub checkout to avoid creating unnecessary remotes

### DIFF
--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -92,22 +92,18 @@ func transformCheckoutArgs(args *Args) error {
 	repo, err := github.LocalRepo()
 	utils.Check(err)
 
+	var remoteRepo string
+
 	_, err = repo.RemoteByName(user)
 	if err == nil {
-		// The remote for the head of the PR is already tracked by the current git workdir.
-		args.Before("git", "remote", "set-branches", "--add", user, branch)
-		remoteURL := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, user, branch)
-		args.Before("git", "fetch", user, remoteURL)
-
-		remoteName := fmt.Sprintf("%s/%s", user, branch)
-		replaceCheckoutParam(args, checkoutURL, "--track", "-B", newBranchName, remoteName)
+		remoteRepo = user
 	} else {
-		// Let's fetch the head directly without adding a remote nor tracking.
-		branchMapping := fmt.Sprintf("pull/%s/head:%s", id, newBranchName)
-		args.Before("git", "fetch", url.GitURL("", "", false), branchMapping)
-
-		replaceCheckoutParam(args, checkoutURL, newBranchName)
+		remoteRepo = url.GitURL("", "", false)
 	}
+
+	branchMapping := fmt.Sprintf("pull/%s/head:%s", id, newBranchName)
+	args.Before("git", "fetch", remoteRepo, branchMapping)
+	replaceCheckoutParam(args, checkoutURL, newBranchName)
 
 	return nil
 }

--- a/commands/checkout_test.go
+++ b/commands/checkout_test.go
@@ -9,7 +9,7 @@ import (
 func TestReplaceCheckoutParam(t *testing.T) {
 	checkoutURL := "https://github.com/github/hub/pull/12"
 	args := NewArgs([]string{"checkout", checkoutURL})
-	replaceCheckoutParam(args, checkoutURL, "jingweno", "origin/master")
+	replaceCheckoutParam(args, checkoutURL, "--track", "-B", "jingweno", "origin/master")
 
 	cmd := args.ToCmd()
 	assert.Equal(t, "git checkout --track -B jingweno origin/master", cmd.String())

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -23,8 +23,8 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
-    Then "git remote add -f --no-tags -t fixes mislav git://github.com/mislav/jekyll.git" should be run
-    And "git checkout -f --track -B mislav-fixes mislav/fixes -q" should be run
+    Then "git fetch git://github.com/mojombo/jekyll.git pull/77/head:mislav-fixes" should be run
+    And "git checkout -f mislav-fixes -q" should be run
 
   Scenario: Pull request from a renamed fork
     Given the GitHub API server:
@@ -41,8 +41,8 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77`
-    Then "git remote add -f --no-tags -t fixes mislav git://github.com/mislav/jekyll-blog.git" should be run
-    And "git checkout --track -B mislav-fixes mislav/fixes" should be run
+    Then "git fetch git://github.com/mojombo/jekyll.git pull/77/head:mislav-fixes" should be run
+    And "git checkout mislav-fixes" should be run
 
   Scenario: Custom name for new branch
     Given the GitHub API server:
@@ -59,8 +59,8 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77 fixes-from-mislav`
-    Then "git remote add -f --no-tags -t fixes mislav git://github.com/mislav/jekyll.git" should be run
-    And "git checkout --track -B fixes-from-mislav mislav/fixes" should be run
+    Then "git fetch git://github.com/mojombo/jekyll.git pull/77/head:fixes-from-mislav" should be run
+    And "git checkout fixes-from-mislav" should be run
 
   Scenario: Private pull request
     Given the GitHub API server:
@@ -77,26 +77,8 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
-    Then "git remote add -f --no-tags -t fixes mislav git@github.com:mislav/jekyll.git" should be run
-    And "git checkout -f --track -B mislav-fixes mislav/fixes -q" should be run
-
-  Scenario: Custom name for new branch
-    Given the GitHub API server:
-      """
-      get('/repos/mojombo/jekyll/pulls/77') {
-        json :head => {
-          :ref => "fixes",
-          :repo => {
-            :owner => { :login => "mislav" },
-            :name => "jekyll",
-            :private => false
-          }
-        }
-      }
-      """
-    When I run `hub checkout https://github.com/mojombo/jekyll/pull/77 fixes-from-mislav`
-    Then "git remote add -f --no-tags -t fixes mislav git://github.com/mislav/jekyll.git" should be run
-    And "git checkout --track -B fixes-from-mislav mislav/fixes" should be run
+    Then "git fetch git://github.com/mojombo/jekyll.git pull/77/head:mislav-fixes" should be run
+    And "git checkout -f mislav-fixes -q" should be run
 
   Scenario: Remote for user already exists
     Given the GitHub API server:

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -96,6 +96,5 @@ Feature: hub checkout <PULLREQ-URL>
       """
     And the "mislav" remote has url "git://github.com/mislav/jekyll.git"
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77`
-    Then "git remote set-branches --add mislav fixes" should be run
-    And "git fetch mislav +refs/heads/fixes:refs/remotes/mislav/fixes" should be run
-    And "git checkout --track -B mislav-fixes mislav/fixes" should be run
+    Then "git fetch mislav pull/77/head:mislav-fixes" should be run
+    And "git checkout mislav-fixes" should be run


### PR DESCRIPTION
Update hub checkout not to create any new remotes thus leaving less tracks behind.