### PR TITLE
Enforce unix eol in bash script files through .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+
+# enforce correct line endings for shell and batch files.
+*.sh text eol=lf
+script/* text eol=lf
+script/*.bat text eol=crlf


### PR DESCRIPTION
Adds a gitattributes file that asks git to checkout the build files with unix file extensions.

The gitattibutes file marks all `.sh` files as well as all file in the `script` directory that are no `.bat` files as build files.

I have tested on my machine by running (from the git repository).

```sh
git config --global core.autocrlf true
git clone . hub2
cd hub2/script
cat -e install.sh
cat -e build
cat -e build.bat
```

Solves issue #1514. Also see pr #1516.
@mislav 
