### PR TITLE
Add unix socket support

### DIFF
--- a/fixtures/test_configs.go
+++ b/fixtures/test_configs.go
@@ -21,6 +21,20 @@ func SetupTomlTestConfig() *TestConfigs {
   host = "github.com"
   user = "jingweno"
   access_token = "123"
+  protocol = "http"`
+	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
+	os.Setenv("HUB_CONFIG", file.Name())
+
+	return &TestConfigs{file.Name()}
+}
+
+func SetupTomlTestConfigWithUnixSocket() *TestConfigs {
+	file, _ := ioutil.TempFile("", "test-gh-config-")
+
+	content := `[[hosts]]
+  host = "github.com"
+  user = "jingweno"
+  access_token = "123"
   protocol = "http"
   unix_socket = "/tmp/go.sock"`
 	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
@@ -30,6 +44,20 @@ func SetupTomlTestConfig() *TestConfigs {
 }
 
 func SetupTestConfigs() *TestConfigs {
+	file, _ := ioutil.TempFile("", "test-gh-config-")
+
+	content := `---
+github.com:
+- user: jingweno
+  oauth_token: 123
+  protocol: http`
+	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
+	os.Setenv("HUB_CONFIG", file.Name())
+
+	return &TestConfigs{file.Name()}
+}
+
+func SetupTestConfigsWithUnixSocket() *TestConfigs {
 	file, _ := ioutil.TempFile("", "test-gh-config-")
 
 	content := `---

--- a/fixtures/test_configs.go
+++ b/fixtures/test_configs.go
@@ -21,7 +21,8 @@ func SetupTomlTestConfig() *TestConfigs {
   host = "github.com"
   user = "jingweno"
   access_token = "123"
-  protocol = "http"`
+  protocol = "http"
+  unix_socket = "/tmp/go.sock"`
 	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
 	os.Setenv("HUB_CONFIG", file.Name())
 
@@ -35,7 +36,8 @@ func SetupTestConfigs() *TestConfigs {
 github.com:
 - user: jingweno
   oauth_token: 123
-  protocol: http`
+  protocol: http
+  unix_socket: /tmp/go.sock`
 	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
 	os.Setenv("HUB_CONFIG", file.Name())
 

--- a/github/client.go
+++ b/github/client.go
@@ -829,7 +829,8 @@ func (client *Client) simpleApi() (c *simpleClient, err error) {
 }
 
 func (client *Client) apiClient() *simpleClient {
-	httpClient := newHttpClient(os.Getenv("HUB_TEST_HOST"), os.Getenv("HUB_VERBOSE") != "")
+	unixSocket := os.ExpandEnv(client.Host.UnixSocket)
+	httpClient := newHttpClient(os.Getenv("HUB_TEST_HOST"), os.Getenv("HUB_VERBOSE") != "", unixSocket)
 	apiRoot := client.absolute(normalizeHost(client.Host.Host))
 	if client.Host != nil && client.Host.Host != GitHubHost {
 		apiRoot.Path = "/api/v3/"

--- a/github/config.go
+++ b/github/config.go
@@ -21,6 +21,7 @@ type yamlHost struct {
 	User       string `yaml:"user"`
 	OAuthToken string `yaml:"oauth_token"`
 	Protocol   string `yaml:"protocol"`
+	UnixSocket string `yaml:"unix_socket,omitempty"`
 }
 
 type yamlConfig map[string][]yamlHost

--- a/github/config.go
+++ b/github/config.go
@@ -30,6 +30,7 @@ type Host struct {
 	User        string `toml:"user"`
 	AccessToken string `toml:"access_token"`
 	Protocol    string `toml:"protocol"`
+	UnixSocket  string `toml:"unix_socket,omitempty"`
 }
 
 type Config struct {

--- a/github/config_decoder.go
+++ b/github/config_decoder.go
@@ -43,6 +43,7 @@ func (y *yamlConfigDecoder) Decode(r io.Reader, c *Config) error {
 			User:        vv.User,
 			AccessToken: vv.OAuthToken,
 			Protocol:    vv.Protocol,
+			UnixSocket:  vv.UnixSocket,
 		}
 		c.Hosts = append(c.Hosts, host)
 	}

--- a/github/config_encoder.go
+++ b/github/config_encoder.go
@@ -30,6 +30,7 @@ func (y *yamlConfigEncoder) Encode(w io.Writer, c *Config) error {
 				User:       h.User,
 				OAuthToken: h.AccessToken,
 				Protocol:   h.Protocol,
+				UnixSocket: h.UnixSocket,
 			},
 		}
 	}

--- a/github/config_service_test.go
+++ b/github/config_service_test.go
@@ -28,6 +28,7 @@ func TestConfigService_TomlLoad(t *testing.T) {
 	assert.Equal(t, "jingweno", host.User)
 	assert.Equal(t, "123", host.AccessToken)
 	assert.Equal(t, "http", host.Protocol)
+	assert.Equal(t, "/tmp/go.sock", host.UnixSocket)
 }
 
 func TestConfigService_YamlLoad(t *testing.T) {
@@ -48,6 +49,7 @@ func TestConfigService_YamlLoad(t *testing.T) {
 	assert.Equal(t, "jingweno", host.User)
 	assert.Equal(t, "123", host.AccessToken)
 	assert.Equal(t, "http", host.Protocol)
+	assert.Equal(t, "/tmp/go.sock", host.UnixSocket)
 }
 
 func TestConfigService_TomlSave(t *testing.T) {
@@ -59,6 +61,7 @@ func TestConfigService_TomlSave(t *testing.T) {
 		User:        "jingweno",
 		AccessToken: "123",
 		Protocol:    "https",
+		UnixSocket:  "/tmp/go.sock",
 	}
 	c := &Config{Hosts: []*Host{host}}
 
@@ -74,7 +77,8 @@ func TestConfigService_TomlSave(t *testing.T) {
   host = "github.com"
   user = "jingweno"
   access_token = "123"
-  protocol = "https"`
+  protocol = "https"
+  unix_socket = "/tmp/go.sock"`
 	assert.Equal(t, content, strings.TrimSpace(string(b)))
 }
 
@@ -87,6 +91,7 @@ func TestConfigService_YamlSave(t *testing.T) {
 		User:        "jingweno",
 		AccessToken: "123",
 		Protocol:    "https",
+		UnixSocket:  "/tmp/go.sock",
 	}
 	c := &Config{Hosts: []*Host{host}}
 
@@ -101,6 +106,7 @@ func TestConfigService_YamlSave(t *testing.T) {
 	content := `github.com:
 - user: jingweno
   oauth_token: "123"
-  protocol: https`
+  protocol: https
+  unix_socket: /tmp/go.sock`
 	assert.Equal(t, content, strings.TrimSpace(string(b)))
 }

--- a/github/config_service_test.go
+++ b/github/config_service_test.go
@@ -28,6 +28,27 @@ func TestConfigService_TomlLoad(t *testing.T) {
 	assert.Equal(t, "jingweno", host.User)
 	assert.Equal(t, "123", host.AccessToken)
 	assert.Equal(t, "http", host.Protocol)
+}
+
+func TestConfigService_TomlLoad_UnixSocket(t *testing.T) {
+	testConfigUnixSocket := fixtures.SetupTomlTestConfigWithUnixSocket()
+	defer testConfigUnixSocket.TearDown()
+
+	cc := &Config{}
+	cs := &configService{
+		Encoder: &tomlConfigEncoder{},
+		Decoder: &tomlConfigDecoder{},
+	}
+
+	err := cs.Load(testConfigUnixSocket.Path, cc)
+	assert.Equal(t, nil, err)
+
+	assert.Equal(t, 1, len(cc.Hosts))
+	host := cc.Hosts[0]
+	assert.Equal(t, "github.com", host.Host)
+	assert.Equal(t, "jingweno", host.User)
+	assert.Equal(t, "123", host.AccessToken)
+	assert.Equal(t, "http", host.Protocol)
 	assert.Equal(t, "/tmp/go.sock", host.UnixSocket)
 }
 
@@ -49,10 +70,59 @@ func TestConfigService_YamlLoad(t *testing.T) {
 	assert.Equal(t, "jingweno", host.User)
 	assert.Equal(t, "123", host.AccessToken)
 	assert.Equal(t, "http", host.Protocol)
+}
+
+func TestConfigService_YamlLoad_Unix_Socket(t *testing.T) {
+	testConfigUnixSocket := fixtures.SetupTestConfigsWithUnixSocket()
+	defer testConfigUnixSocket.TearDown()
+
+	cc := &Config{}
+	cs := &configService{
+		Encoder: &yamlConfigEncoder{},
+		Decoder: &yamlConfigDecoder{},
+	}
+
+	err := cs.Load(testConfigUnixSocket.Path, cc)
+	assert.Equal(t, nil, err)
+
+	assert.Equal(t, 1, len(cc.Hosts))
+	host := cc.Hosts[0]
+	assert.Equal(t, "github.com", host.Host)
+	assert.Equal(t, "jingweno", host.User)
+	assert.Equal(t, "123", host.AccessToken)
+	assert.Equal(t, "http", host.Protocol)
 	assert.Equal(t, "/tmp/go.sock", host.UnixSocket)
 }
 
 func TestConfigService_TomlSave(t *testing.T) {
+	file, _ := ioutil.TempFile("", "test-gh-config-")
+	defer os.RemoveAll(file.Name())
+
+	host := &Host{
+		Host:        "github.com",
+		User:        "jingweno",
+		AccessToken: "123",
+		Protocol:    "https",
+	}
+	c := &Config{Hosts: []*Host{host}}
+
+	cs := &configService{
+		Encoder: &tomlConfigEncoder{},
+		Decoder: &tomlConfigDecoder{},
+	}
+	err := cs.Save(file.Name(), c)
+	assert.Equal(t, nil, err)
+
+	b, _ := ioutil.ReadFile(file.Name())
+	content := `[[hosts]]
+  host = "github.com"
+  user = "jingweno"
+  access_token = "123"
+  protocol = "https"`
+	assert.Equal(t, content, strings.TrimSpace(string(b)))
+}
+
+func TestConfigService_TomlSave_UnixSocket(t *testing.T) {
 	file, _ := ioutil.TempFile("", "test-gh-config-")
 	defer os.RemoveAll(file.Name())
 
@@ -83,6 +153,33 @@ func TestConfigService_TomlSave(t *testing.T) {
 }
 
 func TestConfigService_YamlSave(t *testing.T) {
+	file, _ := ioutil.TempFile("", "test-gh-config-")
+	defer os.RemoveAll(file.Name())
+
+	host := &Host{
+		Host:        "github.com",
+		User:        "jingweno",
+		AccessToken: "123",
+		Protocol:    "https",
+	}
+	c := &Config{Hosts: []*Host{host}}
+
+	cs := &configService{
+		Encoder: &yamlConfigEncoder{},
+		Decoder: &yamlConfigDecoder{},
+	}
+	err := cs.Save(file.Name(), c)
+	assert.Equal(t, nil, err)
+
+	b, _ := ioutil.ReadFile(file.Name())
+	content := `github.com:
+- user: jingweno
+  oauth_token: "123"
+  protocol: https`
+	assert.Equal(t, content, strings.TrimSpace(string(b)))
+}
+
+func TestConfigService_YamlSave_UnixSocket(t *testing.T) {
 	file, _ := ioutil.TempFile("", "test-gh-config-")
 	defer os.RemoveAll(file.Name())
 


### PR DESCRIPTION
Bringing **Unix domain socket** support to the `Hub`.

If `unix_socket` configuration is available for a given host in `~/.config/hub`, it will configure `http.Transport` that will work for `http` and `https` over **Unix domain socket**