### PR TITLE
Fix bash completion test on MacOS X

### DIFF
--- a/features/support/completion.rb
+++ b/features/support/completion.rb
@@ -241,7 +241,7 @@ Given(/^I'm using ((?:zsh|git)-distributed) base git completions$/) do |type|
       end
     end
     if 'bash' == shell
-      unless git_bash_completion = git_distributed_bash_completion.call
+      unless git_distributed_bash_completion.call
         raise "git-distributed bash completion wasn't found. Completion won't work."
       end
     end

--- a/features/support/completion.rb
+++ b/features/support/completion.rb
@@ -29,13 +29,15 @@ git_prefix = lambda {
 }
 
 git_distributed_zsh_completion = lambda {
-  [ git_prefix.call + 'share/git-core/contrib/completion/git-completion.zsh',
+  [ git_prefix.call + 'contrib/completion/git-completion.zsh',
+    git_prefix.call + 'share/git-core/contrib/completion/git-completion.zsh',
     git_prefix.call + 'share/zsh/site-functions/_git',
   ].detect {|p| p.exist? }
 }
 
 git_distributed_bash_completion = lambda {
-  [ git_prefix.call + 'share/git-core/contrib/completion/git-completion.bash',
+  [ git_prefix.call + 'contrib/completion/git-completion.bash',
+    git_prefix.call + 'share/git-core/contrib/completion/git-completion.bash',
     git_prefix.call + 'share/git-core/git-completion.bash',
     git_prefix.call + 'etc/bash_completion.d/git-completion.bash',
     Pathname.new('/etc/bash_completion.d/git'),
@@ -236,6 +238,11 @@ Given(/^I'm using ((?:zsh|git)-distributed) base git completions$/) do |type|
         link_completion.call(git_distributed_bash_completion.call, 'git-completion.bash')
       else
         warn "warning: git-distributed zsh completion wasn't found; using zsh-distributed instead"
+      end
+    end
+    if 'bash' == shell
+      unless git_bash_completion = git_distributed_bash_completion.call
+        raise "git-distributed bash completion wasn't found. Completion won't work."
       end
     end
   else


### PR DESCRIPTION
However my git installation was run, it installed the
git-completion.{bash,zsh} scripts under
"${GIT_PREFIX}/contrib/completion/" instead of any of the paths that
this test case was expecting.

To make matters worse, the only way to know that this was the problem
was that each scenaro failed with a message about timing out while
waiting for completion to happen in tmux. Just in case there are
other paths out there where the git-distributed completion scripts
may live, I've also added some detection logic to raise an exception
during the "Given" clause of the scenario if we cannot find the
git-distributed bash completion scripts in any of the places we're
looking for them. This would have made it a lot easier to diagonse
the failures.