### PR TITLE
fork: Add --remote-name option

### DIFF
--- a/commands/fork.go
+++ b/commands/fork.go
@@ -70,7 +70,7 @@ func fork(cmd *Command, args *Args) {
 	if err != nil {
 		originRemote, err = localRepo.RemoteByName("upstream")
 		if err != nil {
-			utils.Check(errors.New("Error creating fork: No git remote with name origin or upstream"))
+			utils.Check(errors.New("Error creating fork: No origin git remote found"))
 		}
 	}
 

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -27,18 +27,14 @@ Feature: hub fork
   Scenario: Fork the repository with new remote name specified
     Given the GitHub API server:
       """
-      before {
-        halt 400 unless request.env['HTTP_X_ORIGINAL_SCHEME'] == 'https'
-        halt 401 unless request.env['HTTP_AUTHORIZATION'] == 'token OTOKEN'
-      }
-      get('/repos/mislav/dotfiles', :host_name => 'api.github.com') { 404 }
-      post('/repos/evilchelu/dotfiles/forks', :host_name => 'api.github.com') {
+      get('/repos/mislav/dotfiles') { 404 }
+      post('/repos/evilchelu/dotfiles/forks') {
         assert :organization => nil
         status 202
         json :name => 'dotfiles', :owner => { :login => 'mislav' }
       }
       """
-    And I run `git remote rename origin upstream`
+    And I successfully run `git remote rename origin upstream`
     When I successfully run `hub fork --remote-name=origin`
     Then the output should contain exactly "new remote: origin\n"
     And "git remote add -f origin git://github.com/evilchelu/dotfiles.git" should be run

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -175,7 +175,7 @@ Scenario: Related fork already exists
     Then the exit status should be 1
     And the stderr should contain exactly:
       """
-      Error creating fork: No git remote with name origin or upstream\n
+      Error creating fork: No origin git remote found\n
       """
     And there should be no "origin" remote
 

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -154,7 +154,7 @@ Scenario: Related fork already exists
     Then the exit status should be 1
     And the stderr should contain exactly:
       """
-      Error creating fork: No git remote with name origin\n
+      Error creating fork: No git remote with name origin or upstream\n
       """
     And there should be no "origin" remote
 


### PR DESCRIPTION
Allows the user to choose the remote name for their fork instead of
always using their GitHub username. This is useful for workflows where
folks name the remote for their private fork origin `origin` and
the upstream repo remote is named `upstream`. We happen to use this
workflow at work, because it makes the remote names more predictable and
easy to manage (you always push your new commits to `origin` rather than
a remote name that is dependent on your username).

I also made a small change to allow `hub fork` to not fail if there is no
remote named `origin` but there **is** a remote named `upstream`.

```
$ hub clone --origin=upstream github/hub
Cloning into 'hub'...
remote: Counting objects: 13748, done.
remote: Total 13748 (delta 0), reused 0 (delta 0), pack-reused 13747
Receiving objects: 100% (13748/13748), 3.66 MiB | 2.44 MiB/s, done.
Resolving deltas: 100% (8677/8677), done.
Checking out files: 100% (388/388), done.

$ cd hub

$ git remote -v
upstream	git://github.com/github/hub.git (fetch)
upstream	git://github.com/github/hub.git (push)

$ hub fork --remote-name=origin
Updating origin
From git://github.com/github/hub
 * [new branch]      1.11-stable     -> origin/1.11-stable
 * [new branch]      1.12-stable     -> origin/1.12-stable
 * [new branch]      2.2-stable      -> origin/2.2-stable
 * [new branch]      code-coverage   -> origin/code-coverage
 * [new branch]      gh-pages        -> origin/gh-pages
 * [new branch]      master          -> origin/master
 * [new branch]      travis-packages -> origin/travis-packages
new remote: origin

$ git remote -v
origin	git@github.com:msabramo/hub.git (fetch)
origin	git@github.com:msabramo/hub.git (push)
upstream	git://github.com/github/hub.git (fetch)
upstream	git://github.com/github/hub.git (push)
```