### PR TITLE
Set merge configuration on checkout.

### DIFF
--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -127,7 +127,12 @@ func transformCheckoutArgs(args *Args) error {
 		remote := baseRemote.Name
 		mergeRef := ref
 		if pullRequest.MaintainerCanModify && pullRequest.Head.Repo != nil {
-			remote = pullRequest.Head.Repo.SshUrl
+			project, err := github.NewProjectFromRepo(pullRequest.Head.Repo)
+			if err != nil {
+				return err
+			}
+
+			remote = project.GitURL("", "", true)
 			mergeRef = fmt.Sprintf("refs/heads/%s", pullRequest.Head.Ref)
 		}
 		args.Before("git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), remote)

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -25,11 +25,13 @@ Feature: hub checkout <PULLREQ-URL>
             :html_url => 'https://github.com/mojombo/jekyll',
             :owner => { :login => "mojombo" },
           }
-        }
+        }, :maintainer_can_modify => false
       }
       """
     When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
     Then "git fetch origin refs/pull/77/head:mislav-fixes" should be run
+    And "git config branch.mislav-fixes.remote origin" should be run
+    And "git config branch.mislav-fixes.merge refs/pull/77/head" should be run
     And "git checkout -f mislav-fixes -q" should be run
 
   Scenario: No matching remotes for pull request base
@@ -68,11 +70,13 @@ Feature: hub checkout <PULLREQ-URL>
             :html_url => 'https://github.com/mojombo/jekyll',
             :owner => { :login => "mojombo" },
           }
-        }
+        }, :maintainer_can_modify => false
       }
       """
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77 fixes-from-mislav`
     Then "git fetch origin refs/pull/77/head:fixes-from-mislav" should be run
+    And "git config branch.fixes-from-mislav.remote origin" should be run
+    And "git config branch.fixes-from-mislav.merge refs/pull/77/head" should be run
     And "git checkout fixes-from-mislav" should be run
 
   Scenario: Same-repo
@@ -139,6 +143,8 @@ Feature: hub checkout <PULLREQ-URL>
       """
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77`
     Then "git fetch origin refs/pull/77/head:pr-77" should be run
+    And "git config branch.pr-77.remote origin" should be run
+    And "git config branch.pr-77.merge refs/pull/77/head" should be run
     And "git checkout pr-77" should be run
 
   Scenario: Reuse existing remote for head branch
@@ -192,3 +198,31 @@ Feature: hub checkout <PULLREQ-URL>
     Then "git fetch mislav +refs/heads/fixes:refs/remotes/mislav/fixes" should be run
     And "git checkout -f fixes -q" should be run
     And "git merge --ff-only refs/remotes/mislav/fixes" should be run
+
+  Scenario: Modifiable fork
+    Given the GitHub API server:
+      """
+      get('/repos/mojombo/jekyll/pulls/77') {
+        halt 406 unless request.env['HTTP_ACCEPT'] == 'application/vnd.github.v3+json;charset=utf-8'
+        json :head => {
+          :ref => "fixes",
+          :repo => {
+            :owner => { :login => "mislav" },
+            :name => "jekyll",
+            :ssh_url => "git@github.com:mislav/jekyll.git",
+            :private => false
+          },
+        }, :base => {
+          :repo => {
+            :name => 'jekyll',
+            :html_url => 'https://github.com/mojombo/jekyll',
+            :owner => { :login => "mojombo" },
+          }
+        }, :maintainer_can_modify => true
+      }
+      """
+    When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
+    Then "git fetch origin refs/pull/77/head:mislav-fixes" should be run
+    And "git config branch.mislav-fixes.remote git@github.com:mislav/jekyll.git" should be run
+    And "git config branch.mislav-fixes.merge refs/heads/fixes" should be run
+    And "git checkout -f mislav-fixes -q" should be run

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -208,6 +208,14 @@ Then(/^the "([^"]*)" submodule url should be "([^"]*)"$/) do |name, url|
   expect(found).to eql(url)
 end
 
+Then(/^"([^"]*)" should merge "([^"]*)" from remote "([^"]*)"$/) do |name, merge, remote|
+  actual_remote = run_silent %(git config --get-all branch.#{name}.remote)
+  expect(remote).to eql(actual_remote)
+
+  actual_merge = run_silent %(git config --get-all branch.#{name}.merge)
+  expect(merge).to eql(actual_merge)
+end
+
 Then(/^there should be no "([^"]*)" remote$/) do |remote_name|
   remotes = run_silent('git remote').split("\n")
   expect(remotes).to_not include(remote_name)

--- a/features/support/fakebin/git
+++ b/features/support/fakebin/git
@@ -4,7 +4,7 @@
 # asserted that they ran.
 
 command="$1"
-[ "$command" = "config" ] || echo git "$@" >> "$HOME"/.history
+[ "$command" = "config" -a "${#@}" -le 2 ] || echo git "$@" >> "$HOME"/.history
 
 case "$command" in
   "clone" | "fetch" | "pull" | "push" )

--- a/features/support/fakebin/git
+++ b/features/support/fakebin/git
@@ -4,7 +4,7 @@
 # asserted that they ran.
 
 command="$1"
-[ "$command" = "config" -a "${#@}" -le 2 ] || echo git "$@" >> "$HOME"/.history
+[ "$command" = "config" ] || echo git "$@" >> "$HOME"/.history
 
 case "$command" in
   "clone" | "fetch" | "pull" | "push" )

--- a/github/client.go
+++ b/github/client.go
@@ -91,12 +91,13 @@ func (client *Client) PullRequestPatch(project *Project, id string) (patch io.Re
 }
 
 type PullRequest struct {
-	ApiUrl  string           `json:"url"`
-	Number  int              `json:"number"`
-	HtmlUrl string           `json:"html_url"`
-	Title   string           `json:"title"`
-	Head    *PullRequestSpec `json:"head"`
-	Base    *PullRequestSpec `json:"base"`
+	ApiUrl    	    string           `json:"url"`
+	Number    	    int              `json:"number"`
+	HtmlUrl   	    string           `json:"html_url"`
+	Title     	    string           `json:"title"`
+	MaintainerCanModify bool             `json:"maintainer_can_modify"`
+	Head      	    *PullRequestSpec `json:"head"`
+	Base      	    *PullRequestSpec `json:"base"`
 }
 
 type PullRequestSpec struct {
@@ -410,6 +411,7 @@ type Repository struct {
 	Private     bool                   `json:"private"`
 	Permissions *RepositoryPermissions `json:"permissions"`
 	HtmlUrl     string                 `json:"html_url"`
+	SshUrl      string                 `json:"ssh_url"`
 }
 
 type RepositoryPermissions struct {

--- a/github/client.go
+++ b/github/client.go
@@ -411,7 +411,6 @@ type Repository struct {
 	Private     bool                   `json:"private"`
 	Permissions *RepositoryPermissions `json:"permissions"`
 	HtmlUrl     string                 `json:"html_url"`
-	SshUrl      string                 `json:"ssh_url"`
 }
 
 type RepositoryPermissions struct {

--- a/github/project.go
+++ b/github/project.go
@@ -103,6 +103,16 @@ func preferredProtocol() string {
 	return userProtocol
 }
 
+func NewProjectFromRepo(repo *Repository) (p *Project, err error) {
+	url, err := url.Parse(repo.HtmlUrl)
+	if err != nil {
+		return
+	}
+
+	p, err = NewProjectFromURL(url)
+	return
+}
+
 func NewProjectFromURL(url *url.URL) (p *Project, err error) {
 	if !knownGitHubHostsInclude(url.Host) {
 		err = &GithubHostError{url}


### PR DESCRIPTION
When checking out a pull request that doesn't match an existing remote,
this sets the branch's remote and merge configuration fields. If the
pull request is modifiable by the maintainer, it uses the SSH URL to
that you can push to the pull request.