### PR TITLE
Create '--no-track' option for hub pull-request

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -54,6 +54,9 @@ pull-request -i <ISSUE>
 	-p, --push
 		Push the current branch to <HEAD> before creating the pull request.
 
+	--no-track
+		When using "--push", do not change the upstream tracking branch.
+
 	-b, --base <BASE>
 		The base branch in "[OWNER:]BRANCH" format. Defaults to the default branch
 		(usually "master").
@@ -98,6 +101,7 @@ var (
 	flagPullRequestEdit,
 	flagPullRequestPush,
 	flagPullRequestForce,
+	flagPullRequestNoTrack,
 	flagPullRequestNoEdit bool
 
 	flagPullRequestAssignees,
@@ -116,6 +120,7 @@ func init() {
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestPush, "push", "p", false, "PUSH")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestForce, "force", "f", false, "FORCE")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestNoEdit, "no-edit", "", false, "NO-EDIT")
+	cmdPullRequest.Flag.BoolVarP(&flagPullRequestNoTrack, "no-track", "", false, "NO-TRACK")
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestFile, "file", "F", "", "FILE")
 	cmdPullRequest.Flag.VarP(&flagPullRequestAssignees, "assign", "a", "USERS")
 	cmdPullRequest.Flag.VarP(&flagPullRequestReviewers, "reviewer", "r", "USERS")
@@ -300,7 +305,12 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 		if args.Noop {
 			args.Before(fmt.Sprintf("Would push to %s/%s", remote.Name, head), "")
 		} else {
-			err = git.Spawn("push", "--set-upstream", remote.Name, fmt.Sprintf("HEAD:%s", head))
+			args := []string{"push"}
+			if !flagPullRequestNoTrack {
+				args = append(args, "--set-upstream")
+			}
+			args = append(args, remote.Name, fmt.Sprintf("HEAD:%s", head))
+			err = git.Spawn(args...)
 			utils.Check(err)
 		}
 	}

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -1026,6 +1026,24 @@ Feature: hub pull-request
     Then the output should contain exactly "the://url\n"
     And "git push --set-upstream origin HEAD:topic" should be run
 
+  Scenario: Default message with --push --no-track
+    Given the git commit editor is "true"
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :title => 'The commit I never pushed',
+               :body => nil
+        status 201
+        json :html_url => "the://url"
+      }
+      """
+    Given I am on the "master" branch pushed to "origin/master"
+    When I successfully run `git checkout --quiet -b topic`
+    Given I make a commit with message "The commit I never pushed"
+    When I successfully run `hub pull-request -p --no-track`
+    Then the output should contain exactly "the://url\n"
+    And "git push origin HEAD:topic" should be run
+
   Scenario: Text editor fails with --push
     Given the text editor exits with error status
     And I am on the "master" branch pushed to "origin/master"


### PR DESCRIPTION
In my daily work, I always run

    git branch -u origin/master

on my feature branches to keep track of the master branch which I will eventually merge in to. It bothers me that `hub` resets my tracking branch after creating the PR, so that I have to re-run `git branch -u origin/master`.

We could also discuss changing the default behavior of hub to opt-in to `--set-upstream` rather than to opt-out. But for now I am happy as long as I get this option, so that Hub can co-operate smoothly with my workflow.