### PR TITLE
Speed up man page generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,10 @@ man-pages: $(HELP_ALL:=.ronn) $(HELP_ALL) $(HELP_ALL:=.txt)
 %.txt: %.ronn
 	groff -Wall -mtty-char -mandoc -Tutf8 -rLL=$(TEXT_WIDTH)n $< | col -b >$@
 
-%.1: %.1.ronn bin/ronn
+$(HELP_ALL): share/man/man-pages.stamp
+share/man/man-pages.stamp: bin/ronn $(HELP_ALL:=.ronn)
 	bin/ronn --organization=GITHUB --manual="Hub Manual" share/man/man1/*.ronn
+	touch $@
 
 %.1.ronn: bin/hub
 	bin/hub help $(*F) --plain-text | script/format-ronn $(*F) $@


### PR DESCRIPTION
Speed up man page generation by a factor of 3 (from 18 to 6 seconds in the single-CPU case)
by not building every man page and html page several times (e.g. 24x)