### PR TITLE
Update link to code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Contributions to this project are [released](https://help.github.com/articles/gi
 
 This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
 
-[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Hub/opensource@github.com
+[code-of-conduct]: ./CODE_OF_CONDUCT.md
 
 You will need:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing to hub
 
 Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
 
-This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
+This project adheres to a [Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
 
 [code-of-conduct]: ./CODE_OF_CONDUCT.md
 


### PR DESCRIPTION
The contributing doc mentions a code of conduct but this links to a nonexistent URL that used to host a code of conduct that has since been abandoned. I updated it to point to the in-repo code of conduct which seems to be kept up to date.