### PR TITLE
fix `compare` command if not on any branch

### DIFF
--- a/commands/compare.go
+++ b/commands/compare.go
@@ -72,14 +72,14 @@ func compare(command *Command, args *Args) {
 		r       string
 	)
 
-	branch, project, err = localRepo.RemoteBranchAndProject("", false)
-	utils.Check(err)
-
 	usageHelp := func() {
 		utils.Check(fmt.Errorf("Usage: hub compare [-u] [-b <BASE>] [<USER>] [[<START>...]<END>]"))
 	}
 
 	if args.IsParamsEmpty() {
+		branch, project, err = localRepo.RemoteBranchAndProject("", false)
+		utils.Check(err)
+
 		if branch == nil ||
 			(branch.IsMaster() && flagCompareBase == "") ||
 			(flagCompareBase == branch.ShortName()) {

--- a/features/compare.feature
+++ b/features/compare.feature
@@ -155,3 +155,10 @@ Feature: hub compare
       Aborted: the origin remote doesn't point to a GitHub repository.\n
       """
     And the exit status should be 1
+
+  Scenario: Comparing two branches while not on a local branch
+    Given I am in detached HEAD
+    And I run `hub compare refactor...master`
+    Then the exit status should be 0
+    And there should be no output
+    And "open https://github.com/mislav/dotfiles/compare/refactor...master" should be run


### PR DESCRIPTION
There is no need to detect the current branch if a range is provided as an argument.

Fixes #1584.