### PR TITLE
Create '--no-edit' option for hub pull-request

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -246,7 +246,7 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 	} else if flagPullRequestNoEdit {
 		commits, _ := git.RefList(baseTracking, head)
 		if len(commits) == 0 {
-			utils.Check(fmt.Errorf("No commits detected between '<BASE>' and '<HEAD>' branches"))
+			utils.Check(fmt.Errorf("Aborted: no commits detected between %s and %s", baseTracking, head))
 		}
 		message, err := git.Show(commits[len(commits)-1])
 		utils.Check(err)

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -160,6 +160,77 @@ Feature: hub pull-request
     When I successfully run `hub pull-request`
     Then the output should contain exactly "the://url\n"
 
+  Scenario: Single-commit pull request with "--no-edit"
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :title => 'Commit title 1',
+               :body => 'Commit body 1'
+        status 201
+        json :html_url => "the://url"
+      }
+      """
+    Given I am on the "master" branch pushed to "origin/master"
+    When I successfully run `git checkout --quiet -b topic`
+    Given I make a commit with message:
+      """
+      Commit title 1
+
+      Commit body 1
+      """
+    And the "topic" branch is pushed to "origin/topic"
+    When I successfully run `hub pull-request --no-edit`
+    Then the output should contain exactly "the://url\n"
+
+  Scenario: Multiple-commit pull request with "--no-edit"
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :title => 'Commit title 1',
+               :body => 'Commit body 1'
+        status 201
+        json :html_url => "the://url"
+      }
+      """
+    Given I am on the "master" branch pushed to "origin/master"
+    When I successfully run `git checkout --quiet -b topic`
+    Given I make a commit with message:
+      """
+      Commit title 1
+
+      Commit body 1
+      """
+    Given I make a commit with message:
+      """
+      Commit title 2
+
+      Commit body 2
+      """
+    And the "topic" branch is pushed to "origin/topic"
+    When I successfully run `hub pull-request --no-edit`
+    Then the output should contain exactly "the://url\n"
+
+  Scenario: Pull request with "--push" and "--no-edit"
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :title => 'Commit title 1',
+               :body => 'Commit body 1'
+        status 201
+        json :html_url => "the://url"
+      }
+      """
+    Given I am on the "master" branch pushed to "origin/master"
+    When I successfully run `git checkout --quiet -b topic`
+    Given I make a commit with message:
+      """
+      Commit title 1
+
+      Commit body 1
+      """
+    When I successfully run `hub pull-request --push --no-edit`
+    Then the output should contain exactly "the://url\n"
+
   Scenario: Message template should include git log summary between base and head
     Given the text editor adds:
       """

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -231,6 +231,16 @@ Feature: hub pull-request
     When I successfully run `hub pull-request --push --no-edit`
     Then the output should contain exactly "the://url\n"
 
+  Scenario: No commits with "--no-edit"
+    Given I am on the "master" branch pushed to "origin/master"
+    When I successfully run `git checkout --quiet -b topic`
+    And I run `hub pull-request --no-edit`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      Aborted: no commits detected between origin/master and topic\n
+      """
+
   Scenario: Message template should include git log summary between base and head
     Given the text editor adds:
       """


### PR DESCRIPTION
This feature is inspired by Git's own ```git commit --amend --no-edit```. It's nice to have when scripting around Git/Hub to avoid stopping the workflow to save-and-close the text editor e.g. when firing away small fixes on multiple repos.

I create this PR using the feature itself:

```hub pull-request --no-edit```