### PR TITLE
Mention fish completion with bash and zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ New-Item -Type file -Force $PROFILE
 
 ### Shell tab-completion
 
-hub repository contains tab-completion scripts for bash and zsh. These scripts
-complement existing completion scripts that ship with git.
+hub repository contains tab-completion scripts for bash, zsh and fish.
+These scripts complement existing completion scripts that ship with git.
 
 [Installation instructions](etc)
 


### PR DESCRIPTION
The fish syntax highlighting was already linked below this sentence, but oddly wasn't mentioned in the sentence itself.