### PR TITLE
Pull Request: look for templates in docs/ too

### DIFF
--- a/github/template.go
+++ b/github/template.go
@@ -10,12 +10,17 @@ const (
 	PullRequestTemplate = "pull_request_template"
 	IssueTemplate       = "issue_template"
 	githubTemplateDir   = ".github"
+	docsDir             = "docs"
 )
 
 func ReadTemplate(kind, workdir string) (body string, err error) {
 	templateDir := filepath.Join(workdir, githubTemplateDir)
 
 	path, err := getFilePath(templateDir, kind)
+	if err != nil || path == "" {
+		docsDir := filepath.Join(workdir, docsDir)
+		path, err = getFilePath(docsDir, kind)
+	}
 	if err != nil || path == "" {
 		path, err = getFilePath(workdir, kind)
 	}

--- a/github/template_test.go
+++ b/github/template_test.go
@@ -120,6 +120,22 @@ func TestGithubTemplate_WithTemplateInGithubDirAndMarkdown(t *testing.T) {
 	assert.Equal(t, issueContent, tpl)
 }
 
+func TestGithubTemplate_WithTemplateInDocsDir(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	addGithubTemplates(repo, map[string]string{"dir": docsDir})
+
+	pwd, _ := os.Getwd()
+	tpl, err := ReadTemplate(PullRequestTemplate, pwd)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, prContent, tpl)
+
+	tpl, err = ReadTemplate(IssueTemplate, pwd)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, issueContent, tpl)
+}
+
 func addGithubTemplates(r *fixtures.TestRepo, config map[string]string) {
 	repoDir := "test.git"
 	if dir := config["dir"]; dir != "" {


### PR DESCRIPTION
According to https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/, the `pull_request_template.md` file can also be stored in directory called `docs/`.