### PR TITLE
Add a label command

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -19,6 +19,7 @@ var (
 		Usage: `
 issue [-a <ASSIGNEE>] [-c <CREATOR>] [-@ <USER>] [-s <STATE>] [-f <FORMAT>] [-M <MILESTONE>] [-l <LABELS>] [-d <DATE>] [-o <SORT_KEY> [-^]]
 issue create [-oc] [-m <MESSAGE>|-F <FILE>] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
+issue label
 `,
 		Long: `Manage GitHub issues for the current project.
 
@@ -28,6 +29,9 @@ With no arguments, show a list of open issues.
 
 	* _create_:
 		Open an issue in the current project.
+
+    * _label_:
+        List the labels available in this repository.
 
 ## Options:
 	-a, --assignee <ASSIGNEE>
@@ -190,6 +194,7 @@ func init() {
 	cmdIssue.Flag.BoolVarP(&flagIssueIncludePulls, "include-pulls", "", false, "INCLUDE_PULLS")
 
 	cmdIssue.Use(cmdCreateIssue)
+    cmdIssue.Use(cmdLabel)
 	CmdRunner.Use(cmdIssue)
 }
 

--- a/commands/label.go
+++ b/commands/label.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"github.com/github/hub/github"
+	"github.com/github/hub/ui"
+	"github.com/github/hub/utils"
+)
+
+
+var (
+	cmdLabel = &Command{
+		Run: listLabels,
+		Usage: `
+label
+`,
+		Long: `Manage GitHub labels for the current repository.
+
+## Commands:
+
+With no arguments, show a list of open issues.
+`,
+	}
+)
+
+func init() {
+	CmdRunner.Use(cmdLabel)
+}
+
+func listLabels(cmd *Command, args *Args) {
+	localRepo, err := github.LocalRepo()
+	utils.Check(err)
+
+	project, err := localRepo.MainProject()
+	utils.Check(err)
+
+	gh := github.NewClient(project.Host)
+
+    if args.Noop {
+		ui.Printf("Would request list of labels for %s\n", project)
+	} else {
+		labels, err := gh.FetchLabels(project)
+		utils.Check(err)
+
+		for _, label := range labels {
+			ui.Printf(formatLabel(label))
+		}
+	}
+
+	args.NoForward()
+}
+
+func formatLabel(label github.IssueLabel) string {
+    format := "%l%n"
+
+	placeholders := map[string]string{
+		"l":  label.Name,
+	}
+
+	return ui.Expand(format, placeholders, false)
+}

--- a/commands/label.go
+++ b/commands/label.go
@@ -9,22 +9,12 @@ import (
 
 var (
 	cmdLabel = &Command{
+        Key: "label",
 		Run: listLabels,
-		Usage: `
-label
-`,
-		Long: `Manage GitHub labels for the current repository.
-
-## Commands:
-
-With no arguments, show a list of open issues.
-`,
+		Usage: "issue label",
+		Long: "List the labels available in this repository.",
 	}
 )
-
-func init() {
-	CmdRunner.Use(cmdLabel)
-}
 
 func listLabels(cmd *Command, args *Args) {
 	localRepo, err := github.LocalRepo()

--- a/features/label.feature
+++ b/features/label.feature
@@ -17,7 +17,7 @@ Feature: hub label
       ]
     }
     """
-    When I successfully run `hub label`
+    When I successfully run `hub issue label`
     Then the output should contain exactly:
       """
       bug

--- a/features/label.feature
+++ b/features/label.feature
@@ -1,0 +1,25 @@
+Feature: hub label
+  Background:
+    Given I am in "git://github.com/github/hub.git" git repo
+    And I am "testeroni" on github.com with OAuth token "OTOKEN"
+
+  Scenario: Fetch issues
+    Given the GitHub API server:
+    """
+    get('/repos/github/hub/labels') {
+      json [
+        { :name => "bug",
+          :color => "ff0000",
+        },
+        { :name => "feature",
+          :color => "00ff00",
+        },
+      ]
+    }
+    """
+    When I successfully run `hub label`
+    Then the output should contain exactly:
+      """
+      bug
+      feature\n
+      """

--- a/github/client.go
+++ b/github/client.go
@@ -564,6 +564,34 @@ func (client *Client) UpdateIssue(project *Project, issueNumber int, params map[
 	return
 }
 
+func (client *Client) FetchLabels(project *Project) (labels []IssueLabel, err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	path := fmt.Sprintf("repos/%s/%s/labels?per_page=100", project.Owner, project.Name)
+
+	labels = []IssueLabel{}
+	var res *simpleResponse
+
+	for path != "" {
+		res, err = api.Get(path)
+		if err = checkStatus(200, "fetching labels", res, err); err != nil {
+			return
+		}
+		path = res.Link("next")
+
+		labelsPage := []IssueLabel{}
+		if err = res.Unmarshal(&labelsPage); err != nil {
+			return
+		}
+		labels = append(labels, labelsPage...)
+	}
+
+	return
+}
+
 func (client *Client) CurrentUser() (user *octokit.User, err error) {
 	url, err := octokit.CurrentUserURL.Expand(nil)
 	if err != nil {


### PR DESCRIPTION
This command lists the labels for a given repository. This command
will be enhanced with subcommands which can create new labels on the
repository and modify existing labels (i.e. renaming or changing
their colors).

Other enhancements I plan to include in the future.
  * Display the labels using 256 bit colors similar to how the labels
    look on GitHub. This is similar to the functionality in the
    [ghi](https://github.com/stephencelis/ghi) tool.
  * When displaying issues with the `issue` command, use this same
    256 bit color formatting so that labels are easier to read on
    terminals which don't support true colors. (e.g. `Terminal.app`)