### PR TITLE
Fix PATH update in windows installation script

### DIFF
--- a/script/install.bat
+++ b/script/install.bat
@@ -8,12 +8,13 @@ goto checkPrivileges
 :: This function takes care of these problems by calling Environment.Get/SetEnvironmentVariable
 :: via PowerShell, which lacks these issues.
 :appendToUserPath
+setlocal EnableDelayedExpansion
 set "RUNPS=powershell -NoProfile -ExecutionPolicy Bypass -Command" :: Command to start PowerShell.
 set "OLDPATHPS=[Environment]::GetEnvironmentVariable('PATH', 'User')" :: PowerShell command to run to get the old $PATH for the current user.
 
 :: Capture the output of %RUNPS% "%OLDPATHPS%" and set it to OLDPATH
 for /f "delims=" %%i in ('%RUNPS% "%OLDPATHPS%"') do (
-    set "OLDPATH=%%i"
+    set "OLDPATH=!OLDPATH!%%i"
 )
 
 set "NEWPATH=%OLDPATH%;%1"


### PR DESCRIPTION
For some reason, when the installation script is run through the VBS
wrapper on Windows 7, the `OLDPATH` gets cut in multiple parts and only
the final part makes it into the new `PATH`. This fix just collects all
the parts and concatenates them again.