### PR TITLE
Add DESTDIR support for `make install`

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -17,7 +17,7 @@ prefix="${PREFIX:-$prefix}"
 prefix="${prefix:-/usr/local}"
 
 for src in bin/hub share/man/*/*.1; do
-  dest="${prefix}/${src}"
+  dest="${DESTDIR}${prefix}/${src}"
   mkdir -p "${dest%/*}"
   [[ $src == share/* ]] && mode="644" || mode=755
   install -m "$mode" "$src" "$dest"

--- a/script/test
+++ b/script/test
@@ -31,20 +31,25 @@ STATUS=0
 
 trap "exit 1" INT
 
+check_formatting() {
+  [[ "$(go version)" != *" go1.8."* ]] || return 0
+  make fmt >/dev/null
+  if ! git diff -U1 --exit-code; then
+    echo
+    echo "Some go code was not formatted properly." >&2
+    echo "Run \`make fmt' locally to fix these errors." >&2
+    return 1
+  fi
+}
+
 [ -z "$HUB_COVERAGE" ] || script/coverage prepare
 script/build
 go test ./... || STATUS="$?"
 script/ruby-test "$@" || STATUS="$?"
-[ -z "$HUB_COVERAGE" ] || script/coverage summarize "$min_coverage" || STATUS=1
+[ -z "$HUB_COVERAGE" ] || script/coverage summarize "$min_coverage" || STATUS="$?"
 
-if [ -n "$CI" ] && [[ "$(go version)" != *" go1.8."* ]]; then
-  make fmt >/dev/null
-  if ! git diff -U1 --exit-code; then
-    STATUS=1
-    echo
-    echo "Some go code was not formatted properly." >&2
-    echo "Run \`make fmt' locally to fix these errors." >&2
-  fi
+if [ -n "$CI" ]; then
+  check_formatting || STATUS="$?"
 fi
 
 exit "$STATUS"

--- a/script/test
+++ b/script/test
@@ -42,6 +42,15 @@ check_formatting() {
   fi
 }
 
+install_test() {
+  touch share/man/man1/hub.1
+  DESTDIR="$PWD/tmp/destdir" prefix=/my/prefix bash < script/install.sh
+  test -x tmp/destdir/my/prefix/bin/hub
+  test -e tmp/destdir/my/prefix/share/man/man1/hub.1
+  test ! -x tmp/destdir/my/prefix/share/man/man1/hub.1
+  rm share/man/man1/hub.1
+}
+
 [ -z "$HUB_COVERAGE" ] || script/coverage prepare
 script/build
 go test ./... || STATUS="$?"
@@ -50,6 +59,7 @@ script/ruby-test "$@" || STATUS="$?"
 
 if [ -n "$CI" ]; then
   check_formatting || STATUS="$?"
+  install_test || STATUS="$?"
 fi
 
 exit "$STATUS"


### PR DESCRIPTION
When packaging for distributions (particularly RPM), it is common
for the packaging tool to install all of the files into a chroot-
style directory structure as a non-privileged user. This is done
to avoid requiring root privileges for packaging (particularly to
avoid issues where the attempt to package causes changes to be
made to the packaging host.

The standard variable used for this (from autotools) is DESTDIR.
This patch adds DESTDIR before the prefix in install.sh to ensure
that when `make install` is run, it will direct output to the
proper location.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>