### PR TITLE
Reuse existing git remote for PR head in `checkout`

### DIFF
--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/github/hub/git"
 	"github.com/github/hub/github"
 	"github.com/github/hub/utils"
 )
@@ -83,30 +84,41 @@ func transformCheckoutArgs(args *Args) error {
 		return err
 	}
 
-	remote, err := repo.RemoteForRepo(pullRequest.Base.Repo)
+	baseRemote, err := repo.RemoteForRepo(pullRequest.Base.Repo)
 	if err != nil {
 		return err
 	}
 
-	var refSpec string
+	var headRemote *github.Remote
+	if pullRequest.IsSameRepo() {
+		headRemote = baseRemote
+	} else {
+		headRemote, _ = repo.RemoteForRepo(pullRequest.Head.Repo)
+	}
+
 	var newArgs []string
 
-	if pullRequest.IsSameRepo() {
+	if headRemote != nil {
 		if newBranchName == "" {
 			newBranchName = pullRequest.Head.Ref
 		}
-		remoteBranch := fmt.Sprintf("%s/%s", remote.Name, pullRequest.Head.Ref)
-		refSpec = fmt.Sprintf("+refs/heads/%s:refs/remotes/%s", pullRequest.Head.Ref, remoteBranch)
-		newArgs = append(newArgs, "-b", newBranchName, "--track", remoteBranch)
+		remoteBranch := fmt.Sprintf("%s/%s", headRemote.Name, pullRequest.Head.Ref)
+		refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s", pullRequest.Head.Ref, remoteBranch)
+		if git.HasFile("refs", "heads", newBranchName) {
+			newArgs = append(newArgs, newBranchName)
+			args.After("git", "merge", "--ff-only", fmt.Sprintf("refs/remotes/%s", remoteBranch))
+		} else {
+			newArgs = append(newArgs, "-b", newBranchName, "--track", remoteBranch)
+		}
+		args.Before("git", "fetch", headRemote.Name, refSpec)
 	} else {
 		if newBranchName == "" {
 			newBranchName = fmt.Sprintf("%s-%s", pullRequest.Head.Repo.Owner.Login, pullRequest.Head.Ref)
 		}
-		refSpec = fmt.Sprintf("pull/%s/head:%s", id, newBranchName)
+		refSpec := fmt.Sprintf("pull/%s/head:%s", id, newBranchName)
 		newArgs = append(newArgs, newBranchName)
+		args.Before("git", "fetch", baseRemote.Name, refSpec)
 	}
-
-	args.Before("git", "fetch", remote.Name, refSpec)
 	replaceCheckoutParam(args, checkoutURL, newArgs...)
 	return nil
 }

--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -16,8 +16,8 @@ var cmdCheckout = &Command{
 
 ## Examples:
 		$ hub checkout https://github.com/jingweno/gh/pull/73
-		> git remote add -f --no-tags -t feature git://github:com/jingweno/gh.git
-		> git checkout --track -B jingweno-feature jingweno/feature
+		> git fetch origin pull/73/head:jingweno-feature
+		> git checkout jingweno-feature
 
 ## See also:
 

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -120,3 +120,55 @@ Feature: hub checkout <PULLREQ-URL>
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77 mycustombranch`
     Then "git fetch origin +refs/heads/fixes:refs/remotes/origin/fixes" should be run
     And "git checkout -b mycustombranch --track origin/fixes" should be run
+
+  Scenario: Reuse existing remote for head branch
+    Given the GitHub API server:
+      """
+      get('/repos/mojombo/jekyll/pulls/77') {
+        json :head => {
+          :ref => "fixes",
+          :repo => {
+            :owner => { :login => "mislav" },
+            :name => "jekyll",
+            :private => false
+          }
+        }, :base => {
+          :repo => {
+            :name => 'jekyll',
+            :html_url => 'https://github.com/mojombo/jekyll',
+            :owner => { :login => "mojombo" },
+          }
+        }
+      }
+      """
+    And the "mislav" remote has url "git://github.com/mislav/jekyll.git"
+    When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
+    Then "git fetch mislav +refs/heads/fixes:refs/remotes/mislav/fixes" should be run
+    And "git checkout -f -b fixes --track mislav/fixes -q" should be run
+
+  Scenario: Reuse existing remote and branch
+    Given the GitHub API server:
+      """
+      get('/repos/mojombo/jekyll/pulls/77') {
+        json :head => {
+          :ref => "fixes",
+          :repo => {
+            :owner => { :login => "mislav" },
+            :name => "jekyll",
+            :private => false
+          }
+        }, :base => {
+          :repo => {
+            :name => 'jekyll',
+            :html_url => 'https://github.com/mojombo/jekyll',
+            :owner => { :login => "mojombo" },
+          }
+        }
+      }
+      """
+    And the "mislav" remote has url "git://github.com/mislav/jekyll.git"
+    And I am on the "fixes" branch
+    When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
+    Then "git fetch mislav +refs/heads/fixes:refs/remotes/mislav/fixes" should be run
+    And "git checkout -f fixes -q" should be run
+    And "git merge --ff-only refs/remotes/mislav/fixes" should be run


### PR DESCRIPTION
When there is already a git remote for the head repo of a PR to be checked out, fetch the corresponding branch from that remote instead of fetching the special `refs/pull/XY/head` ref.

This sets up a pull/push workflow for branches that the user might have write access to.

Fixes #1238

/cc @blueyed