### PR TITLE
Add milestone to PR by name instead of number

### DIFF
--- a/etc/hub.fish_completion
+++ b/etc/hub.fish_completion
@@ -38,7 +38,7 @@ complete -f -c hub -n ' __fish_hub_using_command pull-request' -s p -d "Push the
 complete -f -c hub -n ' __fish_hub_using_command pull-request' -s b -d 'The base branch in "[OWNER:]BRANCH" format'
 complete -f -c hub -n ' __fish_hub_using_command pull-request' -s h -d 'The head branch in "[OWNER:]BRANCH" format'
 complete -f -c hub -n ' __fish_hub_using_command pull-request' -s a -d 'A comma-separated list of GitHub handles to assign to this pull request'
-complete -f -c hub -n ' __fish_hub_using_command pull-request' -s M -d "Add this pull request to a GitHub milestone with id <ID>"
+complete -f -c hub -n ' __fish_hub_using_command pull-request' -s M -d "The milestone name to add to this pull request. Passing the milestone number is deprecated."
 complete -f -c hub -n ' __fish_hub_using_command pull-request' -s l -d "Add a comma-separated list of labels to this pull request"
 # fork
 complete -f -c hub -n ' __fish_hub_using_command fork' -l no-remote -d "Skip adding a git remote for the fork"

--- a/github/client.go
+++ b/github/client.go
@@ -635,6 +635,34 @@ func (client *Client) FetchLabels(project *Project) (labels []IssueLabel, err er
 	return
 }
 
+func (client *Client) FetchMilestones(project *Project) (milestones []Milestone, err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	path := fmt.Sprintf("repos/%s/%s/milestones?per_page=100", project.Owner, project.Name)
+
+	milestones = []Milestone{}
+	var res *simpleResponse
+
+	for path != "" {
+		res, err = api.Get(path)
+		if err = checkStatus(200, "fetching milestones", res, err); err != nil {
+			return
+		}
+		path = res.Link("next")
+
+		milestonesPage := []Milestone{}
+		if err = res.Unmarshal(&milestonesPage); err != nil {
+			return
+		}
+		milestones = append(milestones, milestonesPage...)
+	}
+
+	return
+}
+
 func (client *Client) CurrentUser() (user *User, err error) {
 	api, err := client.simpleApi()
 	if err != nil {


### PR DESCRIPTION
Now it's possible to add a milestone by name to a pull request instead of looking up the number. If the milestone can't be found it'll stop before creating the PR.

Closes #1089 