### PR TITLE
WIP milestones

### DIFF
--- a/commands/milestones.go
+++ b/commands/milestones.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/github/hub/github"
+	"github.com/github/hub/utils"
+)
+
+var (
+	cmdMilestone = &Command{
+		// TODO: Add usage information, eventually get rid of `Key: "milestone",`
+		Key: "milestone",
+		Run: listMilestones,
+	}
+
+	cmdCreateMilestone = &Command{
+		Key: "create",
+		Run: createMilestone,
+	}
+
+	// TODO: Add update, delete, get subcommands
+)
+
+func init() {
+	cmdMilestone.Use(cmdCreateMilestone)
+	CmdRunner.Use(cmdMilestone)
+}
+
+func listMilestones(cmd *Command, args *Args) {
+	return
+}
+
+func createMilestone(cmd *Command, args *Args) {
+	// TODO: Add flags for title, description, state, due_on date
+	localRepo, err := github.LocalRepo()
+	utils.Check(err)
+
+	project, err := localRepo.CurrentProject()
+	utils.Check(err)
+	gh := github.NewClient(project.Host)
+
+	messageBuilder := &github.MessageBuilder{
+		Filename: "MILESTONE_EDITMSG",
+		Title:    "milestone",
+	}
+	messageBuilder.AddCommentedSection(fmt.Sprintf(`Creating milestone for %s
+
+Write a description for this milestone. The first block of
+text is the title and the rest is the description `, project))
+	messageBuilder.Edit = true
+	title, body, err := messageBuilder.Extract()
+	messageBuilder.Cleanup()
+	utils.Check(err)
+
+	if title == "" {
+		utils.Check(fmt.Errorf("Aborting milestone creation due to empty milestone title"))
+	}
+	params := &github.MilestoneParams{
+		Title:       title,
+		Description: body,
+		State:       "open",
+		DueOn:       "",
+	}
+	var milestone *github.Milestone
+	args.NoForward()
+	milestone, err = gh.CreateMilestone(project, params)
+	utils.Check(err)
+
+	printBrowseOrCopy(args, milestone.HtmlUrl, false, false)
+}

--- a/github/client.go
+++ b/github/client.go
@@ -526,8 +526,89 @@ type User struct {
 }
 
 type Milestone struct {
-	Number int    `json:"number"`
-	Title  string `json:"title"`
+	ApiUrl       string `json:"url"`
+	HtmlUrl      string `json:"html_url"`
+	LabelsUrl    string `json:"labels_url"`
+	Id           int    `json:"id"`
+	Number       int    `json:"number"`
+	State        string `json:"state"`
+	Title        string `json:"title"`
+	Description  string `json:"description"`
+	OpenIssues   int    `json:"open_issues"`
+	ClosedIssues int    `json:"closed_issues"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+	ClosedAt     string `json:"closed_at"`
+	DueOn        string `json:"due_on"`
+}
+
+type MilestoneParams struct {
+	Title       string `json:"title"`
+	State       string `json:"state"`
+	Description string `json:"description,omitempty"`
+	DueOn       string `json:"due_on,omitempty"`
+}
+
+func (client *Client) CreateMilestone(project *Project, params *MilestoneParams) (milestone *Milestone, err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	res, err := api.PostJSON(fmt.Sprintf("repos/%s/%s/milestones", project.Owner, project.Name), params)
+	if err = checkStatus(201, "creating milestone", res, err); err != nil {
+		return
+	}
+
+	milestone = &Milestone{}
+	err = res.Unmarshal(milestone)
+	return
+}
+
+func (client *Client) GetMilestone(project *Project, number string) (milestone *Milestone, err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	res, err := api.Get(fmt.Sprintf("repos/%s/%s/milestones/%s", project.Owner, project.Name, number))
+	if err = checkStatus(200, "creating milestone", res, err); err != nil {
+		return
+	}
+
+	milestone = &Milestone{}
+	err = res.Unmarshal(milestone)
+	return
+}
+
+func (client *Client) UpdateMilestone(project *Project, number string, params *MilestoneParams) (milestone *Milestone, err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	res, err := api.PatchJSON(fmt.Sprintf("repos/%s/%s/milestones/%s", project.Owner, project.Name, number), params)
+	if err = checkStatus(200, "updating milestone", res, err); err != nil {
+		return
+	}
+
+	milestone = &Milestone{}
+	err = res.Unmarshal(milestone)
+	return
+}
+
+func (client *Client) DeleteMilestone(project *Project, number string) (err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	res, err := api.Delete(fmt.Sprintf("repos/%s/%s/milestones/%s", project.Owner, project.Name, number))
+	if err = checkStatus(204, "deleting milestone", res, err); err != nil {
+		return
+	}
+
+	return
 }
 
 func (client *Client) FetchIssues(project *Project, filterParams map[string]interface{}, limit int, filter func(*Issue) bool) (issues []Issue, err error) {


### PR DESCRIPTION
We utilize milestones pretty heavily internally and have had to build one off utilities in order to be able to do it automatically, it'd be great if we could just do this in `hub`.

The goal is basically to provide functionality for all of the API calls found at https://developer.github.com/v3/issues/milestones/

Relates to:

* https://github.com/github/hub/issues/1343

Work to be done:
* Add commands to:
  * [ ] create milestones
  * [ ] list milestones
  * [ ] update milestones
  * [ ] delete milestones
  * [ ] get a single milestone 

UX still needs to be fleshed out but I this right now is just a starting point

If this functionality is not desired let me know and I'll happily close the PR.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>