### PR TITLE
Fix tmux_pane_content test helper

### DIFF
--- a/features/support/completion.rb
+++ b/features/support/completion.rb
@@ -183,7 +183,7 @@ World Module.new {
   end
 
   def tmux_output_lines
-    tmux_pane_contents.split("\n").reject do |line|
+    tmux_pane_contents.split("\n").drop_while { |l| not l.start_with?('$') }.reject do |line|
       line.start_with?('$')
     end
   end


### PR DESCRIPTION
Ignore all lines that are printed before the first command prompt. On
some systems bash prints a message about how to use the sudo command
when started with a clean `$HOME`, causing some tests to fail.

Fixes #1477