### PR TITLE
Allow the unsorted expansion for the fish shell

### DIFF
--- a/features/fish_completion.feature
+++ b/features/fish_completion.feature
@@ -8,7 +8,7 @@ Feature: fish tab-completion
     When I type "git pu" and press <Tab>
     Then the command should not expand
     When I press <Tab> again
-    Then the completion menu should offer "pull push pull-request"
+    Then the completion menu should offer "pull push pull-request" unsorted
 
   Scenario: "ci-" expands to "ci-status"
     When I type "git ci-" and press <Tab>


### PR DESCRIPTION
Before this change, the `pu` would sometimes expand to `pull
pull-request push` if the order isn't important, we should take this
fix.

However, if the order is important, we should probably switch the
expectation such that the options are presented alphabetically as
observed.