### PR TITLE
Add Support indentation YAML

### DIFF
--- a/lib/hub/github_api.rb
+++ b/lib/hub/github_api.rb
@@ -507,7 +507,8 @@ module Hub
             host = hash[$1] = []
           when /^([- ]) (.+?): (.+)/
             key, value = $2, $3
-            host << {} if $1 == '-'
+            host << {} if $1 == '-' or $2 =~ /^\s*-\s*/
+            key.gsub!(/^\s*-\s*|^\s*/, '')
             host.last[key] = value.gsub(/^'|'$/, '')
           else
             raise "unsupported YAML line: #{line}"

--- a/test/github_api_test.rb
+++ b/test/github_api_test.rb
@@ -57,12 +57,17 @@ github.com:
   oauth_token: OTOKEN
 - user: tpw
   oauth_token: POKEN
+  - user: test
+    oauth_token: TEST
+
     YAML
 
     assert_equal 'mislav', data['github.com'][0]['user']
     assert_equal 'OTOKEN', data['github.com'][0]['oauth_token']
     assert_equal 'tpw',    data['github.com'][1]['user']
     assert_equal 'POKEN',  data['github.com'][1]['oauth_token']
+    assert_equal 'test',   data['github.com'][2]['user']
+    assert_equal 'TEST',   data['github.com'][2]['oauth_token']
   end
 
   def test_yaml_load_quoted
@@ -71,9 +76,13 @@ github.com:
 github.com:
 - user: 'true'
   oauth_token: '1234'
+  - user: 'false'
+    oauth_token: '5678'
     YAML
 
     assert_equal 'true', data['github.com'][0]['user']
     assert_equal '1234', data['github.com'][0]['oauth_token']
+    assert_equal 'false', data['github.com'][1]['user']
+    assert_equal '5678', data['github.com'][1]['oauth_token']
   end
 end


### PR DESCRIPTION
Hi, 

My environment is as follows.

```sh
$ ruby --version
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]

$ bundle exec gem list

*** LOCAL GEMS ***

bundler (1.16.2)
byebug (10.0.2)
hub (1.12.4)
minitest (5.11.3)
```

When using the following YAML in $HOME/.config/hub, I got an error(`NoMethodError (undefined method []=' for nil:NilClass)`)  .

```yaml
$ cat $HOME/.config/hub
---
github.com:
  - user: test
    oauth_token: TEST
```

I modified to be able to parse either YAML indentation or not.
Please confirm.

Regards.

Yohei