### PR TITLE
PR checkout: ensure resulting branch is automatically pushable

### DIFF
--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -106,10 +106,9 @@ func transformCheckoutArgs(args *Args, pullRequest *github.PullRequest, newBranc
 		args.Before("git", "fetch", headRemote.Name, refSpec)
 	} else {
 		if newBranchName == "" {
-			if pullRequest.Head.Repo == nil {
-				newBranchName = fmt.Sprintf("pr-%d", pullRequest.Number)
-			} else {
-				newBranchName = fmt.Sprintf("%s-%s", pullRequest.Head.Repo.Owner.Login, pullRequest.Head.Ref)
+			newBranchName = pullRequest.Head.Ref
+			if pullRequest.Head.Repo != nil && newBranchName == pullRequest.Head.Repo.DefaultBranch {
+				newBranchName = fmt.Sprintf("%s-%s", pullRequest.Head.Repo.Owner.Login, newBranchName)
 			}
 		}
 		newArgs = append(newArgs, newBranchName)

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -29,9 +29,35 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
-    Then "git fetch origin refs/pull/77/head:mislav-fixes" should be run
-    And "git checkout -f mislav-fixes -q" should be run
-    And "mislav-fixes" should merge "refs/pull/77/head" from remote "origin"
+    Then "git fetch origin refs/pull/77/head:fixes" should be run
+    And "git checkout -f fixes -q" should be run
+    And "fixes" should merge "refs/pull/77/head" from remote "origin"
+
+  Scenario: Head ref matches default branch
+    Given the GitHub API server:
+      """
+      get('/repos/mojombo/jekyll/pulls/77') {
+        json :number => 77, :head => {
+          :ref => "master",
+          :repo => {
+            :owner => { :login => "mislav" },
+            :name => "jekyll",
+            :default_branch => "master",
+            :private => false
+          }
+        }, :base => {
+          :repo => {
+            :name => 'jekyll',
+            :html_url => 'https://github.com/mojombo/jekyll',
+            :owner => { :login => "mojombo" },
+          }
+        }, :maintainer_can_modify => false
+      }
+      """
+    When I run `hub checkout https://github.com/mojombo/jekyll/pull/77`
+    Then "git fetch origin refs/pull/77/head:mislav-master" should be run
+    And "git checkout mislav-master" should be run
+    And "mislav-master" should merge "refs/pull/77/head" from remote "origin"
 
   Scenario: No matching remotes for pull request base
     Given the GitHub API server:
@@ -140,9 +166,9 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout https://github.com/mojombo/jekyll/pull/77`
-    Then "git fetch origin refs/pull/77/head:pr-77" should be run
-    And "git checkout pr-77" should be run
-    And "pr-77" should merge "refs/pull/77/head" from remote "origin"
+    Then "git fetch origin refs/pull/77/head:fixes" should be run
+    And "git checkout fixes" should be run
+    And "fixes" should merge "refs/pull/77/head" from remote "origin"
 
   Scenario: Reuse existing remote for head branch
     Given the GitHub API server:
@@ -218,9 +244,9 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
-    Then "git fetch origin refs/pull/77/head:mislav-fixes" should be run
-    And "git checkout -f mislav-fixes -q" should be run
-    And "mislav-fixes" should merge "refs/heads/fixes" from remote "git@github.com:mislav/jekyll.git"
+    Then "git fetch origin refs/pull/77/head:fixes" should be run
+    And "git checkout -f fixes -q" should be run
+    And "fixes" should merge "refs/heads/fixes" from remote "git@github.com:mislav/jekyll.git"
 
   Scenario: Modifiable fork with HTTPS
     Given the GitHub API server:
@@ -245,6 +271,6 @@ Feature: hub checkout <PULLREQ-URL>
       """
     And HTTPS is preferred
     When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
-    Then "git fetch origin refs/pull/77/head:mislav-fixes" should be run
-    And "git checkout -f mislav-fixes -q" should be run
-    And "mislav-fixes" should merge "refs/heads/fixes" from remote "https://github.com/mislav/jekyll.git"
+    Then "git fetch origin refs/pull/77/head:fixes" should be run
+    And "git checkout -f fixes -q" should be run
+    And "fixes" should merge "refs/heads/fixes" from remote "https://github.com/mislav/jekyll.git"

--- a/features/pr.feature
+++ b/features/pr.feature
@@ -26,9 +26,9 @@ Feature: hub pr checkout <PULLREQ-NUMBER>
       }
       """
     When I run `hub pr checkout 77`
-    Then "git fetch origin refs/pull/77/head:mislav-fixes" should be run
-    And "git checkout mislav-fixes" should be run
-    And "mislav-fixes" should merge "refs/pull/77/head" from remote "origin"
+    Then "git fetch origin refs/pull/77/head:fixes" should be run
+    And "git checkout fixes" should be run
+    And "fixes" should merge "refs/pull/77/head" from remote "origin"
 
   Scenario: Custom name for new branch
     Given the GitHub API server:

--- a/github/client.go
+++ b/github/client.go
@@ -445,14 +445,15 @@ func (client *Client) FetchCIStatus(project *Project, sha string) (status *CISta
 }
 
 type Repository struct {
-	Name        string                 `json:"name"`
-	FullName    string                 `json:"full_name"`
-	Parent      *Repository            `json:"parent"`
-	Owner       *User                  `json:"owner"`
-	Private     bool                   `json:"private"`
-	HasWiki     bool                   `json:"has_wiki"`
-	Permissions *RepositoryPermissions `json:"permissions"`
-	HtmlUrl     string                 `json:"html_url"`
+	Name          string                 `json:"name"`
+	FullName      string                 `json:"full_name"`
+	Parent        *Repository            `json:"parent"`
+	Owner         *User                  `json:"owner"`
+	Private       bool                   `json:"private"`
+	HasWiki       bool                   `json:"has_wiki"`
+	Permissions   *RepositoryPermissions `json:"permissions"`
+	HtmlUrl       string                 `json:"html_url"`
+	DefaultBranch string                 `json:"default_branch"`
 }
 
 type RepositoryPermissions struct {


### PR DESCRIPTION
When checking out a PR, use its head ref for the default branch name so that `git push` works by default to push commits back to the PR.

With git default `push.default` setting being "simple", having the local branch name match the upstream branch name means that `git push` can work without additional arguments.

Fixes #1495