### PR TITLE
Add Fedora Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ git version 1.7.6
 hub version 2.2.0
 ```
 
+#### Fedora Linux
+
+On Fedora you can install `hub` through DNF:
+
+``` sh
+$ sudo dnf install hub
+$ hub version
+git version 2.9.3
+hub version 2.2.9
+```
+
 #### Standalone
 
 `hub` can be easily installed as an executable. Download the latest


### PR DESCRIPTION
The latest hub version is available in Fedora's official repositories: https://admin.fedoraproject.org/pkgdb/package/rpms/hub/