### PR TITLE
reset-console

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -14,8 +14,11 @@ import (
 )
 
 type Cmd struct {
-	Name string
-	Args []string
+	Name   string
+	Args   []string
+	Stdin  *os.File
+	Stdout *os.File
+	Stderr *os.File
 }
 
 func (cmd Cmd) String() string {
@@ -63,9 +66,9 @@ func (cmd *Cmd) Run() error {
 func (cmd *Cmd) Spawn() error {
 	verboseLog(cmd)
 	c := exec.Command(cmd.Name, cmd.Args...)
-	c.Stdin = os.Stdin
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	c.Stdin = cmd.Stdin
+	c.Stdout = cmd.Stdout
+	c.Stderr = cmd.Stderr
 
 	return c.Run()
 }
@@ -98,7 +101,7 @@ func New(cmd string) *Cmd {
 	for _, arg := range cmds[1:] {
 		args = append(args, arg)
 	}
-	return &Cmd{Name: name, Args: args}
+	return &Cmd{Name: name, Args: args, Stdin: os.Stdin, Stdout: os.Stdout, Stderr: os.Stderr}
 }
 
 func NewWithArray(cmd []string) *Cmd {

--- a/github/editor.go
+++ b/github/editor.go
@@ -118,7 +118,7 @@ func openTextEditor(program, file string) error {
 	}
 	editCmd.WithArg(file)
 	// Reattach stdin to the console before opening the editor
-	resetConsole()
+	setConsole(editCmd)
 
 	return editCmd.Spawn()
 }

--- a/github/editor.go
+++ b/github/editor.go
@@ -117,6 +117,8 @@ func openTextEditor(program, file string) error {
 		editCmd.WithArg("set ft=gitcommit tw=0 wrap lbr")
 	}
 	editCmd.WithArg(file)
+	// Reattach stdin to the console before opening the editor
+	resetConsole()
 
 	return editCmd.Spawn()
 }

--- a/github/reset_console.go
+++ b/github/reset_console.go
@@ -2,12 +2,15 @@
 package github
 
 import (
-	"syscall"
+	"os"
+
+	"github.com/github/hub/cmd"
 )
 
-func resetConsole() {
-	fd, err := syscall.Open("/dev/tty", syscall.O_RDONLY, 0660)
+func setConsole(cmd *cmd.Cmd) {
+
+	stdin, err := os.OpenFile("/dev/tty", os.O_RDONLY, 0660)
 	if err == nil {
-		syscall.Dup2(fd, syscall.Stdin)
+		cmd.Stdin = stdin
 	}
 }

--- a/github/reset_console.go
+++ b/github/reset_console.go
@@ -1,0 +1,13 @@
+// +build  !windows
+package github
+
+import (
+	"syscall"
+)
+
+func resetConsole() {
+	fd, err := syscall.Open("/dev/tty", syscall.O_RDONLY, 0660)
+	if err == nil {
+		syscall.Dup2(fd, syscall.Stdin)
+	}
+}

--- a/github/reset_console_windows.go
+++ b/github/reset_console_windows.go
@@ -2,5 +2,5 @@
 package commands
 
 // This does nothing on windows
-func resetConsole() {
+func setConsole(cmd *cmd.Cmd) {
 }

--- a/github/reset_console_windows.go
+++ b/github/reset_console_windows.go
@@ -1,0 +1,6 @@
+// +build  windows
+package commands
+
+// This does nothing on windows
+func resetConsole() {
+}


### PR DESCRIPTION
This pull request resets stdin to be read from the current console on unix based system.

To avoid the vim error 'Vim: Warning: Input is not from a terminal'

When reading in the pull request message from stdin and editing it afterwards.

For example the following command will no longer causing issues for a terminal (Which is the command I used to create this pull request)

```
(git rev-parse --abbrev-ref HEAD 2>/dev/null;(git diff --no-color -M --patch-with-stat  github/master...HEAD | perl -pi -e's/^/#/') )  | hub pull-request -b github:master -F - --edit
```

Fixes #1481