### PR TITLE
Add documentation link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ $ git clone git://github.com/rtomayko/tilt.git
 hub is best aliased as `git`, so you can type `$ git <command>` in the shell and
 get all the usual `hub` features. See "Aliasing" below.
 
+Usage documentation
+------------
+
+https://hub.github.com/hub.1.html
+
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -14,11 +14,8 @@ $ git clone git://github.com/rtomayko/tilt.git
 hub is best aliased as `git`, so you can type `$ git <command>` in the shell and
 get all the usual `hub` features. See "Aliasing" below.
 
-Usage documentation
-------------
-
-https://hub.github.com/hub.1.html
-
+See [Usage documentation](https://hub.github.com/hub.1.html) for the list of all
+commands and their arguments.
 
 Installation
 ------------


### PR DESCRIPTION
I found it quite hard to find the documentation from the GitHub repo. I think the only link is in the header, and from that page I didn't find the link to documentation easily either. Might be worth adding a link in the Readme?