### PR TITLE
Add ability to delete releases

### DIFF
--- a/features/release.feature
+++ b/features/release.feature
@@ -367,6 +367,24 @@ MARKDOWN
           ASSET_TARBALL
           """
 
+  Scenario: Delete a release
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/will_paginate/releases') {
+          json [
+            { url: 'https://api.github.com/repos/mislav/will_paginate/releases/123',
+              tag_name: 'v1.2.0',
+            },
+          ]
+      }
+
+      delete('/repos/mislav/will_paginate/releases/123') {
+        status 204
+      }
+      """
+    When I successfully run `hub release delete v1.2.0`
+    Then there should be no output
+
   Scenario: Enterprise list releases
     Given the "origin" remote has url "git@git.my.org:mislav/will_paginate.git"
     And I am "mislav" on git.my.org with OAuth token "FITOKEN"

--- a/github/client.go
+++ b/github/client.go
@@ -326,6 +326,20 @@ func (client *Client) EditRelease(release *Release, releaseParams map[string]int
 	return
 }
 
+func (client *Client) DeleteRelease(release *Release) (err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	res, err := api.Delete(release.ApiUrl)
+	if err = checkStatus(204, "deleting release", res, err); err != nil {
+		return
+	}
+
+	return
+}
+
 func (client *Client) UploadReleaseAsset(release *Release, filename, label string) (asset *ReleaseAsset, err error) {
 	api, err := client.simpleApi()
 	if err != nil {


### PR DESCRIPTION
To mirror all the other `hub release` commands, allow the user to delete
releases from the command line. The new subcommand takes only one
argument (the tag of the release being deleted).

Fixes #1326