### PR TITLE
[RFC] Make fork --remote-name=origin rename origin

### DIFF
--- a/commands/fork.go
+++ b/commands/fork.go
@@ -112,7 +112,7 @@ func fork(cmd *Command, args *Args) {
 		originURL := originRemote.URL.String()
 		url := forkProject.GitURL("", "", true)
 
-		// Check to see if the remote already exists and points to the fork.
+		// Check to see if the remote already exists.
 		currentRemote, err := localRepo.RemoteByName(newRemoteName)
 		if err == nil {
 			currentProject, err := currentRemote.Project()
@@ -120,6 +120,11 @@ func fork(cmd *Command, args *Args) {
 				if currentProject.SameAs(forkProject) {
 					ui.Printf("existing remote: %s\n", newRemoteName)
 					return
+				}
+				if newRemoteName == "origin" {
+					// Assume user wants to follow github guides for collaboration
+					ui.Printf("renaming existing \"origin\" remote to \"upstream\"\n")
+					args.Before("git", "remote", "rename", "origin", "upstream")
 				}
 			}
 		}

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -34,12 +34,16 @@ Feature: hub fork
         json :name => 'dotfiles', :owner => { :login => 'mislav' }
       }
       """
-    And I successfully run `git remote rename origin upstream`
     When I successfully run `hub fork --remote-name=origin`
-    Then the output should contain exactly "new remote: origin\n"
+    Then the output should contain exactly:
+      """
+      renaming existing "origin" remote to "upstream"
+      new remote: origin\n
+      """
     And "git remote add -f origin git://github.com/evilchelu/dotfiles.git" should be run
     And "git remote set-url origin git@github.com:mislav/dotfiles.git" should be run
     And the url for "origin" should be "git@github.com:mislav/dotfiles.git"
+    And the url for "upstream" should be "git://github.com/evilchelu/dotfiles.git"
 
   Scenario: Fork the repository with redirect
     Given the GitHub API server:


### PR DESCRIPTION
If user passes `origin` as the remote name
pointing to forked repository it's likely
she wants to rename origin as upstream.