### PR TITLE
Add option to show pull requests again

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -131,8 +131,8 @@ With no arguments, show a list of open issues.
 	-^ --sort-ascending
 		Sort by ascending dates instead of descending.
 
-	--show-pulls
-		Show pull requests as well.
+	--include-pulls
+		Include pull requests as well as issues.
 `,
 	}
 
@@ -159,7 +159,7 @@ With no arguments, show a list of open issues.
 	flagIssueCopy,
 	flagIssueBrowse,
 	flagIssueSortAscending bool
-	flagIssueShowPulls bool
+	flagIssueIncludePulls bool
 
 	flagIssueMilestone uint64
 
@@ -187,7 +187,7 @@ func init() {
 	cmdIssue.Flag.StringVarP(&flagIssueSince, "since", "d", "", "DATE")
 	cmdIssue.Flag.StringVarP(&flagIssueSort, "sort", "o", "created", "SORT_KEY")
 	cmdIssue.Flag.BoolVarP(&flagIssueSortAscending, "sort-ascending", "^", false, "SORT_KEY")
-	cmdIssue.Flag.BoolVarP(&flagIssueShowPulls, "show-pulls", "", false, "SHOW_PULLS")
+	cmdIssue.Flag.BoolVarP(&flagIssueIncludePulls, "include-pulls", "", false, "INCLUDE_PULLS")
 
 	cmdIssue.Use(cmdCreateIssue)
 	CmdRunner.Use(cmdIssue)
@@ -245,7 +245,7 @@ func listIssues(cmd *Command, args *Args) {
 
 		colorize := ui.IsTerminal(os.Stdout)
 		for _, issue := range issues {
-			if !flagIssueShowPulls && issue.PullRequest != nil {
+			if !flagIssueIncludePulls && issue.PullRequest != nil {
 				continue
 			}
 

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -130,6 +130,9 @@ With no arguments, show a list of open issues.
 
 	-^ --sort-ascending
 		Sort by ascending dates instead of descending.
+
+	--show-pulls
+		Show pull requests as well.
 `,
 	}
 
@@ -156,6 +159,7 @@ With no arguments, show a list of open issues.
 	flagIssueCopy,
 	flagIssueBrowse,
 	flagIssueSortAscending bool
+	flagIssueShowPulls bool
 
 	flagIssueMilestone uint64
 
@@ -183,6 +187,7 @@ func init() {
 	cmdIssue.Flag.StringVarP(&flagIssueSince, "since", "d", "", "DATE")
 	cmdIssue.Flag.StringVarP(&flagIssueSort, "sort", "o", "created", "SORT_KEY")
 	cmdIssue.Flag.BoolVarP(&flagIssueSortAscending, "sort-ascending", "^", false, "SORT_KEY")
+	cmdIssue.Flag.BoolVarP(&flagIssueShowPulls, "show-pulls", "", false, "SHOW_PULLS")
 
 	cmdIssue.Use(cmdCreateIssue)
 	CmdRunner.Use(cmdIssue)
@@ -240,7 +245,7 @@ func listIssues(cmd *Command, args *Args) {
 
 		colorize := ui.IsTerminal(os.Stdout)
 		for _, issue := range issues {
-			if issue.PullRequest != nil {
+			if !flagIssueShowPulls && issue.PullRequest != nil {
 				continue
 			}
 

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -12,6 +12,12 @@ Feature: hub issue
              :direction => nil
 
       json [
+        { :number => 999,
+          :title => "First pull",
+          :state => "open",
+          :user => { :login => "octocat" },
+          :pull_request => { },
+        },
         { :number => 102,
           :title => "First issue",
           :state => "open",
@@ -28,6 +34,42 @@ Feature: hub issue
     When I successfully run `hub issue -a Cornwe19`
     Then the output should contain exactly:
       """
+          #102  First issue
+           #13  Second issue\n
+      """
+
+  Scenario: Fetch issues and pull requests
+    Given the GitHub API server:
+    """
+    get('/repos/github/hub/issues') {
+      assert :assignee => "Cornwe19",
+             :sort => nil,
+             :direction => nil
+
+      json [
+        { :number => 999,
+          :title => "First pull",
+          :state => "open",
+          :user => { :login => "octocat" },
+          :pull_request => { },
+        },
+        { :number => 102,
+          :title => "First issue",
+          :state => "open",
+          :user => { :login => "octocat" },
+        },
+        { :number => 13,
+          :title => "Second issue",
+          :state => "open",
+          :user => { :login => "octocat" },
+        },
+      ]
+    }
+    """
+    When I successfully run `hub issue -a Cornwe19 --include-pulls`
+    Then the output should contain exactly:
+      """
+          #999  First pull
           #102  First issue
            #13  Second issue\n
       """


### PR DESCRIPTION
This change adds a long-form flag `--show-pulls` to `hub issue` that directs hub to include pull requests in the issue listing.  The default value is false; the default behavior does not change.

Temporary fix until a better abstraction for pull requests can be designed in #1303.

Related: vermiculus/magithub#44