### PR TITLE
Have `fetch` use writable push URL for writeable fork

### DIFF
--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -61,7 +61,7 @@ func transformFetchArgs(args *Args) error {
 					continue
 				}
 
-				projects[project] = repo.Private
+				projects[project] = repo.Private || repo.Permissions.Push
 			}
 		}
 	}

--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -35,7 +35,10 @@ Feature: hub fetch
   Scenario: Creates new remote
     Given the GitHub API server:
       """
-      get('/repos/mislav/dotfiles') { json :private => false }
+      get('/repos/mislav/dotfiles') {
+        json :private => false,
+             :permissions => { :push => false }
+      }
       """
     When I successfully run `hub fetch mislav`
     Then "git fetch mislav" should be run
@@ -66,6 +69,19 @@ Feature: hub fetch
     Given the GitHub API server:
       """
       get('/repos/mislav/dotfiles') { json :private => true }
+      """
+    When I successfully run `hub fetch mislav`
+    Then "git fetch mislav" should be run
+    And the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
+    And there should be no output
+
+  Scenario: Writeable repo
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :private => false,
+             :permissions => { :push => true }
+      }
       """
     When I successfully run `hub fetch mislav`
     Then "git fetch mislav" should be run


### PR DESCRIPTION
This is to avoid having a writeable fork added with `git://` protocol (the default when `hub.protocol` is not configured).

This matches the behavior of `hub clone`.

Fixes #1614