### PR TITLE
Avoid re-requesting reviewers in case of CODEOWNERS

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -400,16 +400,21 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 			teamReviewers := []string{}
 			for _, reviewer := range flagPullRequestReviewers {
 				if strings.Contains(reviewer, "/") {
-					teamReviewers = append(teamReviewers, strings.SplitN(reviewer, "/", 2)[1])
-				} else {
+					teamName := strings.SplitN(reviewer, "/", 2)[1]
+					if !pr.HasRequestedTeam(teamName) {
+						teamReviewers = append(teamReviewers, teamName)
+					}
+				} else if !pr.HasRequestedReviewer(reviewer) {
 					userReviewers = append(userReviewers, reviewer)
 				}
 			}
-			err = client.RequestReview(baseProject, pr.Number, map[string]interface{}{
-				"reviewers":      userReviewers,
-				"team_reviewers": teamReviewers,
-			})
-			utils.Check(err)
+			if len(userReviewers) > 0 || len(teamReviewers) > 0 {
+				err = client.RequestReview(baseProject, pr.Number, map[string]interface{}{
+					"reviewers":      userReviewers,
+					"team_reviewers": teamReviewers,
+				})
+				utils.Check(err)
+			}
 		}
 	}
 

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -855,7 +855,6 @@ Feature: hub pull-request
         json :html_url => "the://url", :number => 1234
       }
       post('/repos/mislav/coral/pulls/1234/requested_reviewers') {
-        halt 415 unless request.accept?('application/vnd.github.thor-preview+json')
         assert :reviewers => ["mislav", "josh", "pcorpet"]
         assert :team_reviewers => ["robots", "js"]
         status 201
@@ -877,7 +876,6 @@ Feature: hub pull-request
           :requested_teams => [{ :name => "robots" }]
       }
       post('/repos/mislav/coral/pulls/1234/requested_reviewers') {
-        halt 415 unless request.accept?('application/vnd.github.thor-preview+json')
         assert :reviewers => ["mislav", "pcorpet"]
         assert :team_reviewers => ["js"]
         status 201

--- a/github/client.go
+++ b/github/client.go
@@ -551,6 +551,9 @@ type Issue struct {
 	CreatedAt time.Time    `json:"created_at"`
 	UpdatedAt time.Time    `json:"updated_at"`
 
+	RequestedReviewers []User `json:"requested_reviewers"`
+	RequestedTeams     []Team `json:"requested_teams"`
+
 	ApiUrl  string `json:"url"`
 	HtmlUrl string `json:"html_url"`
 }
@@ -570,6 +573,24 @@ func (pr *PullRequest) IsSameRepo() bool {
 		pr.Head.Repo.Owner.Login == pr.Base.Repo.Owner.Login
 }
 
+func (pr *PullRequest) HasRequestedReviewer(name string) bool {
+	for _, user := range pr.RequestedReviewers {
+		if strings.EqualFold(user.Login, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (pr *PullRequest) HasRequestedTeam(name string) bool {
+	for _, team := range pr.RequestedTeams {
+		if strings.EqualFold(team.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
 type IssueLabel struct {
 	Name  string `json:"name"`
 	Color string `json:"color"`
@@ -577,6 +598,10 @@ type IssueLabel struct {
 
 type User struct {
 	Login string `json:"login"`
+}
+
+type Team struct {
+	Name string `json:"name"`
 }
 
 type Milestone struct {

--- a/github/client.go
+++ b/github/client.go
@@ -138,7 +138,7 @@ func (client *Client) RequestReview(project *Project, prNumber int, params map[s
 		return
 	}
 
-	res, err := api.PostReview(fmt.Sprintf("repos/%s/%s/pulls/%d/requested_reviewers", project.Owner, project.Name, prNumber), params)
+	res, err := api.PostJSON(fmt.Sprintf("repos/%s/%s/pulls/%d/requested_reviewers", project.Owner, project.Name, prNumber), params)
 	if err = checkStatus(201, "requesting reviewer", res, err); err != nil {
 		return
 	}

--- a/github/http.go
+++ b/github/http.go
@@ -279,12 +279,6 @@ func (c *simpleClient) PatchJSON(path string, payload interface{}) (*simpleRespo
 	return c.jsonRequest("PATCH", path, payload, nil)
 }
 
-func (c *simpleClient) PostReview(path string, payload interface{}) (*simpleResponse, error) {
-	return c.jsonRequest("POST", path, payload, func(req *http.Request) {
-		req.Header.Set("Accept", "application/vnd.github.thor-preview+json;charset=utf-8")
-	})
-}
-
 func (c *simpleClient) PostFile(path, filename string) (*simpleResponse, error) {
 	stat, err := os.Stat(filename)
 	if err != nil {


### PR DESCRIPTION
Requesting a review via `hub pull-request -r foo` would print a misleading error message that `foo` couldn't be requested for review in case `foo` was already requested per CODEOWNERS.

Fixes #1840