### PR TITLE
Add repo visibility and permission check for remote add command

### DIFF
--- a/commands/remote.go
+++ b/commands/remote.go
@@ -21,7 +21,9 @@ remote set-url [-p] [<OPTIONS>] <NAME> <USER>[/<REPOSITORY>]
 
 ## Options:
 	-p
-		(Deprecated) Use the 'ssh:' protocol for the remote URL.
+		(Deprecated) Use the 'ssh:' protocol instead of 'git:' for the remote URL.
+		The writeable 'ssh:' protocol is automatically used for own repos, GitHub
+		Enterprise remotes, and private or pushable repositories.
 
 	<USER>[/<REPOSITORY>]
 		If <USER> is "origin", that value will be substituted for your GitHub
@@ -32,7 +34,7 @@ remote set-url [-p] [<OPTIONS>] <NAME> <USER>[/<REPOSITORY>]
 		> git remote add jingweno git://github.com/jingweno/REPO.git
 
 		$ hub remote add origin
-		> git remote add origin git://github.com/USER/REPO.git
+		> git remote add origin git@github.com:USER/REPO.git
 
 ## See also:
 

--- a/commands/remote_test.go
+++ b/commands/remote_test.go
@@ -31,15 +31,6 @@ func TestTransformRemoteArgs(t *testing.T) {
 	reg := regexp.MustCompile("^git@github\\.com:jingweno/.+\\.git$")
 	assert.T(t, reg.MatchString(args.GetParam(2)))
 
-	args = NewArgs([]string{"remote", "add", "mislav"})
-	transformRemoteArgs(args)
-
-	assert.Equal(t, 3, args.ParamsSize())
-	assert.Equal(t, "add", args.FirstParam())
-	assert.Equal(t, "mislav", args.GetParam(1))
-	reg = regexp.MustCompile("^git://github\\.com/mislav/.+\\.git$")
-	assert.T(t, reg.MatchString(args.GetParam(2)))
-
 	args = NewArgs([]string{"remote", "add", "-p", "mislav"})
 	transformRemoteArgs(args)
 
@@ -65,12 +56,4 @@ func TestTransformRemoteArgs(t *testing.T) {
 	assert.Equal(t, "jingweno", args.GetParam(1))
 	assert.Equal(t, "add", args.FirstParam())
 	assert.Equal(t, "git@github.com:jingweno/gh.git", args.GetParam(2))
-
-	args = NewArgs([]string{"remote", "add", "-p", "origin", "org/foo"})
-	transformRemoteArgs(args)
-
-	assert.Equal(t, 3, args.ParamsSize())
-	assert.Equal(t, "origin", args.GetParam(1))
-	assert.Equal(t, "add", args.FirstParam())
-	assert.Equal(t, "git@github.com:org/foo.git", args.GetParam(2))
 }

--- a/features/remote_add.feature
+++ b/features/remote_add.feature
@@ -51,11 +51,59 @@ Feature: hub remote add
     And there should be no output
 
   Scenario: Add public remote
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :private => false,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => false }
+      }
+      """
     When I successfully run `hub remote add mislav`
     Then the url for "mislav" should be "git://github.com/mislav/dotfiles.git"
     And there should be no output
 
-  Scenario: Add private remote
+  Scenario: Add detected private remote
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :private => true,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => false }
+      }
+      """
+    When I successfully run `hub remote add mislav`
+    Then the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
+    And there should be no output
+
+  Scenario: Add remote with push access
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :private => false,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => true }
+      }
+      """
+    When I successfully run `hub remote add mislav`
+    Then the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
+    And there should be no output
+
+  Scenario: Add remote for missing repo
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        status 404
+      }
+      """
+    When I run `hub remote add mislav`
+    Then the exit status should be 1
+    And the output should contain exactly:
+      """
+      Error: repository mislav/dotfiles doesn't exist\n
+      """
+
+  Scenario: Add explicitly private remote
     When I successfully run `hub remote add -p mislav`
     Then the url for "mislav" should be "git@github.com:mislav/dotfiles.git"
     And there should be no output
@@ -66,38 +114,94 @@ Feature: hub remote add
     And there should be no output
 
   Scenario: Add remote with arguments
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :private => false,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => false }
+      }
+      """
     When I successfully run `hub remote add -f mislav`
     Then "git remote add -f mislav git://github.com/mislav/dotfiles.git" should be run
     And there should be no output
 
   Scenario: Add remote with branch argument
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :private => false,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => false }
+      }
+      """
     When I successfully run `hub remote add -f -t feature mislav`
     Then "git remote add -f -t feature mislav git://github.com/mislav/dotfiles.git" should be run
     And there should be no output
 
   Scenario: Add HTTPS protocol remote
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :private => false,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => false }
+      }
+      """
     Given HTTPS is preferred
     When I successfully run `hub remote add mislav`
     Then the url for "mislav" should be "https://github.com/mislav/dotfiles.git"
     And there should be no output
 
   Scenario: Add named public remote
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :private => false,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => false }
+      }
+      """
     When I successfully run `hub remote add mm mislav`
     Then the url for "mm" should be "git://github.com/mislav/dotfiles.git"
     And there should be no output
 
   Scenario: set-url
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfiles') {
+        json :private => false,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => false }
+      }
+      """
     Given the "origin" remote has url "git://github.com/evilchelu/dotfiles.git"
     When I successfully run `hub remote set-url origin mislav`
     Then the url for "origin" should be "git://github.com/mislav/dotfiles.git"
     And there should be no output
 
   Scenario: Add public remote including repo name
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfilez.js') {
+        json :private => false,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => false }
+      }
+      """
     When I successfully run `hub remote add mislav/dotfilez.js`
     Then the url for "mislav" should be "git://github.com/mislav/dotfilez.js.git"
     And there should be no output
 
   Scenario: Add named public remote including repo name
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/dotfilez.js') {
+        json :private => false,
+             :name => 'dotfiles', :owner => { :login => 'mislav' },
+             :permissions => { :push => false }
+      }
+      """
     When I successfully run `hub remote add mm mislav/dotfilez.js`
     Then the url for "mm" should be "git://github.com/mislav/dotfilez.js.git"
     And there should be no output


### PR DESCRIPTION
Fixes #1832 .

This PR introduce repo visibility and permission check which will then set `isSSH` variable in GitURL method. However the tests are failing due to these errors:

<img width="1060" alt="screen shot 2018-10-05 at 11 02 14 am" src="https://user-images.githubusercontent.com/7445868/46514118-7f36a900-c88e-11e8-9730-ae3117387679.png">

The other commands that use similar method (clone and fetch) does not have such tests. Can you advice on how to fix the tests/write new tests? Thank you!