### PR TITLE
Document the availability of the development version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ git version 1.7.6
 hub version 2.2.3
 ```
 
-if you want to use the latest unstable version, use:
+If you want to get access to new `hub` features earlier and help with its
+development by reporting bugs, you can install the prerelease version:
 
 ``` sh
 $ brew install --devel hub

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ git version 1.7.6
 hub version 2.2.3
 ```
 
+if you want to use the latest unstable version, use:
+
+``` sh
+$ brew install --devel hub
+```
+
 #### Chocolatey
 
 `hub` can be installed through [Chocolatey](https://chocolatey.org/) on Windows.


### PR DESCRIPTION
I checked the [Chocolatey Gallery](https://chocolatey.org/packages/hub) and it doesn't seem like there's a prerelease of `hub`. So I haven't documented that but Chocolatey itself [supports prereleases](https://chocolatey.github.io/usage.html#installing-packages).