### PR TITLE
Have `ci-status` also query Checks API

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -191,7 +191,7 @@ var helpText = `
 These GitHub commands are provided by hub:
 
    browse         Open a GitHub page in the default browser
-   ci-status      Show the CI status of a commit
+   ci-status      Show the status of GitHub checks for a commit
    compare        Open a compare page on GitHub
    create         Create this repository on GitHub and add GitHub as origin
    delete         Delete a repository on GitHub

--- a/etc/hub.zsh_completion
+++ b/etc/hub.zsh_completion
@@ -92,7 +92,7 @@ __hub_setup_zsh_fns () {
       delete:'delete a GitHub repo'
       browse:'browse the project on GitHub'
       compare:'open GitHub compare view'
-      ci-status:'lookup commit in GitHub Status API'
+      ci-status:'show status of GitHub checks for a commit'
       sync:'update local branches from upstream'
     )
     _describe -t hub-commands 'hub command' hub_commands && ret=0

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -259,6 +259,9 @@ Given(/^the remote commit states of "(.*?)" "(.*?)" are:$/) do |proj, ref, json_
     get('#{'/api/v3' if host}/repos/#{owner}/#{repo}/commits/#{rev}/status'#{", :host_name => '#{host}'" if host}) {
       json(#{json_value})
     }
+    get('#{'/api/v3' if host}/repos/#{owner}/#{repo}/commits/#{rev}/check-runs'#{", :host_name => '#{host}'" if host}) {
+      status 422
+    }
     EOS
   step %{the GitHub API server:}, status_endpoint
 end

--- a/github/http.go
+++ b/github/http.go
@@ -21,6 +21,7 @@ import (
 const apiPayloadVersion = "application/vnd.github.v3+json;charset=utf-8"
 const patchMediaType = "application/vnd.github.v3.patch;charset=utf-8"
 const textMediaType = "text/plain;charset=utf-8"
+const checksType = "application/vnd.github.antiope-preview+json;charset=utf-8"
 
 var inspectHeaders = []string{
 	"Authorization",


### PR DESCRIPTION
The results of Status and [Checks API](https://developer.github.com/v3/checks/runs/) are merged together.

Fixes #1787