### PR TITLE
fea(pull_request): short hand for `--no-edit`

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -17,7 +17,7 @@ import (
 var cmdPullRequest = &Command{
 	Run: pullRequest,
 	Usage: `
-pull-request [-focp] [-b <BASE>] [-h <HEAD>] [-r <REVIEWERS> ] [-a <ASSIGNEES>] [-M <MILESTONE>] [-l <LABELS>]
+pull-request [-focpn] [-b <BASE>] [-h <HEAD>] [-r <REVIEWERS> ] [-a <ASSIGNEES>] [-M <MILESTONE>] [-l <LABELS>]
 pull-request -m <MESSAGE> [--edit]
 pull-request -F <FILE> [--edit]
 pull-request -i <ISSUE>
@@ -32,7 +32,7 @@ pull-request -i <ISSUE>
 		Use the first line of <MESSAGE> as pull request title, and the rest as pull
 		request description.
 
-	--no-edit
+	-n, --no-edit
 		Use the message from the first commit on the branch as pull request title
 		and description without opening a text editor.
 
@@ -115,7 +115,7 @@ func init() {
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestEdit, "edit", "e", false, "EDIT")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestPush, "push", "p", false, "PUSH")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestForce, "force", "f", false, "FORCE")
-	cmdPullRequest.Flag.BoolVarP(&flagPullRequestNoEdit, "no-edit", "", false, "NO-EDIT")
+	cmdPullRequest.Flag.BoolVarP(&flagPullRequestNoEdit, "no-edit", "n", false, "NO-EDIT")
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestFile, "file", "F", "", "FILE")
 	cmdPullRequest.Flag.VarP(&flagPullRequestAssignees, "assign", "a", "USERS")
 	cmdPullRequest.Flag.VarP(&flagPullRequestReviewers, "reviewer", "r", "USERS")


### PR DESCRIPTION
Happens so many times I am submitting a tiny pull request something in a
single commit that a shorthand parameter would be very useful.