### PR TITLE
Better error message when remote origin is not GitHub

### DIFF
--- a/features/ci_status.feature
+++ b/features/ci_status.feature
@@ -85,7 +85,7 @@ Feature: hub ci-status
   Scenario: Non-GitHub repo
     Given the "origin" remote has url "mygh:Manganeez/repo.git"
     When I run `hub ci-status`
-    Then the stderr should contain "Aborted: the origin remote doesn't point to a GitHub repository.\n"
+    Then the stderr should contain "Aborted: the origin remote doesn't point to a GitHub repository: Invalid GitHub URL: ssh://mygh/Manganeez/repo.git.\n"
     And the exit status should be 1
 
   Scenario: Enterprise CI statuses

--- a/features/compare.feature
+++ b/features/compare.feature
@@ -144,6 +144,6 @@ Feature: hub compare
     Then the stdout should contain exactly ""
     And the stderr should contain exactly:
       """
-      Aborted: the origin remote doesn't point to a GitHub repository.\n
+      Aborted: the origin remote doesn't point to a GitHub repository: Invalid GitHub URL: ssh://git@bitbucket.org/mislav/dotfiles.git.\n
       """
     And the exit status should be 1

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -13,7 +13,7 @@ Feature: hub pull-request
   Scenario: Non-GitHub repo
     Given the "origin" remote has url "mygh:Manganeez/repo.git"
     When I run `hub pull-request`
-    Then the stderr should contain "Aborted: the origin remote doesn't point to a GitHub repository.\n"
+    Then the stderr should contain "Aborted: the origin remote doesn't point to a GitHub repository: Invalid GitHub URL: ssh://mygh/Manganeez/repo.git.\n"
     And the exit status should be 1
 
   Scenario: Create pull request respecting "insteadOf" configuration

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -191,14 +191,14 @@ func (r *GitHubRepo) MainRemote() (remote *Remote, err error) {
 func (r *GitHubRepo) MainProject() (project *Project, err error) {
 	origin, err := r.MainRemote()
 	if err != nil {
-		err = fmt.Errorf("Aborted: the origin remote doesn't point to a GitHub repository.")
+		err = fmt.Errorf("Aborted: the origin remote doesn't point to a GitHub repository: %v.", err)
 
 		return
 	}
 
 	project, err = origin.Project()
 	if err != nil {
-		err = fmt.Errorf("Aborted: the origin remote doesn't point to a GitHub repository.")
+		err = fmt.Errorf("Aborted: the origin remote doesn't point to a GitHub repository: %v.", err)
 	}
 
 	return


### PR DESCRIPTION
Previously the actual error was discarded, though that might
contain useful information.

In my case, for example, the actual origin URL that didn't match was not the
one I expected.