### PR TITLE
Fix base branch detection during `hub pull-request`

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -444,14 +444,15 @@ func (client *Client) FetchCIStatus(project *Project, sha string) (status *CISta
 }
 
 type Repository struct {
-	Name        string                 `json:"name"`
-	FullName    string                 `json:"full_name"`
-	Parent      *Repository            `json:"parent"`
-	Owner       *User                  `json:"owner"`
-	Private     bool                   `json:"private"`
-	HasWiki     bool                   `json:"has_wiki"`
-	Permissions *RepositoryPermissions `json:"permissions"`
-	HtmlUrl     string                 `json:"html_url"`
+	Name          string                 `json:"name"`
+	FullName      string                 `json:"full_name"`
+	Parent        *Repository            `json:"parent"`
+	Owner         *User                  `json:"owner"`
+	Private       bool                   `json:"private"`
+	HasWiki       bool                   `json:"has_wiki"`
+	Permissions   *RepositoryPermissions `json:"permissions"`
+	HtmlUrl       string                 `json:"html_url"`
+	DefaultBranch string                 `json:"default_branch"`
 }
 
 type RepositoryPermissions struct {

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -103,12 +103,7 @@ func (r *GitHubRepo) CurrentBranch() (branch *Branch, err error) {
 }
 
 func (r *GitHubRepo) MasterBranch() (branch *Branch) {
-	origin, e := r.RemoteByName("origin")
-	var name string
-	if e == nil {
-		name, _ = git.BranchAtRef("refs", "remotes", origin.Name, "HEAD")
-	}
-
+	name := r.remoteMasterBranchName()
 	if name == "" {
 		name = "refs/heads/master"
 	}
@@ -116,6 +111,23 @@ func (r *GitHubRepo) MasterBranch() (branch *Branch) {
 	branch = &Branch{r, name}
 
 	return
+}
+
+func (r *GitHubRepo) RemoteMasterBranch() (b *Branch, ok bool) {
+	name := r.remoteMasterBranchName()
+	if name == "" {
+		return nil, false
+	}
+	return &Branch{Repo: r, Name: name}, true
+}
+
+func (r *GitHubRepo) remoteMasterBranchName() string {
+	origin, e := r.RemoteByName("origin")
+	var name string
+	if e == nil {
+		name, _ = git.BranchAtRef("refs", "remotes", origin.Name, "HEAD")
+	}
+	return name
 }
 
 func (r *GitHubRepo) RemoteBranchAndProject(owner string, preferUpstream bool) (branch *Branch, project *Project, err error) {


### PR DESCRIPTION
Pull requests now use `default_branch` from the repository configuration (JSON) when no `.git/refs/remotes/origin/HEAD` is present. If the two differ, a warning is printed to the console and the local base branch is used.

This PR covers the following scenarios:

* There is no `.git/refs/remotes/origin/HEAD`, uses `default_branch` (from JSON)
* The branch in `.git/refs/remotes/origin/HEAD` differs from `default_branch`, uses `.git/refs/remotes/origin/HEAD` and prints a warning to the console (see below)

Example warning:

```console
$ hub pull-request
Warning: Local base branch differs from remote (got: developmen, want: development), to fix:
        git remote set-head origin --auto
```

I considered writing a test but the tests don't pass (even on `master`). Running macOS 10.13.3, Go 1.10, Git 2.16.2. The failing test output is available in [this gist](https://gist.github.com/mafredri/eaa34e30ac8022a348c19ab07edf4d95).

Running the tests also made changes to my personal git configuration (including alias modifications, not cool 😢). Lucky I've got it in version control.

Fixes #1538.