### PR TITLE
Handle more cases when Checks API is unavailable

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -468,7 +468,7 @@ func (client *Client) FetchCIStatus(project *Project, sha string) (status *CISta
 	}
 
 	res, err = api.GetFile(fmt.Sprintf("repos/%s/%s/commits/%s/check-runs", project.Owner, project.Name, sha), checksType)
-	if err == nil && res.StatusCode == 422 {
+	if err == nil && (res.StatusCode == 403 || res.StatusCode == 404 || res.StatusCode == 422) {
 		return
 	}
 	if err = checkStatus(200, "fetching checks", res, err); err != nil {


### PR DESCRIPTION
Older Enterprise hosts won't have Checks API, but we still want `hub ci-status` to work with them. It seems like a HTTP 403 is returned in that case, so we can safely ignore it. Also ignore HTTP 404 just in case.

Fixes #1821