### PR TITLE
[WIP] Adding 'git pull-request —show' to list the URL(s) for existing PRs

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -91,6 +91,7 @@ var (
 	flagPullRequestCopy,
 	flagPullRequestEdit,
 	flagPullRequestPush,
+	flagPullRequestShow,
 	flagPullRequestForce bool
 
 	flagPullRequestMilestone uint64
@@ -109,6 +110,7 @@ func init() {
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestMessage, "message", "m", "", "MESSAGE")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestEdit, "edit", "e", false, "EDIT")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestPush, "push", "p", false, "PUSH")
+	cmdPullRequest.Flag.BoolVarP(&flagPullRequestShow, "show", "s", false, "SHOW")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestForce, "force", "f", false, "FORCE")
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestFile, "file", "F", "", "FILE")
 	cmdPullRequest.Flag.VarP(&flagPullRequestAssignees, "assign", "a", "USERS")
@@ -183,6 +185,18 @@ func pullRequest(cmd *Command, args *Args) {
 		} else {
 			head = trackedBranch.ShortName()
 		}
+	}
+
+	if flagPullRequestShow {
+		pullRequests, err := client.GetPullRequestUrlsForHead(headProject, head)
+		utils.Check(err)
+
+		for _, pr := range pullRequests {
+			ui.Println(pr.HtmlUrl)
+		}
+
+		args.NoForward()
+		return
 	}
 
 	if headRepo, err := client.Repository(headProject); err == nil {

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -179,6 +179,7 @@ func pullRequest(cmd *Command, args *Args) {
 		}
 	}
 
+	filterParams := map[string]interface{}{}
 	if head == "" {
 		if trackedBranch == nil {
 			head = currentBranch.ShortName()
@@ -188,7 +189,8 @@ func pullRequest(cmd *Command, args *Args) {
 	}
 
 	if flagPullRequestShow {
-		pullRequests, err := client.GetPullRequestUrlsForHead(headProject, head)
+		filterParams["head"] = fmt.Sprintf("%s:%s", headProject.Owner, head)
+		pullRequests, err := client.FetchPullRequests(headProject, filterParams)
 		utils.Check(err)
 
 		for _, pr := range pullRequests {

--- a/github/client.go
+++ b/github/client.go
@@ -134,6 +134,23 @@ func (client *Client) CreatePullRequest(project *Project, params map[string]inte
 	return
 }
 
+func (client *Client) GetPullRequestUrlsForHead(headProject *Project, branch string) (pr []PullRequest, err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	res, err := api.Get(fmt.Sprintf("repos/%s/%s/pulls?head=%s:%s", headProject.Owner, headProject.Name, headProject.Owner, branch))
+	if err = checkStatus(200, "getting pull request", res, err); err != nil {
+		return
+	}
+
+	pr = []PullRequest{}
+	err = res.Unmarshal(&pr)
+
+	return
+}
+
 func (client *Client) RequestReview(project *Project, prNumber int, params map[string]interface{}) (err error) {
 	api, err := client.simpleApi()
 	if err != nil {


### PR DESCRIPTION
Adding a new switch to the `pull-request` command to show the URL, if the PR already exists (helps solve #897, #1107 and #1451)
This is a prerequisite for other features, such as #867

Keeping WIP because I want to add tests for this.