### PR TITLE
Add --set-upstream to git push commands.

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -247,7 +247,7 @@ func pullRequest(cmd *Command, args *Args) {
 		if args.Noop {
 			args.Before(fmt.Sprintf("Would push to %s/%s", remote.Name, head), "")
 		} else {
-			err = git.Spawn("push", remote.Name, fmt.Sprintf("HEAD:%s", head))
+			err = git.Spawn("push", "--set-upstream", remote.Name, fmt.Sprintf("HEAD:%s", head))
 			utils.Check(err)
 		}
 	}

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -841,7 +841,7 @@ BODY
     Given I make a commit with message "The commit I never pushed"
     When I successfully run `hub pull-request -p`
     Then the output should contain exactly "the://url\n"
-    And "git push origin HEAD:topic" should be run
+    And "git push --set-upstream origin HEAD:topic" should be run
 
   Scenario: Text editor fails with --push
     Given the text editor exits with error status
@@ -853,7 +853,7 @@ BODY
     Then the stderr should contain "error using text editor for pull request message"
     And the exit status should be 1
     And the file ".git/PULLREQ_EDITMSG" should not exist
-    And "git push origin HEAD:topic" should not be run
+    And "git push --set-upstream origin HEAD:topic" should not be run
 
   Scenario: Automatically retry when --push resulted in 422
     Given The default aruba timeout is 7 seconds


### PR DESCRIPTION
This ensures that a branch pushed using "hub pull-request" has its
upstream branch set to the target of the push.