### PR TITLE
Allow use of gio instead of xdg-open

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,25 +27,27 @@ func ConcatPaths(paths ...string) string {
 
 func BrowserLauncher() ([]string, error) {
 	browser := os.Getenv("BROWSER")
+	args := ""
 	if browser == "" {
-		browser = searchBrowserLauncher(runtime.GOOS)
+		browser, args = searchBrowserLauncher(runtime.GOOS)
 	}
 
 	if browser == "" {
 		return nil, errors.New("Please set $BROWSER to a web launcher")
 	}
 
-	return strings.Split(browser, " "), nil
+	return strings.Split(browser+" "+args, " "), nil
 }
 
-func searchBrowserLauncher(goos string) (browser string) {
+func searchBrowserLauncher(goos string) (browser string, args string) {
+	args = ""
 	switch goos {
 	case "darwin":
 		browser = "open"
 	case "windows":
 		browser = "cmd /c start"
 	default:
-		candidates := []string{"xdg-open", "cygstart", "x-www-browser", "firefox",
+		candidates := []string{"gio", "xdg-open", "cygstart", "x-www-browser", "firefox",
 			"opera", "mozilla", "netscape"}
 		for _, b := range candidates {
 			path, err := exec.LookPath(b)
@@ -56,7 +58,11 @@ func searchBrowserLauncher(goos string) (browser string) {
 		}
 	}
 
-	return browser
+	if strings.Contains(browser, "gio") {
+		args = "open"
+	}
+
+	return browser, args
 }
 
 func CommandPath(cmd string) (string, error) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -6,11 +6,13 @@ import (
 )
 
 func TestSearchBrowserLauncher(t *testing.T) {
-	browser := searchBrowserLauncher("darwin")
+	browser, args := searchBrowserLauncher("darwin")
 	assert.Equal(t, "open", browser)
+	assert.Equal(t, "", args)
 
-	browser = searchBrowserLauncher("windows")
+	browser, args = searchBrowserLauncher("windows")
 	assert.Equal(t, "cmd /c start", browser)
+	assert.Equal(t, "", args)
 }
 
 func TestConcatPaths(t *testing.T) {


### PR DESCRIPTION
Closes #1473.

This is a little messy, but gio requires the `open` argument to it, so you need to pass it back, but the launcher checks the paths, so you can't put `gio open` into the list of browsers, and even if you could, you're stripping the spaces out when you return it, so it would get lost as well.

Happy for feedback/direction on how to make this better.