### PR TITLE
Fix integration with git 2.18 shell completions

### DIFF
--- a/commands/args.go
+++ b/commands/args.go
@@ -208,6 +208,7 @@ func NewArgs(args []string) *Args {
 const (
 	noopFlag    = "--noop"
 	versionFlag = "--version"
+	listCmds    = "--list-cmds="
 	helpFlag    = "--help"
 	configFlag  = "-c"
 	chdirFlag   = "-C"
@@ -226,7 +227,7 @@ func slurpGlobalFlags(args *[]string, globalFlags *[]string) {
 		if slurpNextValue {
 			commandIndex = i + 1
 			slurpNextValue = false
-		} else if arg == versionFlag || arg == helpFlag || !looksLikeFlag(arg) {
+		} else if arg == versionFlag || arg == helpFlag || strings.HasPrefix(arg, listCmds) || !looksLikeFlag(arg) {
 			break
 		} else {
 			commandIndex = i + 1

--- a/commands/help.go
+++ b/commands/help.go
@@ -45,8 +45,15 @@ hub(1), git-help(1)
 `,
 }
 
+var cmdListCmds = &Command{
+	Key:          "--list-cmds",
+	Run:          runListCmds,
+	GitExtension: true,
+}
+
 func init() {
 	CmdRunner.Use(cmdHelp, "--help")
+	CmdRunner.Use(cmdListCmds)
 }
 
 func runHelp(helpCmd *Command, args *Args) {
@@ -86,6 +93,24 @@ func runHelp(helpCmd *Command, args *Args) {
 
 		ui.Println(c.HelpText())
 		args.NoForward()
+	}
+}
+
+func runListCmds(cmd *Command, args *Args) {
+	listOthers := false
+	parts := strings.SplitN(args.Command, "=", 2)
+	for _, kind := range strings.Split(parts[1], ",") {
+		if kind == "others" {
+			listOthers = true
+			break
+		}
+	}
+
+	if listOthers {
+		args.AfterFn(func() error {
+			ui.Println(strings.Join(customCommands(), "\n"))
+			return nil
+		})
 	}
 }
 

--- a/commands/help.go
+++ b/commands/help.go
@@ -171,9 +171,9 @@ These GitHub commands are provided by hub:
    create         Create this repository on GitHub and add GitHub as origin
    delete         Delete a repository on GitHub
    fork           Make a fork of a remote repository on GitHub and add as remote
-   issue          List or create issues
-   pr             Work with pull requests
+   issue          List or create GitHub issues
+   pr             List or checkout GitHub pull requests
    pull-request   Open a pull request on GitHub
-   release        List or create releases
+   release        List or create GitHub releases
    sync           Fetch git objects from upstream and update branches
 `

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -92,6 +92,7 @@ func (r *Runner) Execute() ExecError {
 	git.GlobalFlags = args.GlobalFlags // preserve git global flags
 	if !isBuiltInHubCommand(cmdName) {
 		expandAlias(args)
+		cmdName = args.Command
 	}
 
 	cmd := r.Lookup(cmdName)

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -84,12 +84,17 @@ func (r *Runner) Execute() ExecError {
 		forceFail = true
 	}
 
+	cmdName := args.Command
+	if strings.Contains(cmdName, "=") {
+		cmdName = strings.SplitN(cmdName, "=", 2)[0]
+	}
+
 	git.GlobalFlags = args.GlobalFlags // preserve git global flags
-	if !isBuiltInHubCommand(args.Command) {
+	if !isBuiltInHubCommand(cmdName) {
 		expandAlias(args)
 	}
 
-	cmd := r.Lookup(args.Command)
+	cmd := r.Lookup(cmdName)
 	if cmd != nil && cmd.Runnable() {
 		execErr := r.Call(cmd, args)
 		if execErr.ExitCode == 0 && forceFail {

--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -17,8 +17,12 @@ if declare -F _git > /dev/null && ! declare -F __git_list_all_commands_without_h
     cat <<-EOF
 alias
 pull-request
+pr
+issue
+release
 fork
 create
+delete
 browse
 compare
 ci-status

--- a/etc/hub.fish_completion
+++ b/etc/hub.fish_completion
@@ -21,8 +21,12 @@ complete -f -c hub -n '__fish_hub_needs_command' -a alias -d "show shell instruc
 complete -f -c hub -n '__fish_hub_needs_command' -a browse -d "browse the project on GitHub"
 complete -f -c hub -n '__fish_hub_needs_command' -a compare -d "lookup commit in GitHub Status API"
 complete -f -c hub -n '__fish_hub_needs_command' -a create -d "create new repo on GitHub for the current project"
+complete -f -c hub -n '__fish_hub_needs_command' -a delete -d "delete a GitHub repo"
 complete -f -c hub -n '__fish_hub_needs_command' -a fork -d "fork origin repo on GitHub"
 complete -f -c hub -n '__fish_hub_needs_command' -a pull-request -d "open a pull request on GitHub"
+complete -f -c hub -n '__fish_hub_needs_command' -a pr -d "list or checkout a GitHub release"
+complete -f -c hub -n '__fish_hub_needs_command' -a issue -d "list or create a GitHub issue"
+complete -f -c hub -n '__fish_hub_needs_command' -a release -d "list or create a GitHub release"
 complete -f -c hub -n '__fish_hub_needs_command' -a ci-status -d "display GitHub Status information for a commit"
 complete -f -c hub -n '__fish_hub_needs_command' -a sync -d "update local branches from upstream"
 
@@ -58,5 +62,8 @@ complete -f -c hub -n ' __fish_hub_using_command create' -l browse -d "Open the 
 complete -f -c hub -n ' __fish_hub_using_command create' -s p -d "Create a private repository"
 complete -f -c hub -n ' __fish_hub_using_command create' -s c -d "Put the URL of the new repository to clipboard instead of printing it."
 complete -f -c hub -n ' __fish_hub_using_command create' -l copy -d "Put the URL of the new repository to clipboard instead of printing it."
+# delete
+complete -f -c hub -n ' __fish_hub_using_command delete' -s y -d "Skip the confirmation prompt"
+complete -f -c hub -n ' __fish_hub_using_command delete' -l yes -d "Skip the confirmation prompt"
 # ci-status
 complete -f -c hub -n ' __fish_hub_using_command ci-status' -s v -d "Print detailed report of all status checks and their URLs"

--- a/etc/hub.zsh_completion
+++ b/etc/hub.zsh_completion
@@ -84,8 +84,12 @@ __hub_setup_zsh_fns () {
     hub_commands=(
       alias:'show shell instructions for wrapping git'
       pull-request:'open a pull request on GitHub'
+      pr:'list or checkout a GitHub pull request'
+      issue:'list or create a GitHub issue'
+      release:'list or create a GitHub release'
       fork:'fork origin repo on GitHub'
       create:'create new repo on GitHub for the current project'
+      delete:'delete a GitHub repo'
       browse:'browse the project on GitHub'
       compare:'open GitHub compare view'
       ci-status:'lookup commit in GitHub Status API'
@@ -111,8 +115,12 @@ __hub_setup_bash_fns () {
     cat <<-EOF
 alias
 pull-request
+pr
+issue
+release
 fork
 create
+delete
 browse
 compare
 ci-status

--- a/features/git_compatibility.feature
+++ b/features/git_compatibility.feature
@@ -5,3 +5,7 @@ Feature: git-hub compatibility
     When I successfully run `git config --global alias.branch "branch -a"`
     When I run `hub branch`
     Then the stdout should contain exactly "* master\n"
+
+  Scenario: List commands
+    When I successfully run `hub --list-cmds=others`
+    Then the stdout should contain "pull-request"

--- a/features/git_compatibility.feature
+++ b/features/git_compatibility.feature
@@ -9,3 +9,7 @@ Feature: git-hub compatibility
   Scenario: List commands
     When I successfully run `hub --list-cmds=others`
     Then the stdout should contain "pull-request"
+
+  Scenario: Doesn't sabotage --exec-path
+    When I successfully run `hub --exec-path`
+    Then the output should not contain "These GitHub commands"

--- a/features/git_compatibility.feature
+++ b/features/git_compatibility.feature
@@ -8,7 +8,24 @@ Feature: git-hub compatibility
 
   Scenario: List commands
     When I successfully run `hub --list-cmds=others`
-    Then the stdout should contain "pull-request"
+    Then the stdout should contain exactly:
+      """
+      add
+      branch
+      commit
+      alias
+      browse
+      ci-status
+      compare
+      create
+      delete
+      fork
+      issue
+      pr
+      pull-request
+      release
+      sync\n
+      """
 
   Scenario: Doesn't sabotage --exec-path
     When I successfully run `hub --exec-path`

--- a/features/help.feature
+++ b/features/help.feature
@@ -16,7 +16,3 @@ Feature: hub help
   Scenario: Shows help for a subcommand
     When I successfully run `hub help hub-help`
     Then the output should contain "Usage: hub help"
-
-  Scenario: Doesn't sabotage --exec-path
-    When I successfully run `hub --exec-path`
-    Then the output should not contain "These GitHub commands"

--- a/features/support/fakebin/git
+++ b/features/support/fakebin/git
@@ -7,6 +7,11 @@ command="$1"
 [ "$command" = "config" ] || echo git "$@" >> "$HOME"/.history
 
 case "$command" in
+  "--list-cmds="* )
+    echo add
+    echo branch
+    echo commit
+    ;;
   "clone" | "fetch" | "pull" | "push" )
     # don't actually execute these commands
     exit

--- a/share/man/man1/hub.1.ronn
+++ b/share/man/man1/hub.1.ronn
@@ -66,7 +66,7 @@ git but that are extended through hub, and custom ones that hub provides.
 
   * hub-create(1):
     Create a new repository on GitHub and add a git remote for it.
-  
+
   * hub-delete(1):
     Delete a repository on Github.
 
@@ -75,6 +75,9 @@ git but that are extended through hub, and custom ones that hub provides.
 
   * hub-pull-request(1):
     Create a GitHub pull request.
+
+  * hub-pr(1):
+    List and checkout GitHub pull requests.
 
   * hub-issue(1):
     List and create GitHub issues.


### PR DESCRIPTION
Wrap `git --list-cmds=others` command used by git built-in shell completions to add a list of hub custom commands.

Fixes #1792