### PR TITLE
Do not pass `--cmd' to vi in openTextEditor()

### DIFF
--- a/github/editor.go
+++ b/github/editor.go
@@ -129,7 +129,7 @@ func (e *Editor) readContent() (content []byte, err error) {
 
 func openTextEditor(program, file string) error {
 	editCmd := cmd.New(program)
-	r := regexp.MustCompile(`\b(?:[gm]?vim|vi)(?:\.exe)?$`)
+	r := regexp.MustCompile(`\b(?:[gm]?vim)(?:\.exe)?$`)
 	if r.MatchString(editCmd.Name) {
 		editCmd.WithArg("--cmd")
 		editCmd.WithArg("set ft=gitcommit tw=0 wrap lbr")


### PR DESCRIPTION
As discussed in issue #1772 do not pass `--cmd` arguments to `vi` because they
are specific to vim.

(I have not deleted the non-grouping parentheses in the RE to help
readability.)