### PR TITLE
don't copy .txt files to man path

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -16,7 +16,7 @@ fi
 prefix="${PREFIX:-$prefix}"
 prefix="${prefix:-/usr/local}"
 
-for src in bin/hub share/man/*/*.{1,txt}; do
+for src in bin/hub share/man/*/*.1; do
   dest="${prefix}/${src}"
   mkdir -p "${dest%/*}"
   [[ $src == share/* ]] && mode="644" || mode=755


### PR DESCRIPTION
on each ``` man hub* ``` commands in the shell, the shell reports
 ``` warning: ignore bogus filename```  for the respective .txt present
 in the man path.

 copying only the man file to the man path solves this issue.