### PR TITLE
Fix editor behavior when commentchar=auto

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -367,7 +367,7 @@ func createIssue(cmd *Command, args *Args) {
 		title, body, editor, err = readMsgFromFile(flagIssueFile, flagIssueEdit, "ISSUE", "issue")
 		utils.Check(err)
 	} else {
-		cs := git.CommentChar()
+		cs := git.CommentCharNoAuto()
 		message := strings.Replace(fmt.Sprintf(`
 # Creating an issue for %s
 #

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -387,7 +387,24 @@ func createPullRequestMessage(base, head, fullBase, fullHead string) (string, er
 		}
 	}
 
+
 	cs := git.CommentChar()
+	if cs == "auto" {
+		chars := "#;@!$%^&|:"
+		for _, element := range chars {
+			for _, line := range strings.Split(defaultMsg, "\n"){
+
+				if line != "" && line[0] != byte(element){
+					cs = string(element)
+					break
+				}
+
+				// If comment char not found, just leave char as "auto".
+			}
+
+		}
+		git.SetCommentCharForEditor(cs)
+	}
 
 	return renderPullRequestTpl(defaultMsg, cs, fullBase, fullHead, commitLogs)
 }

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -387,26 +387,28 @@ func createPullRequestMessage(base, head, fullBase, fullHead string) (string, er
 		}
 	}
 
-
-	cs := git.CommentChar()
-	if cs == "auto" {
-		chars := "#;@!$%^&|:"
-		for _, element := range chars {
-			for _, line := range strings.Split(defaultMsg, "\n"){
-
-				if line != "" && line[0] != byte(element){
-					cs = string(element)
-					break
-				}
-
-				// If comment char not found, just leave char as "auto".
-			}
-
-		}
-		git.SetCommentCharForEditor(cs)
-	}
+	cs := chooseCommentChar(defaultMsg)
+	git.SetCommentCharForEditor(cs)
 
 	return renderPullRequestTpl(defaultMsg, cs, fullBase, fullHead, commitLogs)
+}
+
+func chooseCommentChar(defaultMsg string) string {
+	cs := git.CommentChar()
+	if(cs != "auto"){
+		return cs
+	}
+	chars := "#;@!$%^&|:"
+	charLoop: for _, element := range chars {
+		for _, line := range strings.Split(defaultMsg, "\n") {
+			if line != "" && line[0] == byte(element){
+				continue charLoop
+			}
+		}
+		return string(element)
+	}
+	// If comment char not found, just leave char as "auto". TODO: Instead, we could fail hard?
+	return "auto"
 }
 
 func parsePullRequestProject(context *github.Project, s string) (p *github.Project, ref string) {

--- a/commands/release.go
+++ b/commands/release.go
@@ -307,7 +307,7 @@ func createRelease(cmd *Command, args *Args) {
 		title, body, editor, err = readMsgFromFile(flagReleaseFile, flagReleaseEdit, "RELEASE", "release")
 		utils.Check(err)
 	} else {
-		cs := git.CommentChar()
+		cs := git.CommentCharNoAuto()
 		message, err := renderReleaseTpl("Creating", cs, tagName, project.String(), flagReleaseCommitish)
 		utils.Check(err)
 
@@ -398,7 +398,7 @@ func editRelease(cmd *Command, args *Args) {
 			utils.Check(fmt.Errorf("Aborting editing due to empty release title"))
 		}
 	} else {
-		cs := git.CommentChar()
+		cs := git.CommentCharNoAuto()
 		message, err := renderReleaseTpl("Editing", cs, tagName, project.String(), commitish)
 		utils.Check(err)
 

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -265,6 +265,30 @@ Feature: hub issue
       https://github.com/github/hub/issues/1337\n
       """
 
+   Scenario: Create an issue with commentchar=auto
+      Given the git commit editor is "vim"
+      Given git "core.commentchar" is set to "auto"
+       Given the text editor adds:
+       """
+       auto this should work
+       """
+       Given the GitHub API server:
+         """
+         post('/repos/github/hub/issues') {
+           assert :title => "auto this should work",
+                  :body => "",
+                  :labels => :no
+
+           status 201
+           json :html_url => "https://github.com/github/hub/issues/1337"
+         }
+         """
+       When I successfully run `hub issue create`
+       Then the output should contain exactly:
+         """
+         https://github.com/github/hub/issues/1337\n
+         """
+
   Scenario: Create an issue and open in browser
     Given the GitHub API server:
       """

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -291,7 +291,7 @@ BODY
          # Body starts with #.
          """
         And the "topic" branch is pushed to "origin/topic"
-        When I successfully run `hub pull-request`
+        When I successfully run `hub pull-request`  
         Then the output should contain exactly "the://url\n"
 
 

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -267,6 +267,34 @@ BODY
     When I successfully run `hub pull-request`
     Then the output should contain exactly "the://url\n"
 
+     
+     Scenario: Text editor with commentchar=auto
+        Given git "core.commentchar" is set to "auto" 
+        Given the text editor adds:
+          """
+          """
+        Given the GitHub API server:
+          """
+          post('/repos/mislav/coral/pulls') {
+            assert :title => 'auto Title start with auto.',
+                  :body => '# Body starts with #.'
+            status 201
+            json :html_url => "the://url"
+          }
+          """
+        Given I am on the "master" branch pushed to "origin/master"
+        When I successfully run `git checkout --quiet -b topic`
+        Given I make a commit with message:
+         """
+         auto Title start with auto.
+
+         # Body starts with #.
+         """
+        And the "topic" branch is pushed to "origin/topic"
+        When I successfully run `hub pull-request`
+        Then the output should contain exactly "the://url\n"
+
+
   Scenario: Failed pull request preserves previous message
     Given the text editor adds:
       """

--- a/git/git.go
+++ b/git/git.go
@@ -14,9 +14,6 @@ var GlobalFlags []string
 
 var commentCharForEditor string
 
-func SetCommentCharForEditor(char string){
-	commentCharForEditor = char
-}
 
 func Version() (string, error) {
 	output, err := gitOutput("version")
@@ -200,17 +197,42 @@ func (r *Range) IsAncestor() bool {
 }
 
 func CommentChar() string {
-	if (commentCharForEditor != ""){
-		return commentCharForEditor;
-	}
 
 	char, err := Config("core.commentchar")
 	if err != nil {
 		char = "#"
 	}
 
+
 	return char
 }
+
+func CommentCharNoAuto() string {
+	cs := CommentChar()
+	if cs == "auto" {
+		return "#"
+	}
+	return cs;
+}
+
+func CommentCharForEditor() string {
+
+	cs := CommentChar()
+
+	if(cs == "auto") {
+		if (commentCharForEditor != "") {
+			return commentCharForEditor;
+		} else {
+			return "#";
+		}
+	}
+	return cs;
+}
+
+func SetCommentCharForEditor(char string){
+	commentCharForEditor = char
+}
+
 
 func Show(sha string) (string, error) {
 	cmd := cmd.New("git")

--- a/git/git.go
+++ b/git/git.go
@@ -12,6 +12,12 @@ import (
 
 var GlobalFlags []string
 
+var commentCharForEditor string
+
+func SetCommentCharForEditor(char string){
+	commentCharForEditor = char
+}
+
 func Version() (string, error) {
 	output, err := gitOutput("version")
 	if err == nil {
@@ -169,6 +175,7 @@ func RefList(a, b string) ([]string, error) {
 	return output, nil
 }
 
+
 func NewRange(a, b string) (*Range, error) {
 	output, err := gitOutput("rev-parse", "-q", a, b)
 	if err != nil {
@@ -193,6 +200,10 @@ func (r *Range) IsAncestor() bool {
 }
 
 func CommentChar() string {
+	if (commentCharForEditor != ""){
+		return commentCharForEditor;
+	}
+
 	char, err := Config("core.commentchar")
 	if err != nil {
 		char = "#"

--- a/github/editor.go
+++ b/github/editor.go
@@ -26,7 +26,7 @@ func NewEditor(filePrefix, topic, message string) (editor *Editor, err error) {
 		return
 	}
 
-	cs := git.CommentChar()
+	cs := git.CommentCharForEditor()
 
 	editor = &Editor{
 		Program:    program,


### PR DESCRIPTION
Fixes #1512.

I didn't write a test for whether the feature works for releases; all that's changed is using # rather than auto, which doesn't seem very important.

There is also the extreme possibility that every candidate comment character is already in the message. In this case, i just use "auto", but I'm not sure if this is right.

I've not coded in Go before, so there might be issues with code organization?