### PR TITLE
Allow edits from maintainers

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -144,8 +144,9 @@ func pullRequest(cmd *Command, args *Args) {
 	utils.Check(err)
 
 	var (
-		base, head string
-		force      bool
+		base, head       string
+		force            bool
+		maintainerModify bool
 	)
 
 	force = flagPullRequestForce
@@ -205,6 +206,17 @@ func pullRequest(cmd *Command, args *Args) {
 			err = fmt.Errorf("%s\n(use `-f` to force submit a pull request anyway)", err)
 			utils.Check(err)
 		}
+	}
+
+	mm, _ := git.Config("hub.maintainerModify")
+	switch mm {
+	case "", "true":
+		// flagPullRequestRestrictMaintainerModify overwrites hub.maintainerModify
+		maintainerModify = !flagPullRequestRestrictMaintainerModify
+	case "false":
+		maintainerModify = false
+	default:
+		utils.Check(fmt.Errorf("Invalid value for hub.maintainerModify. `true` or `flase` is valid."))
 	}
 
 	var editor *github.Editor
@@ -270,7 +282,7 @@ func pullRequest(cmd *Command, args *Args) {
 		params := map[string]interface{}{
 			"base":                  base,
 			"head":                  fullHead,
-			"maintainer_can_modify": !flagPullRequestRestrictMaintainerModify,
+			"maintainer_can_modify": maintainerModify,
 		}
 
 		if title != "" {

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -17,7 +17,7 @@ import (
 var cmdPullRequest = &Command{
 	Run: pullRequest,
 	Usage: `
-pull-request [-foc] [-b <BASE>] [-h <HEAD>] [-r <REVIEWERS> ] [-a <ASSIGNEES>] [-M <MILESTONE>] [-l <LABELS>]
+pull-request [-focR] [-b <BASE>] [-h <HEAD>] [-r <REVIEWERS> ] [-a <ASSIGNEES>] [-M <MILESTONE>] [-l <LABELS>]
 pull-request -m <MESSAGE>
 pull-request -F <FILE> [--edit]
 pull-request -i <ISSUE>
@@ -69,6 +69,9 @@ pull-request -i <ISSUE>
 	-l, --labels <LABELS>
 		Add a comma-separated list of labels to this pull request.
 
+	-R, --restrict-maintainer-modify
+    Do not allow permissions modfying this pull request from maintainer.
+
 ## Configuration:
 
 	HUB_RETRY_TIMEOUT=<SECONDS>
@@ -90,6 +93,7 @@ var (
 	flagPullRequestBrowse,
 	flagPullRequestCopy,
 	flagPullRequestEdit,
+	flagPullRequestRestrictMaintainerModify,
 	flagPullRequestPush,
 	flagPullRequestForce bool
 
@@ -115,6 +119,7 @@ func init() {
 	cmdPullRequest.Flag.VarP(&flagPullRequestReviewers, "reviewer", "r", "USERS")
 	cmdPullRequest.Flag.Uint64VarP(&flagPullRequestMilestone, "milestone", "M", 0, "MILESTONE")
 	cmdPullRequest.Flag.VarP(&flagPullRequestLabels, "labels", "l", "LABELS")
+	cmdPullRequest.Flag.BoolVarP(&flagPullRequestRestrictMaintainerModify, "restrict-maintainer-modify", "R", false, "RESTRICT-MAINTAINER-MODIFY")
 
 	CmdRunner.Use(cmdPullRequest)
 }
@@ -263,8 +268,9 @@ func pullRequest(cmd *Command, args *Args) {
 		pullRequestURL = "PULL_REQUEST_URL"
 	} else {
 		params := map[string]interface{}{
-			"base": base,
-			"head": fullHead,
+			"base":                  base,
+			"head":                  fullHead,
+			"maintainer_can_modify": !flagPullRequestRestrictMaintainerModify,
 		}
 
 		if title != "" {

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -921,3 +921,15 @@ BODY
       """
     And the output should match /Given up after retrying for 5\.\d seconds\./
     And a file named ".git/PULLREQ_EDITMSG" should exist
+
+  Scenario: Explicit restrict-maintainer-modify
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :maintainer_can_modify => false
+        status 201
+        json :html_url => "the://url"
+      }
+      """
+    When I successfully run `hub pull-request -R -m message`
+    Then the output should contain exactly "the://url\n"


### PR DESCRIPTION
I added the option `--restrict-maintainer-modfy` to `hub pull-request` command to off the checkbox of 'Allow edits from maintainers' in github\.com Web UI.
And also, restrict-maintainer-modfy can be configured at `~/.gitconfig` like a following code.

```
[hub]
  maintainerModify = false
```
Default value of  restrict-maintainer-modfy is `false` since github\.com Web UI is flase (means **Allow** edits from maintainers )

ref. #1349
