### PR TITLE
Remove trailing slashes from the $TMPDIR variable

### DIFF
--- a/script/build
+++ b/script/build
@@ -14,9 +14,8 @@ windows=
 
 setup_gopath() {
   TMPDIR="${LOCALAPPDATA:-$TMPDIR}"
-  MY_TMPDIR=${TMPDIR:-/tmp}
-  # TMPDIR may or may not have had a trailing slash.
-  TMP_GOPATH="${MY_TMPDIR%/}/go"
+  TMPDIR=${TMPDIR:-/tmp}
+  TMP_GOPATH="${TMPDIR%/}/go"
   TMP_SELF="${TMP_GOPATH}/src/github.com/github/hub"
 
   if [ -n "$windows" ]; then

--- a/script/build
+++ b/script/build
@@ -14,7 +14,9 @@ windows=
 
 setup_gopath() {
   TMPDIR="${LOCALAPPDATA:-$TMPDIR}"
-  TMP_GOPATH="${TMPDIR:-/tmp}/go"
+  MY_TMPDIR=${TMPDIR:-/tmp}
+  # TMPDIR may or may not have had a trailing slash.
+  TMP_GOPATH="${MY_TMPDIR%/}/go"
   TMP_SELF="${TMP_GOPATH}/src/github.com/github/hub"
 
   if [ -n "$windows" ]; then

--- a/script/ruby-test
+++ b/script/ruby-test
@@ -2,9 +2,8 @@
 set -e
 
 STATUS=0
-warnings_dir="${TMPDIR:-/tmp}"
-# TMPDIR may or may not have had a trailing slash.
-warnings="${warnings_dir%/}/gh-warnings.$$"
+TMPDIR="${TMPDIR:-/tmp}"
+warnings="${TMPDIR%/}/gh-warnings.$$"
 
 run() {
   # Save warnings on stderr to a separate file

--- a/script/ruby-test
+++ b/script/ruby-test
@@ -2,7 +2,9 @@
 set -e
 
 STATUS=0
-warnings="${TMPDIR:-/tmp}/gh-warnings.$$"
+warnings_dir="${TMPDIR:-/tmp}"
+# TMPDIR may or may not have had a trailing slash.
+warnings="${warnings_dir%/}/gh-warnings.$$"
 
 run() {
   # Save warnings on stderr to a separate file


### PR DESCRIPTION
This is helpful for when TMPDIR already has a trailing slash. We can't
be sure that it will on all operating systems, but this will remove it
if it is there.