### PR TITLE
Make fork command idempotent

### DIFF
--- a/commands/fork.go
+++ b/commands/fork.go
@@ -6,7 +6,6 @@ import (
 	"github.com/github/hub/github"
 	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
-	"github.com/github/hub/git"
 )
 
 var cmdFork = &Command{
@@ -109,11 +108,13 @@ func fork(cmd *Command, args *Args) {
 
 		// Check to see if the remote already exists and points to the fork.
 		currentRemote, err := localRepo.RemoteByName(newRemoteName)
-		if (err == nil) {
-
-			parsedURL, err := git.ParseURL(url)
-			if err == nil && parsedURL.String() == currentRemote.URL.String(){
-				return // Already forked, nothing to do.
+		if err == nil {
+			currentProject, err := currentRemote.Project()
+			if err == nil {
+				if currentProject.SameAs(forkProject){
+					ui.Printf("existing remote: %s\n", newRemoteName)
+					return
+				}
 			}
 		}
 

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -7,7 +7,6 @@ import (
 	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 	"github.com/github/hub/git"
-
 )
 
 var cmdFork = &Command{
@@ -51,7 +50,6 @@ func init() {
 
 	CmdRunner.Use(cmdFork)
 }
-
 
 func fork(cmd *Command, args *Args) {
 	localRepo, err := github.LocalRepo()

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -164,22 +164,20 @@ Scenario: Related fork already exists
      Then the exit status should be 0
      And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
 
-   Scenario: Related fork and related remote, but with differing protocol, already exist
-       Given the "mislav" remote has url "https://github.com/mislav/dotfiles.git"
-       Given the GitHub API server:
-       """
-         get('/repos/mislav/dotfiles') {
-               json :parent => { :html_url => 'https://github.com/EvilChelu/Dotfiles' }
-             }
-       """
-       When I run `hub fork`
-       Then the exit status should be 128
-	   And the stderr should contain exactly:
-		 """
-		 fatal: remote mislav already exists.\n
-		 """
-
-
+  Scenario: Related fork and related remote, but with differing protocol, already exist
+      Given the "mislav" remote has url "https://github.com/mislav/dotfiles.git"
+      Given the GitHub API server:
+      """
+        get('/repos/mislav/dotfiles') {
+              json :parent => { :html_url => 'https://github.com/EvilChelu/Dotfiles' }
+            }
+      """
+      When I run `hub fork`
+      Then the exit status should be 128
+      And the stderr should contain exactly:
+      """
+      fatal: remote mislav already exists.\n
+      """
 
   Scenario: Invalid OAuth token
     Given the GitHub API server:

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -162,6 +162,10 @@ Scenario: Related fork already exists
      """
      When I run `hub fork`
      Then the exit status should be 0
+     And the stdout should contain exactly:
+     """
+     existing remote: mislav\n
+     """
      And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
 
   Scenario: Related fork and related remote, but with differing protocol, already exist
@@ -173,11 +177,7 @@ Scenario: Related fork already exists
             }
       """
       When I run `hub fork`
-      Then the exit status should be 128
-      And the stderr should contain exactly:
-      """
-      fatal: remote mislav already exists.\n
-      """
+      Then the exit status should be 0
 
   Scenario: Invalid OAuth token
     Given the GitHub API server:

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -152,6 +152,19 @@ Scenario: Related fork already exists
       """
     And the url for "mislav" should be "git@github.com:mislav/unrelated.git"
 
+ Scenario: Related fork and origin already exist
+     Given the "mislav" remote has url "git@github.com:mislav/dotfiles.git"
+     Given the GitHub API server:
+     """
+       get('/repos/mislav/dotfiles') {
+             json :parent => { :html_url => 'https://github.com/EvilChelu/Dotfiles' }
+           }
+     """
+     When I run `hub fork`
+     Then the exit status should be 0
+     And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
+
+
   Scenario: Invalid OAuth token
     Given the GitHub API server:
       """

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -152,7 +152,7 @@ Scenario: Related fork already exists
       """
     And the url for "mislav" should be "git@github.com:mislav/unrelated.git"
 
- Scenario: Related fork and origin already exist
+ Scenario: Related fork and related remote already exist
      Given the "mislav" remote has url "git@github.com:mislav/dotfiles.git"
      Given the GitHub API server:
      """

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -121,7 +121,7 @@ Feature: hub fork
       """
     And there should be no "mislav" remote
 
-Scenario: Related fork already exists
+  Scenario: Related fork already exists
     Given the GitHub API server:
       """
       get('/repos/mislav/dotfiles') {
@@ -133,16 +133,16 @@ Scenario: Related fork already exists
     And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
 
 
- Scenario: Unrelated remote already exists
+  Scenario: Unrelated remote already exists
     Given the "mislav" remote has url "git@github.com:mislav/unrelated.git"
     Given the GitHub API server:
       """
-        get('/repos/mislav/dotfiles', :host_name => 'api.github.com') { 404 }
-        post('/repos/evilchelu/dotfiles/forks', :host_name => 'api.github.com') {
-          assert :organization => nil
-          status 202
-          json :name => 'dotfiles', :owner => { :login => 'mislav' }
-        }
+      get('/repos/mislav/dotfiles', :host_name => 'api.github.com') { 404 }
+      post('/repos/evilchelu/dotfiles/forks', :host_name => 'api.github.com') {
+        assert :organization => nil
+        status 202
+        json :name => 'dotfiles', :owner => { :login => 'mislav' }
+      }
       """
     When I run `hub fork`
     Then the exit status should be 128
@@ -152,32 +152,32 @@ Scenario: Related fork already exists
       """
     And the url for "mislav" should be "git@github.com:mislav/unrelated.git"
 
- Scenario: Related fork and related remote already exist
-     Given the "mislav" remote has url "git@github.com:mislav/dotfiles.git"
-     Given the GitHub API server:
-     """
-       get('/repos/mislav/dotfiles') {
-             json :parent => { :html_url => 'https://github.com/EvilChelu/Dotfiles' }
-           }
-     """
-     When I run `hub fork`
-     Then the exit status should be 0
-     And the stdout should contain exactly:
-     """
-     existing remote: mislav\n
-     """
-     And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
+  Scenario: Related fork and related remote already exist
+    Given the "mislav" remote has url "git@github.com:mislav/dotfiles.git"
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :parent => { :html_url => 'https://github.com/EvilChelu/Dotfiles' }
+      }
+      """
+    When I run `hub fork`
+    Then the exit status should be 0
+    And the stdout should contain exactly:
+      """
+      existing remote: mislav\n
+      """
+    And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
 
   Scenario: Related fork and related remote, but with differing protocol, already exist
-      Given the "mislav" remote has url "https://github.com/mislav/dotfiles.git"
-      Given the GitHub API server:
+    Given the "mislav" remote has url "https://github.com/mislav/dotfiles.git"
+    Given the GitHub API server:
       """
-        get('/repos/mislav/dotfiles') {
-              json :parent => { :html_url => 'https://github.com/EvilChelu/Dotfiles' }
-            }
+	  get('/repos/mislav/dotfiles') {
+	    json :parent => { :html_url => 'https://github.com/EvilChelu/Dotfiles' }
+	  }
       """
-      When I run `hub fork`
-      Then the exit status should be 0
+    When I run `hub fork`
+    Then the exit status should be 0
 
   Scenario: Invalid OAuth token
     Given the GitHub API server:

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -164,6 +164,22 @@ Scenario: Related fork already exists
      Then the exit status should be 0
      And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
 
+   Scenario: Related fork and related remote, but with differing protocol, already exist
+       Given the "mislav" remote has url "https://github.com/mislav/dotfiles.git"
+       Given the GitHub API server:
+       """
+         get('/repos/mislav/dotfiles') {
+               json :parent => { :html_url => 'https://github.com/EvilChelu/Dotfiles' }
+             }
+       """
+       When I run `hub fork`
+       Then the exit status should be 128
+	   And the stderr should contain exactly:
+		 """
+		 fatal: remote mislav already exists.\n
+		 """
+
+
 
   Scenario: Invalid OAuth token
     Given the GitHub API server:


### PR DESCRIPTION
Fixes #1499.

This PR makes `hub fork` succeed, with no operation, if a remote pointing to the forked repository already exists.
 