### PR TITLE
Add ability to list requested reviewers with `%rs`

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -316,6 +316,10 @@ func formatIssuePlaceholders(issue github.Issue, colorize bool) map[string]strin
 	for _, requestedReviewer := range issue.RequestedReviewers {
 		requestedReviewers = append(requestedReviewers, requestedReviewer.Login)
 	}
+	for _, requestedTeam := range issue.RequestedTeams {
+		teamSlug := fmt.Sprintf("%s/%s", issue.Base.Repo.Owner.Login, requestedTeam.Slug)
+		requestedReviewers = append(requestedReviewers, teamSlug)
+	}
 
 	var milestoneNumber, milestoneTitle string
 	if issue.Milestone != nil {

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -312,6 +312,11 @@ func formatIssuePlaceholders(issue github.Issue, colorize bool) map[string]strin
 		assignees = append(assignees, assignee.Login)
 	}
 
+	var requestedReviewers []string
+	for _, requestedReviewer := range issue.RequestedReviewers {
+		requestedReviewers = append(requestedReviewers, requestedReviewer.Login)
+	}
+
 	var milestoneNumber, milestoneTitle string
 	if issue.Milestone != nil {
 		milestoneNumber = fmt.Sprintf("%d", issue.Milestone.Number)
@@ -351,6 +356,7 @@ func formatIssuePlaceholders(issue github.Issue, colorize bool) map[string]strin
 		"b":  issue.Body,
 		"au": issue.User.Login,
 		"as": strings.Join(assignees, ", "),
+		"rs": strings.Join(requestedReviewers, ", "),
 		"Mn": milestoneNumber,
 		"Mt": milestoneTitle,
 		"NC": numComments,

--- a/commands/pr.go
+++ b/commands/pr.go
@@ -72,6 +72,8 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 
 		%as: comma-separated list of assignees
 
+		%rs: comma-separated list of requested reviewers
+
 		%Mn: milestone number
 
 		%Mt: milestone title

--- a/features/pr-list.feature
+++ b/features/pr-list.feature
@@ -76,13 +76,19 @@ Feature: hub pr list
         { :number => 999,
           :title => "First",
           :state => "open",
-          :base => { :ref => "master", :label => "github:master" },
+          :base => {
+            :ref => "master",
+            :label => "github:master",
+            :repo => { :owner => { :login => "github" } }
+          },
           :head => { :ref => "patch-1", :label => "octocat:patch-1" },
           :user => { :login => "octocat" },
           :requested_reviewers => [
-            {
-              :login => "rey"
-            }
+            { :login => "rey" },
+          ],
+          :requested_teams => [
+            { :slug => "troopers" },
+            { :slug => "cantina-band" },
           ]
         },
         { :number => 102,
@@ -92,12 +98,8 @@ Feature: hub pr list
           :head => { :ref => "patch-2", :label => "octocat:patch-2" },
           :user => { :login => "octocat" },
           :requested_reviewers => [
-            {
-              :login => "luke"
-            },
-            {
-              :login => "jyn"
-            }
+            { :login => "luke" },
+            { :login => "jyn" },
           ]
         },
       ]
@@ -106,7 +108,7 @@ Feature: hub pr list
     When I successfully run `hub pr list -f "%sC%>(8)%i %rs%n"`
     Then the output should contain exactly:
       """
-          #999 rey
+          #999 rey, github/troopers, github/cantina-band
           #102 luke, jyn\n
       """
 

--- a/features/pr-list.feature
+++ b/features/pr-list.feature
@@ -63,6 +63,53 @@ Feature: hub pr list
             #7  Fourth\n
       """
 
+  Scenario: List pull requests with requested reviewers
+    Given the GitHub API server:
+    """
+    get('/repos/github/hub/pulls') {
+      assert :per_page => "100",
+             :page => :no,
+             :sort => nil,
+             :direction => "desc"
+
+      json [
+        { :number => 999,
+          :title => "First",
+          :state => "open",
+          :base => { :ref => "master", :label => "github:master" },
+          :head => { :ref => "patch-1", :label => "octocat:patch-1" },
+          :user => { :login => "octocat" },
+          :requested_reviewers => [
+            {
+              :login => "rey"
+            }
+          ]
+        },
+        { :number => 102,
+          :title => "Second",
+          :state => "open",
+          :base => { :ref => "master", :label => "github:master" },
+          :head => { :ref => "patch-2", :label => "octocat:patch-2" },
+          :user => { :login => "octocat" },
+          :requested_reviewers => [
+            {
+              :login => "luke"
+            },
+            {
+              :login => "jyn"
+            }
+          ]
+        },
+      ]
+    }
+    """
+    When I successfully run `hub pr list -f "%sC%>(8)%i %rs%n"`
+    Then the output should contain exactly:
+      """
+          #999 rey
+          #102 luke, jyn\n
+      """
+
   Scenario: Sort by number of comments ascending
     Given the GitHub API server:
     """

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -873,7 +873,7 @@ Feature: hub pull-request
         status 201
         json :html_url => "the://url", :number => 1234,
           :requested_reviewers => [{ :login => "josh" }],
-          :requested_teams => [{ :name => "robots" }]
+          :requested_teams => [{ :slug => "robots" }]
       }
       post('/repos/mislav/coral/pulls/1234/requested_reviewers') {
         assert :reviewers => ["mislav", "pcorpet"]
@@ -894,7 +894,7 @@ Feature: hub pull-request
         status 201
         json :html_url => "the://url", :number => 1234,
           :requested_reviewers => [{ :login => "josh" }, { :login => "mislav" }],
-          :requested_teams => [{ :name => "robots" }]
+          :requested_teams => [{ :slug => "robots" }]
       }
       """
     When I successfully run `hub pull-request -m hereyougo -r mislav,josh -rgithub/robots`

--- a/github/client.go
+++ b/github/client.go
@@ -578,7 +578,7 @@ func (pr *PullRequest) HasRequestedReviewer(name string) bool {
 
 func (pr *PullRequest) HasRequestedTeam(name string) bool {
 	for _, team := range pr.RequestedTeams {
-		if strings.EqualFold(team.Name, name) {
+		if strings.EqualFold(team.Slug, name) {
 			return true
 		}
 	}

--- a/github/client.go
+++ b/github/client.go
@@ -596,6 +596,7 @@ type User struct {
 
 type Team struct {
 	Name string `json:"name"`
+	Slug string `json:"slug"`
 }
 
 type Milestone struct {


### PR DESCRIPTION
Not sure if I understood @whatsadebugger correctly in #1913.
If instead we want to list all reviewers (not just requested ones) we
would need to make additional API requests I think.