### PR TITLE
Add a link to the workaround for SSO with GHE

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,6 +382,12 @@ $ git <strong>pull-request -F prepared-message.md | pbcopy</strong>
 <span class="comment"># push to multiple remotes</span>
 $ git <strong>push production,staging</strong>
 </pre>
+
+<p>
+If your organization is using GitHub Enterprise with their own SSO system, you will need to
+add some <a href="https://github.com/github/hub/issues/826">additional configuration</a> to
+hub before use.
+</p>
 </section>
 
 <p class=footer>


### PR DESCRIPTION
While a more permanent solution is being developed, link to the
workaround so that people can continue to use hub in their GHE
environments.

Related-Bug: #826
Related-Bug: #384