### PR TITLE
Pass file descriptors to cmd.NewWithArray

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -105,7 +105,7 @@ func New(cmd string) *Cmd {
 }
 
 func NewWithArray(cmd []string) *Cmd {
-	return &Cmd{Name: cmd[0], Args: cmd[1:]}
+	return &Cmd{Name: cmd[0], Args: cmd[1:], Stdin: os.Stdin, Stdout: os.Stdout, Stderr: os.Stderr}
 }
 
 func verboseLog(cmd *Cmd) {


### PR DESCRIPTION
This fixes a change in the behavior of hub console output introduced in d937d287037b9a24022e16337ea5e06ffdc726a.

That commit changed the way file descriptors are passed around so that commands created by `cmd.NewWithArray` have nil stdin, stdout, and stderr. I believe not passing file descriptors to the function was an oversight.

 An example of a resultant change in behavior is that the `hub fork` command will error-out with code 128 when the forked repo and remote already exist, but will print no error message. Before d937d287037b9a24022e16337ea5e06ffdc726a, `hub fork` prints the normal error message in this case. I noticed this from the discussion in #1499.


Am I correct in thinking that this is a bug?