### PR TITLE
Checkout no branch

### DIFF
--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -114,6 +114,8 @@ func transformCheckoutArgs(args *Args) error {
 	} else {
 		if newBranchName == "" {
 			newBranchName = fmt.Sprintf("%s-%s", pullRequest.Head.Repo.Owner.Login, pullRequest.Head.Ref)
+		} else if flagCheckoutNoBranch {
+			return fmt.Errorf("Cannot specify a branch name and --no-branch flag")
 		}
 		if flagCheckoutNoBranch {
 			refSpec = fmt.Sprintf("pull/%s/head", id)

--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -107,10 +107,17 @@ func transformCheckoutArgs(args *Args) error {
 	if pullRequest.IsSameRepo() {
 		if newBranchName == "" {
 			newBranchName = pullRequest.Head.Ref
+		} else if flagCheckoutNoBranch {
+			return fmt.Errorf("Cannot specify a branch name and --no-branch flag")
 		}
 		remoteBranch := fmt.Sprintf("%s/%s", remote.Name, pullRequest.Head.Ref)
-		refSpec = fmt.Sprintf("+refs/heads/%s:refs/remotes/%s", pullRequest.Head.Ref, remoteBranch)
-		newArgs = append(newArgs, "-b", newBranchName, "--track", remoteBranch)
+		if flagCheckoutNoBranch {
+			refSpec = fmt.Sprintf("refs/heads/%s", pullRequest.Head.Ref)
+			newArgs = append(newArgs, "FETCH_HEAD")
+		} else {
+			refSpec = fmt.Sprintf("+refs/heads/%s:refs/remotes/%s", pullRequest.Head.Ref, remoteBranch)
+			newArgs = append(newArgs, "-b", newBranchName, "--track", remoteBranch)
+		}
 	} else {
 		if newBranchName == "" {
 			newBranchName = fmt.Sprintf("%s-%s", pullRequest.Head.Repo.Owner.Login, pullRequest.Head.Ref)

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -173,3 +173,51 @@ Feature: hub checkout <PULLREQ-URL>
       """
       Cannot specify a branch name and --no-branch flag\n
       """
+
+  Scenario: Same-repo with --no-branch
+    Given the GitHub API server:
+      """
+      get('/repos/mojombo/jekyll/pulls/77') {
+        json :head => {
+          :ref => "fixes",
+          :repo => {
+            :name => "jekyll",
+            :owner => { :login => "mojombo" },
+          }
+        }, :base => {
+          :repo => {
+            :name => "jekyll",
+            :html_url => "https://github.com/mojombo/jekyll",
+            :owner => { :login => "mojombo" },
+          }
+        }
+      }
+      """
+    When I run `hub checkout --no-branch https://github.com/mojombo/jekyll/pull/77`
+    Then "git fetch origin refs/heads/fixes" should be run
+    And "git checkout FETCH_HEAD" should be run
+
+  Scenario: Same-repo with --no-branch and a branch name
+    Given the GitHub API server:
+      """
+      get('/repos/mojombo/jekyll/pulls/77') {
+        json :head => {
+          :ref => "fixes",
+          :repo => {
+            :name => "jekyll",
+            :owner => { :login => "mojombo" },
+          }
+        }, :base => {
+          :repo => {
+            :name => "jekyll",
+            :html_url => "https://github.com/mojombo/jekyll",
+            :owner => { :login => "mojombo" },
+          }
+        }
+      }
+      """
+    When I run `hub checkout --no-branch https://github.com/mojombo/jekyll/pull/77 mycustombranch`
+    And the stderr should contain exactly:
+      """
+      Cannot specify a branch name and --no-branch flag\n
+      """

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -120,3 +120,28 @@ Feature: hub checkout <PULLREQ-URL>
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77 mycustombranch`
     Then "git fetch origin +refs/heads/fixes:refs/remotes/origin/fixes" should be run
     And "git checkout -b mycustombranch --track origin/fixes" should be run
+
+  Scenario: Checkout a pull request with --no-branch
+    Given the GitHub API server:
+      """
+      get('/repos/mojombo/jekyll/pulls/77') {
+        halt 406 unless request.env['HTTP_ACCEPT'] == 'application/vnd.github.v3+json;charset=utf-8'
+        json :head => {
+          :ref => "fixes",
+          :repo => {
+            :owner => { :login => "mislav" },
+            :name => "jekyll",
+            :private => false
+          }
+        }, :base => {
+          :repo => {
+            :name => 'jekyll',
+            :html_url => 'https://github.com/mojombo/jekyll',
+            :owner => { :login => "mojombo" },
+          }
+        }
+      }
+      """
+    When I run `hub checkout --no-branch https://github.com/mojombo/jekyll/pull/77 -q`
+    Then "git fetch origin pull/77/head" should be run
+    And "git checkout FETCH_HEAD -q" should be run

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -145,3 +145,31 @@ Feature: hub checkout <PULLREQ-URL>
     When I run `hub checkout --no-branch https://github.com/mojombo/jekyll/pull/77 -q`
     Then "git fetch origin pull/77/head" should be run
     And "git checkout FETCH_HEAD -q" should be run
+
+  Scenario: Checkout a pull request with --no-branch and a branch name
+    Given the GitHub API server:
+      """
+      get('/repos/mojombo/jekyll/pulls/77') {
+        halt 406 unless request.env['HTTP_ACCEPT'] == 'application/vnd.github.v3+json;charset=utf-8'
+        json :head => {
+          :ref => "fixes",
+          :repo => {
+            :owner => { :login => "mislav" },
+            :name => "jekyll",
+            :private => false
+          }
+        }, :base => {
+          :repo => {
+            :name => 'jekyll',
+            :html_url => 'https://github.com/mojombo/jekyll',
+            :owner => { :login => "mojombo" },
+          }
+        }
+      }
+      """
+    When I run `hub checkout --no-branch https://github.com/mojombo/jekyll/pull/77 mybranch`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      Cannot specify a branch name and --no-branch flag\n
+      """


### PR DESCRIPTION
Initial draft for the `checkout --no-branch <PULLREQUEST>` as discussed in #1206 