### PR TITLE
Implement `pr show`

### DIFF
--- a/commands/pr.go
+++ b/commands/pr.go
@@ -11,8 +11,18 @@ import (
 
 var (
 	cmdPr = &Command{
-		Run:   printHelp,
-		Usage: "pr checkout <PULLREQ-NUMBER> [<BRANCH>]",
+		Run: printHelp,
+		Usage: `
+pr checkout <PULLREQ-NUMBER> [<BRANCH>]
+pr show [-b <BASE>] [-h <HEAD>]
+pr help <COMMAND>
+`,
+	}
+
+	cmdCheckoutPr = &Command{
+		Key:   "checkout",
+		Run:   checkoutPr,
+		Usage: `pr checkout <PULLREQ-NUMBER> [<BRANCH>]`,
 		Long: `Check out the head of a pull request as a local branch.
 
 ## Examples:
@@ -26,19 +36,60 @@ hub-merge(1), hub(1), hub-checkout(1)
 	`,
 	}
 
-	cmdCheckoutPr = &Command{
-		Key: "checkout",
-		Run: checkoutPr,
+	cmdShowPr = &Command{
+		Key:   "show",
+		Run:   showPr,
+		Usage: `show [-b <BASE>] [-h <HEAD>]`,
+		Long: `Display information about the pull request for the current branch.
+
+## Examples:
+	$ hub pr show
+	$ hub pr show -b devel
+
+## See also:
+
+hub-pull-request(1), hub(1)
+	`,
 	}
+
+	cmdHelpPr = &Command{
+		Key: "help",
+		Run: helpPr,
+	}
+
+	flagPullRequestShowBase,
+	flagPullRequestShowHead string
 )
 
 func init() {
+	cmdShowPr.Flag.StringVarP(&flagPullRequestShowBase, "base", "b", "", "BASE")
+	cmdShowPr.Flag.StringVarP(&flagPullRequestShowHead, "head", "h", "", "HEAD")
+
 	cmdPr.Use(cmdCheckoutPr)
+	cmdPr.Use(cmdShowPr)
+	cmdPr.Use(cmdHelpPr)
 	CmdRunner.Use(cmdPr)
 }
 
 func printHelp(command *Command, args *Args) {
 	fmt.Print(command.HelpText())
+	os.Exit(0)
+}
+
+func helpPr(command *Command, args *Args) {
+	words := args.Words()
+	if len(words) == 0 {
+		fmt.Print(cmdPr.HelpText())
+	} else {
+		switch words[0] {
+		case "checkout":
+			fmt.Print(cmdCheckoutPr.HelpText())
+		case "show":
+			fmt.Print(cmdShowPr.HelpText())
+		default:
+			utils.Check(fmt.Errorf("Error: No such subcommand: %s", words[0]))
+		}
+	}
 	os.Exit(0)
 }
 
@@ -71,4 +122,82 @@ func checkoutPr(command *Command, args *Args) {
 	utils.Check(err)
 
 	args.Replace(args.Executable, "checkout", newArgs...)
+}
+
+func showPr(command *Command, args *Args) {
+	localRepo, err := github.LocalRepo()
+	utils.Check(err)
+
+	currentBranch, err := localRepo.CurrentBranch()
+	utils.Check(err)
+
+	baseProject, err := localRepo.MainProject()
+	utils.Check(err)
+
+	host, err := github.CurrentConfig().PromptForHost(baseProject.Host)
+	utils.Check(err)
+	client := github.NewClientWithHost(host)
+
+	trackedBranch, headProject, err := localRepo.RemoteBranchAndProject(host.User, false)
+	utils.Check(err)
+
+	var base, head string
+
+	if flagPullRequestShowBase != "" {
+		baseProject, base = parsePullRequestProject(baseProject, flagPullRequestShowBase)
+	}
+
+	if flagPullRequestHead != "" {
+		headProject, head = parsePullRequestProject(headProject, flagPullRequestShowHead)
+	}
+
+	if base == "" {
+		masterBranch := localRepo.MasterBranch()
+		base = masterBranch.ShortName()
+	}
+
+	if head == "" && trackedBranch != nil {
+		if !trackedBranch.IsRemote() {
+			// the current branch tracking another branch
+			// pretend there's no upstream at all
+			trackedBranch = nil
+		} else {
+			if baseProject.SameAs(headProject) && base == trackedBranch.ShortName() {
+				e := fmt.Errorf(`Aborted: head branch is the same as base ("%s")`, base)
+				e = fmt.Errorf("%s\n(use `-h <branch>` to specify an explicit pull request head)", e)
+				utils.Check(e)
+			}
+		}
+	}
+
+	if head == "" {
+		if trackedBranch != nil {
+			head = currentBranch.ShortName()
+		} else {
+			head = trackedBranch.ShortName()
+		}
+	}
+
+	if headRepo, err := client.Repository(headProject); err == nil {
+		headProject.Owner = headRepo.Owner.Login
+		headProject.Name = headRepo.Name
+	}
+
+	filters := map[string]interface{}{
+		"base":  base,
+		"head":  fmt.Sprintf("%s:%s", headProject.Owner, head),
+		"state": "open",
+	}
+	prs, err := client.FetchPullRequests(baseProject, filters)
+	utils.Check(err)
+
+	if len(prs) == 0 {
+		utils.Check(fmt.Errorf("No pull requests found"))
+		os.Exit(1)
+	} else {
+		for _, pr := range prs {
+			fmt.Println(pr.HtmlUrl)
+		}
+		os.Exit(0)
+	}
 }


### PR DESCRIPTION
`hub pr show` will display any existing pull requests that would have
been created by `hub pull-request`. For any pull requests it finds, it
prints out the link to the pull request.

If no pull requests are found, this will result in an error. That means
it can be used to check for any existing pull requests before attempting
to create one using `hub pull-request`.

Fixes #897. Replaces #1498. Some code was taken from #1498 as a starter
for this pull request.