### PR TITLE
Make remote URLs default to HTTPS

### DIFF
--- a/commands/clone.go
+++ b/commands/clone.go
@@ -104,7 +104,7 @@ func transformCloneArgs(args *Args) {
 				if !isSSH &&
 					args.Command != "submodule" &&
 					!github.IsHttpsProtocol() {
-					isSSH = repo.Private || repo.Permissions.Push
+					isSSH = repo.Private
 				}
 
 				url := project.GitURL(name, owner, isSSH)

--- a/commands/clone.go
+++ b/commands/clone.go
@@ -101,12 +101,6 @@ func transformCloneArgs(args *Args) {
 					}
 				}
 
-				if !isSSH &&
-					args.Command != "submodule" &&
-					!github.IsHttpsProtocol() {
-					isSSH = repo.Private
-				}
-
 				url := project.GitURL(name, owner, isSSH)
 				args.ReplaceParam(i, url)
 			}

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -159,7 +159,7 @@ Feature: OAuth authentication
       """
     Given $GITHUB_TOKEN is "PTOKEN"
     When I successfully run `hub clone dotfiles`
-    Then it should clone "git@github.com:parkr/dotfiles.git"
+    Then it should clone "https://github.com/parkr/dotfiles.git"
     And the file "../home/.config/hub" should contain "user: mislav"
     And the file "../home/.config/hub" should contain "oauth_token: OTOKEN"
 

--- a/features/cherry_pick.feature
+++ b/features/cherry_pick.feature
@@ -60,14 +60,14 @@ Feature: hub cherry-pick
 
   Scenario: Using GitHub owner@SHA notation with remote add
     When I run `hub cherry-pick mislav@a319d88`
-    Then "git remote add _hub-cherry-pick git://github.com/mislav/ronn.git" should be run
+    Then "git remote add _hub-cherry-pick https://github.com/mislav/ronn.git" should be run
     And "git fetch -q --no-tags _hub-cherry-pick" should be run
     And "git remote rm _hub-cherry-pick" should be run
     And "git cherry-pick a319d88" should be run
 
   Scenario: From fork that doesn't have a remote
-    When I run `hub cherry-pick https://github.com/jingweno/ronn/commit/a319d88`
-    Then "git remote add _hub-cherry-pick git://github.com/jingweno/ronn.git" should be run
+    When I run `hub cherry-pick git://github.com/jingweno/ronn/commit/a319d88`
+    Then "git remote add _hub-cherry-pick https://github.com/jingweno/ronn.git" should be run
     And "git fetch -q --no-tags _hub-cherry-pick" should be run
     And "git remote rm _hub-cherry-pick" should be run
     And "git cherry-pick a319d88" should be run

--- a/features/clone.feature
+++ b/features/clone.feature
@@ -225,7 +225,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone myorg/myrepo`
-    Then it should clone "git@git.my.org:myorg/myrepo.git"
+    Then it should clone "https://git.my.org/myorg/myrepo.git"
     And there should be no output
 
   Scenario: Clone from existing directory is a local clone

--- a/features/clone.feature
+++ b/features/clone.feature
@@ -12,7 +12,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone rtomayko/ronn`
-    Then it should clone "git://github.com/rtomayko/ronn.git"
+    Then it should clone "https://github.com/rtomayko/ronn.git"
     And there should be no output
 
   Scenario: Clone a public repo with period in name
@@ -25,7 +25,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone hookio/hook.js`
-    Then it should clone "git://github.com/hookio/hook.js.git"
+    Then it should clone "https://github.com/hookio/hook.js.git"
     And there should be no output
 
   Scenario: Clone a public repo that starts with a period
@@ -38,7 +38,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone zhuangya/.vim`
-    Then it should clone "git://github.com/zhuangya/.vim.git"
+    Then it should clone "https://github.com/zhuangya/.vim.git"
     And there should be no output
 
   Scenario: Clone a repo even if same-named directory exists
@@ -52,11 +52,11 @@ Feature: hub clone
       """
     And a directory named "rtomayko/ronn"
     When I successfully run `hub clone rtomayko/ronn`
-    Then it should clone "git://github.com/rtomayko/ronn.git"
+    Then it should clone "https://github.com/rtomayko/ronn.git"
     And there should be no output
 
-  Scenario: Clone a public repo with HTTPS
-    Given HTTPS is preferred
+  Scenario: Clone a public repo with plain git protocol
+    Given Plain git protocol is preferred
     Given the GitHub API server:
       """
       get('/repos/rtomayko/ronn') {
@@ -66,7 +66,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone rtomayko/ronn`
-    Then it should clone "https://github.com/rtomayko/ronn.git"
+    Then it should clone "git://github.com/rtomayko/ronn.git"
     And there should be no output
 
   Scenario: Clone command aliased
@@ -80,7 +80,7 @@ Feature: hub clone
       """
     When I successfully run `git config --global alias.c "clone --bare"`
     And I successfully run `hub c rtomayko/ronn`
-    Then "git clone --bare git://github.com/rtomayko/ronn.git" should be run
+    Then "git clone --bare https://github.com/rtomayko/ronn.git" should be run
     And there should be no output
 
   Scenario: Unchanged public clone
@@ -251,7 +251,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone rtomayko/ronn.wiki`
-    Then it should clone "git://github.com/RTomayko/ronin.wiki.git"
+    Then it should clone "https://github.com/RTomayko/ronin.wiki.git"
     And there should be no output
 
   Scenario: Clone a nonexisting wiki
@@ -284,5 +284,5 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone rtomayko/ronn`
-    Then it should clone "git://github.com/RTomayko/ronin.git"
+    Then it should clone "https://github.com/RTomayko/ronin.git"
     And there should be no output

--- a/features/clone.feature
+++ b/features/clone.feature
@@ -160,7 +160,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone dotfiles`
-    Then it should clone "git@github.com:mislav/dotfiles.git"
+    Then it should clone "https://github.com/mislav/dotfiles.git"
     And there should be no output
 
   Scenario: Clone my repo that doesn't exist
@@ -184,7 +184,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone --bare -o master dotfiles`
-    Then "git clone --bare -o master git@github.com:mislav/dotfiles.git" should be run
+    Then "git clone --bare -o master https://github.com/mislav/dotfiles.git" should be run
     And there should be no output
 
   Scenario: Clone repo to which I have push access to
@@ -197,7 +197,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub clone sstephenson/rbenv`
-    Then "git clone git@github.com:sstephenson/rbenv.git" should be run
+    Then "git clone https://github.com/sstephenson/rbenv.git" should be run
     And there should be no output
 
   Scenario: Preview cloning a repo I have push access to
@@ -210,7 +210,7 @@ Feature: hub clone
       }
       """
     When I successfully run `hub --noop clone sstephenson/rbenv`
-    Then the output should contain exactly "git clone git@github.com:sstephenson/rbenv.git\n"
+    Then the output should contain exactly "git clone https://github.com/sstephenson/rbenv.git\n"
     But it should not clone anything
 
   Scenario: Clone my Enterprise repo

--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -45,7 +45,7 @@ Feature: hub fetch
       """
     When I successfully run `hub fetch mislav`
     Then "git fetch mislav" should be run
-    And the url for "mislav" should be "git://github.com/mislav/dotfiles.git"
+    And the url for "mislav" should be "https://github.com/mislav/dotfiles.git"
     And there should be no output
 
   Scenario: Owner name with dash
@@ -58,10 +58,10 @@ Feature: hub fetch
       """
     When I successfully run `hub fetch ankit-maverick`
     Then "git fetch ankit-maverick" should be run
-    And the url for "ankit-maverick" should be "git://github.com/ankit-maverick/dotfiles.git"
+    And the url for "ankit-maverick" should be "https://github.com/ankit-maverick/dotfiles.git"
     And there should be no output
 
-  Scenario: HTTPS is preferred
+  Scenario: Plain git protocol is preferred
     Given the GitHub API server:
       """
       get('/repos/mislav/dotfiles') {
@@ -69,10 +69,10 @@ Feature: hub fetch
              :permissions => { :push => false }
       }
       """
-    And HTTPS is preferred
+    And Plain git protocol is preferred
     When I successfully run `hub fetch mislav`
     Then "git fetch mislav" should be run
-    And the url for "mislav" should be "https://github.com/mislav/dotfiles.git"
+    And the url for "mislav" should be "git://github.com/mislav/dotfiles.git"
 
   Scenario: Private repo
     Given the GitHub API server:
@@ -121,8 +121,8 @@ Feature: hub fetch
       """
     When I successfully run `hub fetch --multiple mislav rtomayko`
     Then "git fetch --multiple mislav rtomayko" should be run
-    And the url for "mislav" should be "git://github.com/mislav/dotfiles.git"
-    And the url for "rtomayko" should be "git://github.com/rtomayko/dotfiles.git"
+    And the url for "mislav" should be "https://github.com/mislav/dotfiles.git"
+    And the url for "rtomayko" should be "https://github.com/rtomayko/dotfiles.git"
 
   Scenario: Fetch multiple with filtering
     Given the GitHub API server:
@@ -135,7 +135,7 @@ Feature: hub fetch
     When I successfully run `git config remotes.mygrp "foo bar"`
     When I successfully run `hub fetch --multiple origin mislav mygrp git://example.com typo`
     Then "git fetch --multiple origin mislav mygrp git://example.com typo" should be run
-    And the url for "mislav" should be "git://github.com/mislav/dotfiles.git"
+    And the url for "mislav" should be "https://github.com/mislav/dotfiles.git"
     But there should be no "mygrp" remote
     And there should be no "typo" remote
 
@@ -149,9 +149,9 @@ Feature: hub fetch
       """
     When I successfully run `hub fetch mislav,rtomayko,dustinleblanc`
     Then "git fetch --multiple mislav rtomayko dustinleblanc" should be run
-    And the url for "mislav" should be "git://github.com/mislav/dotfiles.git"
-    And the url for "rtomayko" should be "git://github.com/rtomayko/dotfiles.git"
-    And the url for "dustinleblanc" should be "git://github.com/dustinleblanc/dotfiles.git"
+    And the url for "mislav" should be "https://github.com/mislav/dotfiles.git"
+    And the url for "rtomayko" should be "https://github.com/rtomayko/dotfiles.git"
+    And the url for "dustinleblanc" should be "https://github.com/dustinleblanc/dotfiles.git"
 
   Scenario: Doesn't create a new remote if repo doesn't exist on GitHub
     Given the GitHub API server:

--- a/features/remote_add.feature
+++ b/features/remote_add.feature
@@ -52,7 +52,7 @@ Feature: hub remote add
 
   Scenario: Add public remote
     When I successfully run `hub remote add mislav`
-    Then the url for "mislav" should be "git://github.com/mislav/dotfiles.git"
+    Then the url for "mislav" should be "https://github.com/mislav/dotfiles.git"
     And there should be no output
 
   Scenario: Add private remote
@@ -67,34 +67,34 @@ Feature: hub remote add
 
   Scenario: Add remote with arguments
     When I successfully run `hub remote add -f mislav`
-    Then "git remote add -f mislav git://github.com/mislav/dotfiles.git" should be run
+    Then "git remote add -f mislav https://github.com/mislav/dotfiles.git" should be run
     And there should be no output
 
-  Scenario: Add HTTPS protocol remote
-    Given HTTPS is preferred
+  Scenario: Add plain git protocol remote
+    Given Plain git protocol is preferred
     When I successfully run `hub remote add mislav`
-    Then the url for "mislav" should be "https://github.com/mislav/dotfiles.git"
+    Then the url for "mislav" should be "git://github.com/mislav/dotfiles.git"
     And there should be no output
 
   Scenario: Add named public remote
     When I successfully run `hub remote add mm mislav`
-    Then the url for "mm" should be "git://github.com/mislav/dotfiles.git"
+    Then the url for "mm" should be "https://github.com/mislav/dotfiles.git"
     And there should be no output
 
   Scenario: set-url
-    Given the "origin" remote has url "git://github.com/evilchelu/dotfiles.git"
+    Given the "origin" remote has url "https://github.com/evilchelu/dotfiles.git"
     When I successfully run `hub remote set-url origin mislav`
-    Then the url for "origin" should be "git://github.com/mislav/dotfiles.git"
+    Then the url for "origin" should be "https://github.com/mislav/dotfiles.git"
     And there should be no output
 
   Scenario: Add public remote including repo name
     When I successfully run `hub remote add mislav/dotfilez.js`
-    Then the url for "mislav" should be "git://github.com/mislav/dotfilez.js.git"
+    Then the url for "mislav" should be "https://github.com/mislav/dotfilez.js.git"
     And there should be no output
 
   Scenario: Add named public remote including repo name
     When I successfully run `hub remote add mm mislav/dotfilez.js`
-    Then the url for "mm" should be "git://github.com/mislav/dotfilez.js.git"
+    Then the url for "mm" should be "https://github.com/mislav/dotfilez.js.git"
     And there should be no output
 
   Scenario: Add named private remote

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -4,6 +4,10 @@ Given(/^HTTPS is preferred$/) do
   run_silent %(git config --global hub.protocol https)
 end
 
+Given(/^Plain git protocol is preferred$/) do
+  run_silent %(git config --global hub.protocol git)
+end
+
 Given(/^there are no remotes$/) do
   result = run_silent('git remote')
   expect(result).to be_empty

--- a/features/submodule_add.feature
+++ b/features/submodule_add.feature
@@ -15,7 +15,7 @@ Feature: hub submodule add
       }
       """
     When I successfully run `hub submodule add mojombo/grit vendor/grit`
-    Then the "vendor/grit" submodule url should be "git://github.com/mojombo/grit.git"
+    Then the "vendor/grit" submodule url should be "https://github.com/mojombo/grit.git"
     And the output should contain exactly:
       """
       Adding existing repo at 'vendor/grit' to the index\n
@@ -43,7 +43,7 @@ Feature: hub submodule add
       }
       """
     When I successfully run `hub submodule add grit vendor/grit`
-    Then the "vendor/grit" submodule url should be "git://github.com/mislav/grit.git"
+    Then the "vendor/grit" submodule url should be "https://github.com/mislav/grit.git"
 
   Scenario: Add submodule with arguments
     Given the GitHub API server:
@@ -55,7 +55,7 @@ Feature: hub submodule add
       }
       """
     When I successfully run `hub submodule add -b foo --name grit mojombo/grit vendor/grit`
-    Then "git submodule add -b foo --name grit git://github.com/mojombo/grit.git vendor/grit" should be run
+    Then "git submodule add -b foo --name grit https://github.com/mojombo/grit.git vendor/grit" should be run
 
   Scenario: Add submodule with branch
     Given the GitHub API server:
@@ -67,4 +67,4 @@ Feature: hub submodule add
       }
       """
     When I successfully run `hub submodule add --branch foo mojombo/grit vendor/grit`
-    Then "git submodule add --branch foo git://github.com/mojombo/grit.git vendor/grit" should be run
+    Then "git submodule add --branch foo https://github.com/mojombo/grit.git vendor/grit" should be run

--- a/github/project.go
+++ b/github/project.go
@@ -73,14 +73,19 @@ func (p *Project) GitURL(name, owner string, isSSH bool) (url string) {
 	host := rawHost(p.Host)
 
 	if preferredProtocol() == "https" {
-		url = fmt.Sprintf("https://%s/%s/%s.git", host, owner, name)
-	} else if isSSH || preferredProtocol() == "ssh" {
-		url = fmt.Sprintf("git@%s:%s/%s.git", host, owner, name)
-	} else {
-		url = fmt.Sprintf("git://%s/%s/%s.git", host, owner, name)
+		return fmt.Sprintf("https://%s/%s/%s.git", host, owner, name)
 	}
 
-	return url
+	if isSSH || preferredProtocol() == "ssh" {
+		return fmt.Sprintf("git@%s:%s/%s.git", host, owner, name)
+	}
+
+	if preferredProtocol() == "git" {
+		return fmt.Sprintf("git://%s/%s/%s.git", host, owner, name)
+	}
+
+	// default to using the https url
+	return fmt.Sprintf("https://%s/%s/%s.git", host, owner, name)
 }
 
 // Remove the scheme from host when the host url is absolute.

--- a/github/project_test.go
+++ b/github/project_test.go
@@ -34,7 +34,6 @@ func TestProject_WebURL(t *testing.T) {
 }
 
 func TestProject_GitURL(t *testing.T) {
-	os.Setenv("HUB_PROTOCOL", "https")
 	defer os.Setenv("HUB_PROTOCOL", "")
 
 	project := Project{
@@ -43,6 +42,7 @@ func TestProject_GitURL(t *testing.T) {
 		Host:  "github.com",
 	}
 
+	os.Setenv("HUB_PROTOCOL", "https")
 	url := project.GitURL("gh", "jingweno", false)
 	assert.Equal(t, "https://github.com/jingweno/gh.git", url)
 
@@ -54,8 +54,12 @@ func TestProject_GitURL(t *testing.T) {
 	url = project.GitURL("gh", "jingweno", true)
 	assert.Equal(t, "git@github.com:jingweno/gh.git", url)
 
-	url = project.GitURL("gh", "jingweno", true)
+	url = project.GitURL("gh", "jingweno", false)
 	assert.Equal(t, "git@github.com:jingweno/gh.git", url)
+
+	os.Setenv("HUB_PROTOCOL", "")
+	url = project.GitURL("gh", "jingweno", false)
+	assert.Equal(t, "https://github.com/jingweno/gh.git", url)
 }
 
 func TestProject_GitURLEnterprise(t *testing.T) {
@@ -81,6 +85,10 @@ func TestProject_GitURLEnterprise(t *testing.T) {
 
 	url = project.GitURL("gh", "jingweno", true)
 	assert.Equal(t, "git@github.corporate.com:jingweno/gh.git", url)
+
+	os.Setenv("HUB_PROTOCOL", "")
+	url = project.GitURL("gh", "jingweno", false)
+	assert.Equal(t, "https://github.corporate.com/jingweno/gh.git", url)
 }
 
 func TestProject_NewProjectFromURL(t *testing.T) {


### PR DESCRIPTION
Fixes #1596 and closes #1318 

This makes URLs default to using HTTPS instead of the plain git protocol (`git://`).

I think I got all the tests related to this change. Let me know if I missed out anything!