### PR TITLE
Set slice length to known number of args

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -97,7 +97,7 @@ func New(cmd string) *Cmd {
 	utils.Check(err)
 
 	name := cmds[0]
-	args := make([]string, 0)
+	args := make([]string, len(cmds)-1)
 	for _, arg := range cmds[1:] {
 		args = append(args, arg)
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -97,8 +97,7 @@ func New(cmd string) *Cmd {
 	utils.Check(err)
 
 	name := cmds[0]
-	args := make([]string, len(cmds)-1)
-	copy(args, cmds[1:])
+	args := cmds[1:]
 
 	return &Cmd{Name: name, Args: args, Stdin: os.Stdin, Stdout: os.Stdout, Stderr: os.Stderr}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -98,9 +98,8 @@ func New(cmd string) *Cmd {
 
 	name := cmds[0]
 	args := make([]string, len(cmds)-1)
-	for _, arg := range cmds[1:] {
-		args = append(args, arg)
-	}
+	copy(args, cmds[1:])
+
 	return &Cmd{Name: name, Args: args, Stdin: os.Stdin, Stdout: os.Stdout, Stderr: os.Stderr}
 }
 


### PR DESCRIPTION
*This is a majorly inconsequential change and saw this when I was looking through the source on my phone.*

The arguments slice is made with an initial length of 0 rather than the number of arguments that will be given, so it will be reprovisioned at least once by copying contents from the underlying array to a new one. This is work that doesn't need to be done, this PR makes the the args slice's initial length the exact number of arguments that will be appending to the slice. No array copies needed!

I could not find a contribution guide from the README, please let me know if there are any more steps through which this needs to go. 