### PR TITLE
add pullrequest vim syntax.

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -16,7 +16,7 @@ fi
 prefix="${PREFIX:-$prefix}"
 prefix="${prefix:-/usr/local}"
 
-for src in bin/hub share/man/*/*.1; do
+for src in bin/hub share/man/*/*.1 share/vim/vimfiles/*/*.vim; do
   dest="${DESTDIR}${prefix}/${src}"
   mkdir -p "${dest%/*}"
   [[ $src == share/* ]] && mode="644" || mode=755

--- a/share/vim/vimfiles/ftdetect/pullrequest.vim
+++ b/share/vim/vimfiles/ftdetect/pullrequest.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead PULLREQ_EDITMSG set filetype=pullrequest

--- a/share/vim/vimfiles/syntax/pullrequest.vim
+++ b/share/vim/vimfiles/syntax/pullrequest.vim
@@ -1,0 +1,37 @@
+" Vim syntax file
+" Language: Hub Pull Request
+" Maintainer: Derek Sifford <dereksifford@gmail.com>
+" Filenames: *.git/PULLREQ_EDITMSG
+" Latest Revision: 2018 Oct 30
+
+if exists('b:current_syntax')
+    finish
+endif
+
+syn case match
+
+syn include @Markdown syntax/markdown.vim
+
+syn match pullreqBlank         contained                  "^.*"        contains=@Spell
+syn match pullreqOverflow      contained                  ".*"         contains=@Spell
+syn match pullreqSummary       contained                  "^.\{0,50\}" contains=@Spell nextgroup=pullreqOverflow
+syn match pullreqMetaHeader    contained                  "^Changes:"
+syn match pullreqSha           contained                  "^[a-z0-9]\{7\}\ze ("        nextgroup=pullreqCommitMeta
+syn match pullreqCommitMeta    contained skipnl skipwhite ".*"                         nextgroup=pullreqCommitMessage
+syn match pullreqCommitMessage contained                  "^\s*\zs.*"
+syn match pullreqBranchInfo    contained                  "\S\+:\S\+"
+
+syn region pullreqBranchInfoLine contained transparent start="^Requesting a pull" end="$"             contains=pullreqBranchInfo
+syn region pullreqMessage        keepend               start="^."                 end="^\ze# [-]* >8" contains=@Markdown,@Spell                                   nextgroup=pullreqMetadata
+syn region pullreqMetadata       fold                  start="^# [-]* >8 [-]*$"   end="\%$"           contains=pullreqMetaHeader,pullreqSha,pullreqBranchInfoLine
+syn match  pullreqFirstLine      skipnl                "\%^[^#].*"                                    contains=pullreqSummary                                     nextgroup=pullreqBlank
+
+hi def link pullreqBlank         Error
+hi def link pullreqBranchInfo    Keyword
+hi def link pullreqCommitMessage String
+hi def link pullreqMetaHeader    htmlH1
+hi def link pullreqMetadata      Comment
+hi def link pullreqSha           Constant
+hi def link pullreqSummary       Keyword
+
+let b:current_syntax = 'pullrequest'


### PR DESCRIPTION
See #1916. ([discussion starts here](https://github.com/github/hub/pull/1916#issuecomment-434759694))

This _should_ install fine on MacOS and Linux. Windows install steps still need to be added. I don't own a windows machine so any tips there would be appreciated.

One thing I'm noticing right now as I write this is that on MacOS the pullrequest template doesn't render with any whitespace between the title line and the scissors line, so the syntax currently causes the first line of the scissors line to be highlighted with an error group.

I think it would be best to keep that way and instead just put some whitespace in the template if it doesn't already exist.

Let me know if you need anything else. Thanks!