### PR TITLE
Fixed CI status check exit code.

### DIFF
--- a/commands/ci_status.go
+++ b/commands/ci_status.go
@@ -88,15 +88,13 @@ func ciStatus(cmd *Command, args *Args) {
 		response, err := gh.FetchCIStatus(project, sha)
 		utils.Check(err)
 
-		state := response.State
+		state := ""
 		if len(response.Statuses) > 0 {
 			for _, status := range response.Statuses {
 				if checkSeverity(status.State) > checkSeverity(state) {
 					state = status.State
 				}
 			}
-		} else if len(response.Statuses) == 0 {
-			state = ""
 		}
 
 		var exitCode int


### PR DESCRIPTION
`response.State` extracts the state from the deprecated Github endpoint (see: https://blog.travis-ci.com/2018-09-27-deprecating-github-commit-status-api-for-github-apps-managed-repositories).

This can return "pending" even for successfully completed checks, which results in an exit code of 2:
```
$ hub ci-status --verbose xxx
✔︎      Travis CI - Pull Request        https://github.com/xxx/xxx/runs/xxx
✔︎      Travis CI - Branch              https://github.com/xxx/xxx/runs/xxx
$ echo $?
2
```

```
curl -i --header "Authorization: token xxx" https://api.github.com/repos/xxx/xxx/commits/xxx/status
{
  "state": "pending",
  "statuses": [

  ],
  ...
```

The exit code is determined by this switch-case: https://github.com/github/hub/blob/master/commands/ci_status.go#L108-L109

This is a proposed fix that relies completely on the data provided by the new endpoint, let me know what you think.
