### PR TITLE
Add a flag `-s|--stat` to append a diffstat to pull request message.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,3 +52,6 @@ DEPENDENCIES
   cucumber (~> 1.3.9)
   ronn
   sinatra
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,3 @@ DEPENDENCIES
   cucumber (~> 1.3.9)
   ronn
   sinatra
-
-BUNDLED WITH
-   1.11.2

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -321,7 +321,7 @@ func createPullRequestMessage(base, head, fullBase, fullHead string) (string, er
 		if err != nil {
 			return "", err
 		}
-		defaultMsg = defaultMsg + "\n---\n" + diffstat
+		defaultMsg = defaultMsg + "\n\n---\n" + diffstat
 	}
 	cs := git.CommentChar()
 

--- a/git/git.go
+++ b/git/git.go
@@ -184,6 +184,22 @@ func Show(sha string) (string, error) {
 	return output, err
 }
 
+func DiffStat(sha1, sha2 string) (string, error) {
+	execCmd := cmd.New("git")
+	execCmd.WithArg("diff").WithArg("--no-color")
+	execCmd.WithArg("-M").WithArg("--stat").WithArg("--summary")
+	// `diff a..b` is synonymous to `diff a b`.
+	// But the following line will returns a error without info on stderr:
+	//     &exec.ExitError{ProcessState:(*os.ProcessState)(0x...),
+	//         Stderr:[]uint8(nil)}
+	// execCmd.WithArg("sha1").WithArg("sha2")
+	commits := fmt.Sprintf("%s..%s", sha1, sha2)
+	execCmd.WithArg(commits)
+
+	output, err := execCmd.CombinedOutput()
+	return output, err
+}
+
 func Log(sha1, sha2 string) (string, error) {
 	execCmd := cmd.New("git")
 	execCmd.WithArg("-c").WithArg("log.showSignature=false").WithArg("log").WithArg("--no-color")

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -51,6 +51,18 @@ func TestGitLog(t *testing.T) {
 	assert.NotEqual(t, "", log)
 }
 
+func TestGitDiffStat(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	sha1 := "08f4b7b6513dffc6245857e497cfd6101dc47818"
+	sha2 := "9b5a719a3d76ac9dc2fa635d9b1f34fd73994c06"
+	diffstat, err := DiffStat(sha1, sha2)
+	assert.Equal(t, nil, err)
+	output := " test_file | 1 +\n 1 file changed, 1 insertion(+)\n"
+	assert.Equal(t, output, diffstat)
+}
+
 func TestGitRef(t *testing.T) {
 	repo := fixtures.SetupTestRepo()
 	defer repo.TearDown()


### PR DESCRIPTION
Add a flag `-s|--stat`
to append a diffstat to pull request message.

For MarkDown compatibility, seperate `---` with an empty line.
This avoids `---` being recognized as heading mark.

---

 Gemfile.lock             |  3 ---
 commands/pull_request.go | 15 ++++++++++++++-
 git/git.go               | 16 ++++++++++++++++
 git/git_test.go          | 12 ++++++++++++
 4 files changed, 42 insertions(+), 4 deletions(-)
