### PR TITLE
Add the command `hub issue view <NUMBER>`

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -18,9 +18,9 @@ var (
 		Run: listIssues,
 		Usage: `
 issue [-a <ASSIGNEE>] [-c <CREATOR>] [-@ <USER>] [-s <STATE>] [-f <FORMAT>] [-M <MILESTONE>] [-l <LABELS>] [-d <DATE>] [-o <SORT_KEY> [-^]] [-L <LIMIT>]
+issue show [-f <FORMAT>] <NUMBER>
 issue create [-oc] [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
 issue labels [--color]
-issue show <NUMBER>
 `,
 		Long: `Manage GitHub issues for the current project.
 
@@ -174,6 +174,7 @@ With no arguments, show a list of open issues.
 	flagIssueAssignee,
 	flagIssueState,
 	flagIssueFormat,
+	flagShowIssueFormat,
 	flagIssueMessage,
 	flagIssueMilestoneFilter,
 	flagIssueCreator,
@@ -200,6 +201,8 @@ With no arguments, show a list of open issues.
 )
 
 func init() {
+	cmdShowIssue.Flag.StringVarP(&flagShowIssueFormat, "format", "f", "", "FORMAT")
+
 	cmdCreateIssue.Flag.StringVarP(&flagIssueMessage, "message", "m", "", "MESSAGE")
 	cmdCreateIssue.Flag.StringVarP(&flagIssueFile, "file", "F", "", "FILE")
 	cmdCreateIssue.Flag.Uint64VarP(&flagIssueMilestone, "milestone", "M", 0, "MILESTONE")
@@ -401,6 +404,14 @@ func showIssue(cmd *Command, args *Args) {
 	issue, err = gh.FetchIssue(project, issueNumber)
 	utils.Check(err)
 
+	args.NoForward()
+
+	colorize := ui.IsTerminal(os.Stdout)
+	if flagShowIssueFormat != "" {
+		ui.Printf(formatIssue(*issue, flagShowIssueFormat, colorize))
+		return
+	}
+
 	var closed = ""
 	if issue.State != "open" {
 		closed = "[CLOSED] "
@@ -428,7 +439,6 @@ func showIssue(cmd *Command, args *Args) {
 		}
 	}
 
-	args.NoForward()
 	return
 }
 

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -28,6 +28,9 @@ issue show <NUMBER>
 
 With no arguments, show a list of open issues.
 
+	* _show_:
+		Show an existing issue specified by <NUMBER>.
+
 	* _create_:
 		Open an issue in the current project.
 
@@ -405,38 +408,25 @@ func showIssue(cmd *Command, args *Args) {
 	commentsList, err := gh.FetchComments(project, issueNumber)
 	utils.Check(err)
 
-	var assignees []string
-	var assigneesString = ""
+	ui.Printf("# %s%s\n\n", closed, issue.Title)
+	ui.Printf("* created by @%s on %s\n", issue.User.Login, issue.CreatedAt.String())
+
 	if len(issue.Assignees) > 0 {
+		var assignees []string
 		for _, user := range issue.Assignees {
 			assignees = append(assignees, user.Login)
 		}
-		assigneesString = fmt.Sprintf("* assignees: %s\n\n", strings.Join(assignees, ", "))
+		ui.Printf("* assignees: %s\n", strings.Join(assignees, ", "))
 	}
 
-	var comments []string
-	var commentsString = ""
+	ui.Printf("\n%s\n", issue.Body)
+
 	if issue.Comments > 0 {
+		ui.Printf("\n## Comments:\n")
 		for _, comment := range commentsList {
-			comments = append(comments, fmt.Sprintf(
-				"### comment by @%s on %s\n\n"+
-					"%s\n", comment.User.Login, comment.CreatedAt.String(), comment.Body))
+			ui.Printf("\n### comment by @%s on %s\n\n%s\n", comment.User.Login, comment.CreatedAt.String(), comment.Body)
 		}
-		commentsString = fmt.Sprintf("\n## Comments:\n\n%s", strings.Join(comments, ""))
-
 	}
-
-	ui.Printf("# %s\n\n"+
-		"* created by @%s on %s\n"+
-		"%s"+
-		"%s\n"+
-		"%s",
-		closed+issue.Title,
-		issue.User.Login,
-		issue.CreatedAt.String(),
-		assigneesString,
-		issue.Body,
-		commentsString)
 
 	args.NoForward()
 	return

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -530,3 +530,84 @@ Feature: hub issue
       bug
       feature\n
       """
+
+
+  Scenario: Fetch single issue
+    Given the GitHub API server:
+    """
+    get('/repos/github/hub/issues/102') { json \
+        :number => 102,
+        :state => "open",
+        :body => "I want this feature",
+        :title => "Feature request for hub issue show",
+        :created_at => "2017-04-14T16:00:49Z",
+        :user => { :login => "royels" },
+        :assignees => [{:login => "royels"}],
+        :comments => 1
+     }
+      get('/repos/github/hub/issues/102/comments') {
+      json [{
+              :id => 1,
+              :body => "I am from the future",
+              :created_at => "2011-04-14T16:00:49Z",
+              :user => { :login => "octocat" }}
+      ]
+      }
+      """
+    When I successfully run `hub issue show 102`
+    Then the output should contain exactly:
+      """
+      # Feature request for hub issue show
+
+      * created by @royels on 2017-04-14 16:00:49 +0000 UTC
+      * assignees: royels
+
+      I want this feature
+
+      ## Comments:
+
+      ### comment by @octocat on 2011-04-14 16:00:49 +0000 UTC
+
+      I am from the future
+
+      """
+
+  Scenario: Did not supply an issue number
+    When I run `hub issue show`
+    Then the exit status should be 1
+    Then the output should contain exactly "Usage: hub issue show <NUMBER>\n"
+
+
+  Scenario: Show error message if http code is not 200 for issues endpoint
+    Given the GitHub API server:
+    """
+    get('/repos/github/hub/issues/102') {
+    status 500
+     }
+      """
+    When I run `hub issue show 102`
+    Then the output should contain exactly:
+      """
+      Error fetching issue: Internal Server Error (HTTP 500)\n
+      """
+
+
+  Scenario: Show error message if http code is not 200 for comments endpoint
+    Given the GitHub API server:
+    """
+    get('/repos/github/hub/issues/102') { json \
+        :number => 102,
+        :body => "I want this feature",
+        :title => "Feature request for hub issue show",
+        :created_at => "2017-04-14T16:00:49Z",
+        :user => { :login => "royels" }
+     }
+      get('/repos/github/hub/issues/102/comments') {
+      status 404
+      }
+    """
+    When I run `hub issue show 102`
+    Then the output should contain exactly:
+      """
+      Error fetching comments for issue: Not Found (HTTP 404)\n
+      """

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -531,27 +531,31 @@ Feature: hub issue
       feature\n
       """
 
-
   Scenario: Fetch single issue
     Given the GitHub API server:
-    """
-    get('/repos/github/hub/issues/102') { json \
-        :number => 102,
-        :state => "open",
-        :body => "I want this feature",
-        :title => "Feature request for hub issue show",
-        :created_at => "2017-04-14T16:00:49Z",
-        :user => { :login => "royels" },
-        :assignees => [{:login => "royels"}],
-        :comments => 1
-     }
+      """
+      get('/repos/github/hub/issues/102') {
+        json \
+          :number => 102,
+          :state => "open",
+          :body => "I want this feature",
+          :title => "Feature request for hub issue show",
+          :created_at => "2017-04-14T16:00:49Z",
+          :user => { :login => "royels" },
+          :assignees => [{:login => "royels"}],
+          :comments => 1
+      }
       get('/repos/github/hub/issues/102/comments') {
-      json [{
-              :id => 1,
-              :body => "I am from the future",
-              :created_at => "2011-04-14T16:00:49Z",
-              :user => { :login => "octocat" }}
-      ]
+        json [
+          { :body => "I am from the future",
+            :created_at => "2011-04-14T16:00:49Z",
+            :user => { :login => "octocat" }
+          },
+          { :body => "I did the thing",
+            :created_at => "2013-10-30T22:20:00Z",
+            :user => { :login => "hubot" }
+          },
+        ]
       }
       """
     When I successfully run `hub issue show 102`
@@ -570,6 +574,9 @@ Feature: hub issue
 
       I am from the future
 
+      ### comment by @hubot on 2013-10-30 22:20:00 +0000 UTC
+
+      I did the thing\n
       """
 
   Scenario: Did not supply an issue number
@@ -577,13 +584,12 @@ Feature: hub issue
     Then the exit status should be 1
     Then the output should contain exactly "Usage: hub issue show <NUMBER>\n"
 
-
   Scenario: Show error message if http code is not 200 for issues endpoint
     Given the GitHub API server:
-    """
-    get('/repos/github/hub/issues/102') {
-    status 500
-     }
+      """
+      get('/repos/github/hub/issues/102') {
+        status 500
+      }
       """
     When I run `hub issue show 102`
     Then the output should contain exactly:
@@ -591,21 +597,21 @@ Feature: hub issue
       Error fetching issue: Internal Server Error (HTTP 500)\n
       """
 
-
   Scenario: Show error message if http code is not 200 for comments endpoint
     Given the GitHub API server:
-    """
-    get('/repos/github/hub/issues/102') { json \
-        :number => 102,
-        :body => "I want this feature",
-        :title => "Feature request for hub issue show",
-        :created_at => "2017-04-14T16:00:49Z",
-        :user => { :login => "royels" }
-     }
-      get('/repos/github/hub/issues/102/comments') {
-      status 404
+      """
+      get('/repos/github/hub/issues/102') {
+        json \
+          :number => 102,
+          :body => "I want this feature",
+          :title => "Feature request for hub issue show",
+          :created_at => "2017-04-14T16:00:49Z",
+          :user => { :login => "royels" }
       }
-    """
+      get('/repos/github/hub/issues/102/comments') {
+        status 404
+      }
+      """
     When I run `hub issue show 102`
     Then the output should contain exactly:
       """

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -579,6 +579,41 @@ Feature: hub issue
       I did the thing\n
       """
 
+  Scenario: Format single issue
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/102') {
+        json \
+          :number => 102,
+          :state => "open",
+          :body => "I want this feature",
+          :title => "Feature request for hub issue show",
+          :created_at => "2017-04-14T16:00:49Z",
+          :user => { :login => "royels" },
+          :assignees => [{:login => "royels"}],
+          :comments => 1
+      }
+      get('/repos/github/hub/issues/102/comments') {
+        json [
+          { :body => "I am from the future",
+            :created_at => "2011-04-14T16:00:49Z",
+            :user => { :login => "octocat" }
+          },
+          { :body => "I did the thing",
+            :created_at => "2013-10-30T22:20:00Z",
+            :user => { :login => "hubot" }
+          },
+        ]
+      }
+      """
+    When I successfully run `hub issue show 102 --format='%I %t%n%n%b%n'`
+    Then the output should contain exactly:
+      """
+      102 Feature request for hub issue show
+
+      I want this feature\n
+      """
+
   Scenario: Did not supply an issue number
     When I run `hub issue show`
     Then the exit status should be 1

--- a/features/release.feature
+++ b/features/release.feature
@@ -325,6 +325,43 @@ MARKDOWN
       https://github.com/mislav/will_paginate/archive/v1.2.0.tar.gz\n
       """
 
+  Scenario: Format specific release
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/will_paginate/releases') {
+        json [
+          { tag_name: 'v1.2.0',
+            name: 'will_paginate 1.2.0',
+            draft: true,
+            prerelease: false,
+            tarball_url: "https://github.com/mislav/will_paginate/archive/v1.2.0.tar.gz",
+            zipball_url: "https://github.com/mislav/will_paginate/archive/v1.2.0.zip",
+            assets: [
+              { browser_download_url: "https://github.com/mislav/will_paginate/releases/download/v1.2.0/example.zip",
+              },
+            ],
+            body: <<MARKDOWN
+### Hello to my release
+
+Here is what's broken:
+- everything
+MARKDOWN
+          },
+        ]
+      }
+      """
+    When I successfully run `hub release show v1.2.0 --format='%t (%T)%n%as%n%n%b%n'`
+    Then the output should contain exactly:
+      """
+      will_paginate 1.2.0 (v1.2.0)
+      https://github.com/mislav/will_paginate/releases/download/v1.2.0/example.zip	
+
+      ### Hello to my release
+
+      Here is what's broken:
+      - everything\n\n
+      """
+
   Scenario: Show release no tag
     When I run `hub release show`
     Then the exit status should be 1


### PR DESCRIPTION
This commit adds the subcommand hub issue view, which displays an issue as well as
lists its comments underneath.

Addresses issue #1865 