### PR TITLE
Do not expand aliases which are in-built git and hub commands

### DIFF
--- a/commands/runner.go
+++ b/commands/runner.go
@@ -90,9 +90,8 @@ func (r *Runner) Execute() ExecError {
 	utils.Check(err)
 
 	git.GlobalFlags = args.GlobalFlags // preserve git global flags
-
 	expandAlias(args)
-	
+
 	cmd := r.Lookup(args.Command)
 	if cmd != nil && cmd.Runnable() {
 		execErr := r.Call(cmd, args)

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -90,7 +90,9 @@ func (r *Runner) Execute() ExecError {
 	utils.Check(err)
 
 	git.GlobalFlags = args.GlobalFlags // preserve git global flags
-	expandAlias(args)
+	if !isBuiltInHubCommand(args.Command) {
+		expandAlias(args)
+	}
 
 	cmd := r.Lookup(args.Command)
 	if cmd != nil && cmd.Runnable() {
@@ -164,7 +166,7 @@ func expandAlias(args *Args) {
 	cmd := args.Command
 	expandedCmd, err := git.Alias(cmd)
 
-	if err == nil && expandedCmd != "" && !isBuiltInHubCommand(cmd) && !git.IsBuiltInGitCommand(cmd) {
+	if err == nil && expandedCmd != "" && !git.IsBuiltInGitCommand(cmd) {
 		words, e := splitAliasCmd(expandedCmd)
 		if e == nil {
 			args.Command = words[0]

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
-	"regexp"
 
 	"github.com/github/hub/cmd"
 	"github.com/github/hub/git"
@@ -92,11 +91,8 @@ func (r *Runner) Execute() ExecError {
 
 	git.GlobalFlags = args.GlobalFlags // preserve git global flags
 
-	// Don't expand built in commands : Issue #1305
-	if !isBuiltInCommand(args.Command) {
-		expandAlias(args)
-	}
-
+	expandAlias(args)
+	
 	cmd := r.Lookup(args.Command)
 	if cmd != nil && cmd.Runnable() {
 		execErr := r.Call(cmd, args)
@@ -165,21 +161,26 @@ func executeCommands(cmds []*cmd.Cmd, execFinal bool) error {
 	return nil
 }
 
-func isBuiltInCommand(command string) bool {
-	builtInCommands := getListOfBuiltInCommands()
-	return builtInCommands[command]
-}
-
 func expandAlias(args *Args) {
 	cmd := args.Command
 	expandedCmd, err := git.Alias(cmd)
-	if err == nil && expandedCmd != "" {
+
+	if err == nil && expandedCmd != "" && !isBuiltInHubCommand(cmd) && !git.IsBuiltInGitCommand(cmd) {
 		words, e := splitAliasCmd(expandedCmd)
 		if e == nil {
 			args.Command = words[0]
 			args.PrependParams(words[1:]...)
 		}
 	}
+}
+
+func isBuiltInHubCommand(command string) bool {
+	for hubCommand, _ := range CmdRunner.All() {
+		if hubCommand == command {
+			return true
+		}
+	}
+	return false
 }
 
 func splitAliasCmd(cmd string) ([]string, error) {
@@ -197,27 +198,4 @@ func splitAliasCmd(cmd string) ([]string, error) {
 	}
 
 	return words, nil
-}
-
-func getListOfBuiltInCommands() map[string]bool {
-	gitHelpOutput, _ := cmd.New("git help -a").CombinedOutput()
-	builtInCommands := parseGitHelpOutput(gitHelpOutput)
-	for hubCommand, _ := range CmdRunner.All() {
-		builtInCommands[hubCommand] = true
-	}
-	return builtInCommands
-}
-
-func parseGitHelpOutput(gitHelpOutput string) map[string]bool {
-	builtInCommands := make(map[string]bool)
-	re := regexp.MustCompile(`(?m)^  ([a-z- 0-9]+)`)
-	for _, commands := range re.FindAllString(gitHelpOutput, -1) {
-		for _, command := range strings.Split(commands, " ") {
-			trimmedCommand := strings.Trim(command, " ")
-			if trimmedCommand != "" {
-				builtInCommands[trimmedCommand] = true
-			}
-		}
-	}
-	return builtInCommands
 }

--- a/features/ci_status.feature
+++ b/features/ci_status.feature
@@ -96,3 +96,11 @@ Feature: hub ci-status
     Given the remote commit state of "git.my.org/michiels/pencilbox" "the_sha" is "success"
     When I successfully run `hub ci-status the_sha`
     Then the output should contain exactly "success\n"
+
+  Scenario: If alias named ci-status exists, it should not be expanded.
+    Given there is a commit named "the_sha"
+    Given the remote commit state of "michiels/pencilbox" "the_sha" is "success"
+    When I successfully run `git config --global alias.ci-status "ci-status -v"`
+    When I run `hub ci-status the_sha`
+    Then the output should contain exactly "success\n"
+    And the exit status should be 0

--- a/features/clone.feature
+++ b/features/clone.feature
@@ -286,17 +286,3 @@ Feature: hub clone
     When I successfully run `hub clone rtomayko/ronn`
     Then it should clone "git://github.com/RTomayko/ronin.git"
     And there should be no output
-
-  Scenario: If alias named clone exists, it should not be expanded.
-      Given the GitHub API server:
-        """
-        get('/repos/rtomayko/ronn') {
-          json :private => false,
-               :name => 'ronn', :owner => { :login => 'rtomayko' },
-               :permissions => { :push => false }
-        }
-        """
-      When I successfully run `git config --global alias.clone "clone -v"`
-      When I successfully run `hub clone rtomayko/ronn`
-      Then it should clone "git://github.com/rtomayko/ronn.git"
-      And there should be no output

--- a/features/clone.feature
+++ b/features/clone.feature
@@ -286,3 +286,17 @@ Feature: hub clone
     When I successfully run `hub clone rtomayko/ronn`
     Then it should clone "git://github.com/RTomayko/ronin.git"
     And there should be no output
+
+  Scenario: If alias named clone exists, it should not be expanded.
+      Given the GitHub API server:
+        """
+        get('/repos/rtomayko/ronn') {
+          json :private => false,
+               :name => 'ronn', :owner => { :login => 'rtomayko' },
+               :permissions => { :push => false }
+        }
+        """
+      When I successfully run `git config --global alias.clone "clone -v"`
+      When I successfully run `hub clone rtomayko/ronn`
+      Then it should clone "git://github.com/rtomayko/ronn.git"
+      And there should be no output

--- a/features/git_compatibility.feature
+++ b/features/git_compatibility.feature
@@ -1,13 +1,7 @@
 Feature: git-hub compatibility
   Scenario: If alias named branch exists, it should not be expanded.
     Given I am in "git://github.com/rtomayko/ronn.git" git repo
-    And I am "mislav" on github.com with OAuth token "OTOKEN"
-    And the default branch for "origin" is "develop"
-    And I am on the "develop" branch with upstream "origin/develop"
+    And the default branch for "origin" is "master"
     When I successfully run `git config --global alias.branch "branch -a"`
     When I run `hub branch`
-    Then the stdout should contain exactly:
-      """
-      * develop
-        master\n
-      """
+    Then the stdout should contain exactly "* master\n"

--- a/features/git_compatibility.feature
+++ b/features/git_compatibility.feature
@@ -1,0 +1,13 @@
+Feature: git-hub compatibility
+Scenario: If alias named branch exists, it should not be expanded.
+  Given I am in "git://github.com/rtomayko/ronn.git" git repo
+  And I am "mislav" on github.com with OAuth token "OTOKEN"
+  Given the default branch for "origin" is "develop"
+  And I am on the "develop" branch with upstream "origin/develop"
+  When I successfully run `git config --global alias.branch "branch -a"`
+  When I run `hub branch`
+  Then the stdout should contain exactly:
+    """
+    * develop
+      master\n
+    """

--- a/features/git_compatibility.feature
+++ b/features/git_compatibility.feature
@@ -1,13 +1,13 @@
 Feature: git-hub compatibility
-Scenario: If alias named branch exists, it should not be expanded.
-  Given I am in "git://github.com/rtomayko/ronn.git" git repo
-  And I am "mislav" on github.com with OAuth token "OTOKEN"
-  Given the default branch for "origin" is "develop"
-  And I am on the "develop" branch with upstream "origin/develop"
-  When I successfully run `git config --global alias.branch "branch -a"`
-  When I run `hub branch`
-  Then the stdout should contain exactly:
-    """
-    * develop
-      master\n
-    """
+  Scenario: If alias named branch exists, it should not be expanded.
+    Given I am in "git://github.com/rtomayko/ronn.git" git repo
+    And I am "mislav" on github.com with OAuth token "OTOKEN"
+    And the default branch for "origin" is "develop"
+    And I am on the "develop" branch with upstream "origin/develop"
+    When I successfully run `git config --global alias.branch "branch -a"`
+    When I run `hub branch`
+    Then the stdout should contain exactly:
+      """
+      * develop
+        master\n
+      """

--- a/git/git.go
+++ b/git/git.go
@@ -304,8 +304,8 @@ func LocalBranches() ([]string, error) {
 	lines, err := gitOutput("branch", "--list")
 	if err == nil {
 		for i, line := range lines {
-			lines[i] = strings.TrimLeft(line, "* ")
-			lines[i] = strings.TrimLeft(lines[i], " ")
+			lines[i] = strings.TrimPrefix(line, "* ")
+			lines[i] = strings.TrimPrefix(lines[i], "  ")
 		}
 	}
 	return lines, err
@@ -316,23 +316,7 @@ func gitOutput(input ...string) (outputs []string, err error) {
 
 	out, err := cmd.CombinedOutput()
 	for _, line := range strings.Split(out, "\n") {
-		//line = strings.TrimSpace(line)
-		//fmt.Println("FFF %s", line, strings.TrimSpace(line) != "")
 		if strings.TrimSpace(line) != "" {
-			//fmt.Println("Line %s", line, strings.TrimSpace(line))
-			outputs = append(outputs, string(line))
-		}
-	}
-
-	return outputs, err
-}
-
-func gitOutputWithNoTrim(input ...string) (outputs []string, err error) {
-	cmd := gitCmd(input...)
-
-	out, err := cmd.CombinedOutput()
-	for _, line := range strings.Split(out, "\n") {
-		if line != "" {
 			outputs = append(outputs, string(line))
 		}
 	}
@@ -357,7 +341,7 @@ func gitCmd(args ...string) *cmd.Cmd {
 func IsBuiltInGitCommand(command string) bool {
 	helpCommandOutput, err := gitOutput("help", "-a")
 	if err != nil {
-		fmt.Errorf("Unable to run git %s", err)
+		fmt.Errorf("Unable to get git commands")
 	}
 	for _, helpCommandOutputLine := range helpCommandOutput {
 		if strings.HasPrefix(helpCommandOutputLine, "  ") {

--- a/git/git.go
+++ b/git/git.go
@@ -341,7 +341,7 @@ func gitCmd(args ...string) *cmd.Cmd {
 func IsBuiltInGitCommand(command string) bool {
 	helpCommandOutput, err := gitOutput("help", "-a")
 	if err != nil {
-		fmt.Errorf("Unable to get git commands")
+		return false
 	}
 	for _, helpCommandOutputLine := range helpCommandOutput {
 		if strings.HasPrefix(helpCommandOutputLine, "  ") {


### PR DESCRIPTION
Issue #1305

Initial version for the fix. I think it is a bit computation for every command. Will be glad to get any comment for any possible optimization. 

One possible optimization is we check for alias first and if we find it, before expanding, we check if it is in-built command.

```
func expandAlias(args *Args) {
	cmd := args.Command
	expandedCmd, err := git.Alias(cmd)
	// Don't expand built in commands : Issue #1305
	
	if err == nil && expandedCmd != "" && !isBuiltInCommand(cmd) {
		words, e := splitAliasCmd(expandedCmd)
		if e == nil {
			args.Command = words[0]
			args.PrependParams(words[1:]...)
		}
	}
}
```