### PR TITLE
Ensure that _git completion func is replaced only once.

### DIFF
--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -6,8 +6,8 @@ if ! declare -F _git > /dev/null && declare -F _completion_loader > /dev/null; t
   _completion_loader git
 fi
 
-# Check that git tab completion is available
-if declare -F _git > /dev/null; then
+# Check that git tab completion is available and we haven't already set up completion
+if declare -F _git > /dev/null && ! declare -F __git_list_all_commands_without_hub > /dev/null; then
   # Duplicate and rename the 'list_all_commands' function
   eval "$(declare -f __git_list_all_commands | \
         sed 's/__git_list_all_commands/__git_list_all_commands_without_hub/')"


### PR DESCRIPTION
This allows the completion script to be sourced more than once while
still behaving correctly. Previously, the script would attempt to
replace `__git_list_all_commands` blindly, which would yield
multiply-replaced calls like
`__git_list_all_commands_without_hub_without_hub`.

The zsh completions already do something very similar to this to ensure
that the replacement isn't done more than once.