### PR TITLE
pull-request: Hide Signed-off-by

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -252,6 +252,9 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 		if len(commits) == 1 {
 			message, err = git.Show(commits[0])
 			utils.Check(err)
+
+			re := regexp.MustCompile(`(?m)\n^Signed-off-by:\s.*$`)
+			message = re.ReplaceAllString(message, "")
 		} else if len(commits) > 1 {
 			commitLogs, err = git.Log(baseTracking, headForMessage)
 			utils.Check(err)

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -253,7 +253,7 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 			message, err = git.Show(commits[0])
 			utils.Check(err)
 
-			re := regexp.MustCompile(`(?m)\n^Signed-off-by:\s.*$`)
+			re := regexp.MustCompile(`\nSigned-off-by:\s.*$`)
 			message = re.ReplaceAllString(message, "")
 		} else if len(commits) > 1 {
 			commitLogs, err = git.Log(baseTracking, headForMessage)

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -81,14 +81,20 @@ Feature: hub pull-request
       post('/repos/mislav/coral/pulls') {
         halt 400 if request.content_charset != 'utf-8'
         assert :title => 'This is somewhat of a longish title that does not get wrapped & references #1234',
-               :body => nil
+               :body => 'Hello'
         status 201
         json :html_url => "the://url"
       }
       """
     Given I am on the "master" branch pushed to "origin/master"
     When I successfully run `git checkout --quiet -b topic`
-    Given I make a commit with message "This is somewhat of a longish title that does not get wrapped & references #1234"
+    Given I make a commit with message:
+      """
+      This is somewhat of a longish title that does not get wrapped & references #1234
+
+      Hello
+      Signed-off-by: NAME <email@example.com>
+      """
     And the "topic" branch is pushed to "origin/topic"
     When I successfully run `hub pull-request`
     Then the output should contain exactly "the://url\n"


### PR DESCRIPTION
Fixes #1724.

This patch omits the "Signed-off-by:" line coming from pull requests created
out of single commit messages. This way the user does not need to manually
remove their email address from the PR description.

Not introducing a flag for this as it applies to only one case (single-commit
diff between heads, as well as no -m/-f/-i specified).

Meta: sending this PR with the patched build, my Signed-off-by line is removed
automatically from the PR message.