### PR TITLE
Add a --push flag to hub pull-request.

### DIFF
--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -814,9 +814,7 @@ BODY
       """
 
   Scenario: Default message with --push
-    Given the text editor adds:
-      """
-      """
+    Given the git commit editor is "true"
     Given the GitHub API server:
       """
       post('/repos/mislav/coral/pulls') {
@@ -839,7 +837,7 @@ BODY
     And I am on the "master" branch pushed to "origin/master"
     And an empty file named ".git/PULLREQ_EDITMSG"
     When I successfully run `git checkout --quiet -b topic`
-    Given I make a commit with message "Title"
+    Given I make a commit
     When I run `hub pull-request -p`
     Then the stderr should contain "error using text editor for pull request message"
     And the exit status should be 1

--- a/git/git.go
+++ b/git/git.go
@@ -223,6 +223,10 @@ func Log(sha1, sha2 string) (string, error) {
 	return outputs, nil
 }
 
+func Push(remote, source, dest string) error {
+	return Spawn("push", remote, fmt.Sprintf("%s:%s", source, dest))
+}
+
 func Remotes() ([]string, error) {
 	return gitOutput("remote", "-v")
 }

--- a/git/git.go
+++ b/git/git.go
@@ -223,10 +223,6 @@ func Log(sha1, sha2 string) (string, error) {
 	return outputs, nil
 }
 
-func Push(remote, source, dest string) error {
-	return Spawn("push", remote, fmt.Sprintf("%s:%s", source, dest))
-}
-
 func Remotes() ([]string, error) {
 	return gitOutput("remote", "-v")
 }


### PR DESCRIPTION
This removes an extra step from the process of publishing a pull
request. It also gives the user a chance to back out of the entire
process by saving an empty pull request message.