### PR TITLE
Supported pull subpage to browse command

### DIFF
--- a/commands/browse.go
+++ b/commands/browse.go
@@ -25,7 +25,7 @@ var cmdBrowse = &Command{
 		Defaults to repository in the current working directory.
 
 	<SUBPAGE>
-		One of "wiki", "commits", "issues", or other (default: "tree").
+		One of "wiki", "commits", "issues", "pull", or other (default: "tree").
 
 ## Examples:
 		$ hub browse
@@ -85,7 +85,7 @@ func browse(command *Command, args *Args) {
 	if dest != "" {
 		project = github.NewProject("", dest, "")
 		branch = localRepo.MasterBranch()
-	} else if subpage != "" && subpage != "commits" && subpage != "tree" && subpage != "blob" && subpage != "settings" {
+	} else if subpage != "" && subpage != "commits" && subpage != "tree" && subpage != "blob" && subpage != "settings" && subpage != "pull" {
 		project, err = localRepo.MainProject()
 		branch = localRepo.MasterBranch()
 		utils.Check(err)
@@ -119,6 +119,8 @@ func browse(command *Command, args *Args) {
 
 	if subpage == "commits" {
 		path = fmt.Sprintf("commits/%s", branchInURL(branch))
+	} else if subpage == "pull" {
+		path = fmt.Sprintf("pull/%s", branchInURL(branch))
 	} else if subpage == "tree" || subpage == "" {
 		if !branch.IsMaster() {
 			path = fmt.Sprintf("tree/%s", branchInURL(branch))

--- a/features/browse.feature
+++ b/features/browse.feature
@@ -141,6 +141,13 @@ Feature: hub browse
     When I successfully run `hub browse`
     Then "open https://github.com/mislav/dotfiles" should be run
 
+  Scenario: Pull subpage on current branch
+    Given I am in "git://github.com/mislav/dotfiles.git" git repo
+    And git "push.default" is set to "upstream"
+    And I am on the "feature" branch with upstream "origin/experimental"
+    When I successfully run `hub browse -- pull`
+    Then "open https://github.com/mislav/dotfiles/pull/experimental" should be run
+
   Scenario: No branch to pulls
     Given I am in "git://github.com/mislav/dotfiles.git" git repo
     And I am in detached HEAD


### PR DESCRIPTION
Supported `pull` subpage to browse command.
I want to open Pull Request related to the current branch.

related #688