### PR TITLE
Check modtime of message file after it is edited by the user

### DIFF
--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -94,7 +94,7 @@ Feature: hub pull-request
     Then the output should contain exactly "the://url\n"
 
   Scenario: Single-commit with pull request template
-    Given the git commit editor is "true"
+    Given the git commit editor is "touch"
     Given the GitHub API server:
       """
       post('/repos/mislav/coral/pulls') {
@@ -838,7 +838,7 @@ BODY
     Then the output should contain exactly "the://url\n"
 
   Scenario: Default message with --push
-    Given the git commit editor is "true"
+    Given the git commit editor is "touch"
     Given the GitHub API server:
       """
       post('/repos/mislav/coral/pulls') {

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -392,6 +392,15 @@ BODY
       (use `-h <branch>` to specify an explicit pull request head)\n
       """
 
+  Scenario: Error when editor exits without editing the message
+    Given I am on the "master" branch
+    Given the git commit editor is "true"
+    When I run `hub pull-request`
+    Then the stderr should contain exactly:
+      """
+      Aborting; you did not edit the message\n
+      """
+
   Scenario: Explicit head
     Given I am on the "master" branch
     Given the GitHub API server:

--- a/github/editor.go
+++ b/github/editor.go
@@ -91,7 +91,6 @@ func (e *Editor) openAndEdit() (content []byte, err error) {
 		return
 	}
 
-	// If the modified time after is not greater than modified time before, they quit with something like :q!, so error-out.
 	info, err := os.Stat(e.File)
 	if err != nil {
 		return

--- a/github/editor.go
+++ b/github/editor.go
@@ -81,6 +81,7 @@ func (e *Editor) openAndEdit() (content []byte, err error) {
 	beforeTime := time.Now().Add(-2 * time.Minute)
 	err = os.Chtimes(e.File, beforeTime, beforeTime)
 	if err != nil {
+		defer e.DeleteFile()
 		return
 	}
 
@@ -100,6 +101,7 @@ func (e *Editor) openAndEdit() (content []byte, err error) {
 
 	if !(info.ModTime().After(beforeTime)){
 		err = fmt.Errorf("Aborting; you did not edit the message")
+		defer e.DeleteFile()
 		return
 	}
 

--- a/github/editor.go
+++ b/github/editor.go
@@ -55,7 +55,6 @@ func (e *Editor) DeleteFile() error {
 }
 
 func (e *Editor) EditTitleAndBody() (title, body string, err error) {
-
 	content, err := e.openAndEdit()
 	if err != nil {
 		return
@@ -78,7 +77,7 @@ func (e *Editor) openAndEdit() (content []byte, err error) {
 		return
 	}
 
-	beforeTime := time.Now().Add(-2 * time.Minute)
+	beforeTime := time.Now().Add(-5 * time.Second)
 	err = os.Chtimes(e.File, beforeTime, beforeTime)
 	if err != nil {
 		defer e.DeleteFile()
@@ -86,7 +85,6 @@ func (e *Editor) openAndEdit() (content []byte, err error) {
 	}
 
 	err = e.openEditor(e.Program, e.File)
-
 	if err != nil {
 		err = fmt.Errorf("error using text editor for %s message", e.Topic)
 		defer e.DeleteFile()
@@ -95,11 +93,11 @@ func (e *Editor) openAndEdit() (content []byte, err error) {
 
 	// If the modified time after is not greater than modified time before, they quit with something like :q!, so error-out.
 	info, err := os.Stat(e.File)
-	if err != nil{
+	if err != nil {
 		return
 	}
 
-	if !(info.ModTime().After(beforeTime)){
+	if ! info.ModTime().After(beforeTime) {
 		err = fmt.Errorf("Aborting; you did not edit the message")
 		defer e.DeleteFile()
 		return

--- a/github/editor_test.go
+++ b/github/editor_test.go
@@ -50,7 +50,7 @@ func TestEditor_openAndEdit_readFileIfExist(t *testing.T) {
 		openEditor: func(program string, file string) error {
 			assert.Equal(t, "memory", program)
 			assert.Equal(t, tempFile.Name(), file)
-			os.Chtimes(file, time.Now(), time.Now())
+			os.Chtimes(file, time.Now(), time.Now()) // file modtime must be changed by editor.
 
 			return nil
 		},

--- a/github/editor_test.go
+++ b/github/editor_test.go
@@ -51,6 +51,7 @@ func TestEditor_openAndEdit_readFileIfExist(t *testing.T) {
 			assert.Equal(t, "memory", program)
 			assert.Equal(t, tempFile.Name(), file)
 			os.Chtimes(file, time.Now(), time.Now())
+
 			return nil
 		},
 	}

--- a/github/editor_test.go
+++ b/github/editor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/bmizerany/assert"
+	"time"
 )
 
 func TestEditor_openAndEdit_deleteFileWhenOpeningEditorFails(t *testing.T) {
@@ -49,7 +50,7 @@ func TestEditor_openAndEdit_readFileIfExist(t *testing.T) {
 		openEditor: func(program string, file string) error {
 			assert.Equal(t, "memory", program)
 			assert.Equal(t, tempFile.Name(), file)
-
+			os.Chtimes(file, time.Now(), time.Now())
 			return nil
 		},
 	}


### PR DESCRIPTION
Fixes #1428.

This change would affect the behavior of the editor for issues, releases, and pull requests by setting the modified time of the message file 5 seconds back before it is edited, then verifying that the time-stamp changed.

Some existing tests had to be modified to reflect that the editor must at least `touch` the message file.

