### PR TITLE
Handle case of `.github/ISSUE_TEMPLATE` directory

### DIFF
--- a/features/issue.feature
+++ b/features/issue.feature
@@ -427,6 +427,63 @@ Feature: hub issue
       https://github.com/github/hub/issues/1337\n
       """
 
+  Scenario: Multiple issue templates
+    Given the git commit editor is "vim"
+    And the text editor adds:
+      """
+      hello
+      """
+    And a file named ".github/ISSUE_TEMPLATE/bug_report.md" with:
+      """
+      I want to report a bug
+      """
+    And a file named ".github/ISSUE_TEMPLATE/feature_request.md" with:
+      """
+      There is a feature that I need!
+      """
+    Given the GitHub API server:
+      """
+      post('/repos/github/hub/issues') {
+        assert :title => "hello",
+               :body => ""
+
+        status 201
+        json :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      """
+    When I successfully run `hub issue create`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+
+  Scenario: Multiple issue templates with default
+    Given the git commit editor is "vim"
+    And the text editor adds:
+      """
+      hello
+      """
+    And a directory named ".github/ISSUE_TEMPLATE"
+    And a file named ".github/ISSUE_TEMPLATE.md" with:
+      """
+      The default template
+      """
+    Given the GitHub API server:
+      """
+      post('/repos/github/hub/issues') {
+        assert :title => "hello",
+               :body => "The default template"
+
+        status 201
+        json :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      """
+    When I successfully run `hub issue create`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+
   Scenario: A file named ".github"
     Given the git commit editor is "vim"
     And the text editor adds:

--- a/github/template.go
+++ b/github/template.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -31,25 +33,32 @@ func ReadTemplate(kind, workdir string) (body string, err error) {
 	return
 }
 
+type sortedFiles []os.FileInfo
+
+func (s sortedFiles) Len() int {
+	return len(s)
+}
+func (s sortedFiles) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s sortedFiles) Less(i, j int) bool {
+	return strings.Compare(strings.ToLower(s[i].Name()), strings.ToLower(s[j].Name())) > 0
+}
+
 func getFilePath(dir, pattern string) (found string, err error) {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return
 	}
 
+	sort.Sort(sortedFiles(files))
+
 	for _, file := range files {
 		fileName := file.Name()
-		path := fileName
+		path := strings.TrimSuffix(fileName, ".md")
+		path = strings.TrimSuffix(path, ".txt")
 
-		if ext := filepath.Ext(fileName); ext == ".md" {
-			path = strings.TrimRight(fileName, ".md")
-		} else if ext == ".txt" {
-			path = strings.TrimRight(fileName, ".txt")
-		}
-
-		path = strings.ToLower(path)
-
-		if ok, _ := filepath.Match(pattern, path); ok {
+		if strings.EqualFold(pattern, path) {
 			found = filepath.Join(dir, fileName)
 			return
 		}
@@ -60,6 +69,9 @@ func getFilePath(dir, pattern string) (found string, err error) {
 func readContentsFromFile(filename string) (contents string, err error) {
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
+		if strings.HasSuffix(err.Error(), " is a directory") {
+			err = nil
+		}
 		return
 	}
 


### PR DESCRIPTION
Ignore the directory of multiple issue templates for now. In the future, there might be a way to pick a specific template from the list; this change is just to prevent crashes.

Fixes #1822