### PR TITLE
Add .config/hub yaml file example

### DIFF
--- a/share/man/man1/hub.1.ronn
+++ b/share/man/man1/hub.1.ronn
@@ -101,6 +101,13 @@ variables.
 Alternatively, you may provide `GITHUB_TOKEN`, an access token with
 **repo** permissions. This will not be written to `~/.config/hub`.
 
+```yml
+github.com:
+- user: your-username
+  oauth_token: "your-personal-token"
+  protocol: https
+```
+
 ### HTTPS instead of git protocol
 
 If you prefer the HTTPS protocol for git operations, you can configure hub to


### PR DESCRIPTION
I spend a good time trying to find an example of `.hub/conf` file and I understand how it works looking the tests, but I was not sure about the file format.

As my 2fa does not work, I never got the chance to see the file being generated. I decide to share an example in the official docs. Not sure if that place is the best, but I figured how that I needed that file exactly from that point.