### PR TITLE
Add authentication instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ complement existing completion scripts that ship with git.
 * [hub bash completion](https://github.com/github/hub/blob/master/etc/hub.bash_completion.sh)
 * [hub zsh completion](https://github.com/github/hub/blob/master/etc/hub.zsh_completion)
 
+Authentication
+--------------
+
+Many hub commands must authenticate against GitHub to operate. Often, hub will prompt you for your credentials when they are needed.
+
+The best way to authenticate hub without prompting is to set the environment variable GITHUB_TOKEN to the value of a [personal access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) that you create for this purpose.
+
 Meta
 ----
 


### PR DESCRIPTION
Authentication options are discussed in #491 and #463; it would be good to have some of this information in the README as well.