### PR TITLE
Use --cmd instead of -c to set default filetype for vim

### DIFF
--- a/github/editor.go
+++ b/github/editor.go
@@ -113,7 +113,7 @@ func openTextEditor(program, file string) error {
 	editCmd := cmd.New(program)
 	r := regexp.MustCompile("[mg]?vi[m]$")
 	if r.MatchString(program) {
-		editCmd.WithArg("-c")
+		editCmd.WithArg("--cmd")
 		editCmd.WithArg("set ft=gitcommit tw=0 wrap lbr")
 	}
 	editCmd.WithArg(file)


### PR DESCRIPTION
You are overriding the filetype set by the user using the -c option. This makes
it hard to set a filetype in the vimrc.
