### PR TITLE
Add support for multiple `--message` options

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -109,6 +109,9 @@ With no arguments, show a list of open issues.
 		The text up to the first blank line in <MESSAGE> is treated as the issue
 		title, and the rest is used as issue description in Markdown format.
 
+		If multiple <MESSAGE> options are given, their values are concatenated as
+		separate paragraphs.
+
 	-F, --file <FILE>
 		Read the issue title and description from <FILE>.
 
@@ -176,7 +179,6 @@ With no arguments, show a list of open issues.
 	flagIssueState,
 	flagIssueFormat,
 	flagShowIssueFormat,
-	flagIssueMessage,
 	flagIssueMilestoneFilter,
 	flagIssueCreator,
 	flagIssueMentioned,
@@ -184,6 +186,8 @@ With no arguments, show a list of open issues.
 	flagIssueSince,
 	flagIssueSort,
 	flagIssueFile string
+
+	flagIssueMessage messageBlocks
 
 	flagIssueEdit,
 	flagIssueCopy,
@@ -204,7 +208,7 @@ With no arguments, show a list of open issues.
 func init() {
 	cmdShowIssue.Flag.StringVarP(&flagShowIssueFormat, "format", "f", "", "FORMAT")
 
-	cmdCreateIssue.Flag.StringVarP(&flagIssueMessage, "message", "m", "", "MESSAGE")
+	cmdCreateIssue.Flag.VarP(&flagIssueMessage, "message", "m", "MESSAGE")
 	cmdCreateIssue.Flag.StringVarP(&flagIssueFile, "file", "F", "", "FILE")
 	cmdCreateIssue.Flag.Uint64VarP(&flagIssueMilestone, "milestone", "M", 0, "MILESTONE")
 	cmdCreateIssue.Flag.VarP(&flagIssueLabels, "label", "l", "LABEL")
@@ -472,8 +476,8 @@ func createIssue(cmd *Command, args *Args) {
 Write a message for this issue. The first block of
 text is the title and the rest is the description.`, project))
 
-	if cmd.FlagPassed("message") {
-		messageBuilder.Message = flagIssueMessage
+	if len(flagIssueMessage) > 0 {
+		messageBuilder.Message = flagIssueMessage.String()
 		messageBuilder.Edit = flagIssueEdit
 	} else if cmd.FlagPassed("file") {
 		messageBuilder.Message, err = msgFromFile(flagIssueFile)

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -106,7 +106,8 @@ With no arguments, show a list of open issues.
 		%uI: updated date, ISO 8601 format
 
 	-m, --message <MESSAGE>
-		Use the first line of <MESSAGE> as issue title, and the rest as issue description.
+		The text up to the first blank line in <MESSAGE> is treated as the issue
+		title, and the rest is used as issue description in Markdown format.
 
 	-F, --file <FILE>
 		Read the issue title and description from <FILE>.

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -29,8 +29,9 @@ pull-request -i <ISSUE>
 		Skip the check for unpushed commits.
 
 	-m, --message <MESSAGE>
-		Use the first line of <MESSAGE> as pull request title, and the rest as pull
-		request description.
+		The text up to the first blank line in <MESSAGE> is treated as the pull
+		request title, and the rest is used as pull request description in Markdown
+		format.
 
 	--no-edit
 		Use the message from the first commit on the branch as pull request title

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -33,6 +33,9 @@ pull-request -i <ISSUE>
 		request title, and the rest is used as pull request description in Markdown
 		format.
 
+		If multiple <MESSAGE> options are given, their values are concatenated as
+		separate paragraphs.
+
 	--no-edit
 		Use the message from the first commit on the branch as pull request title
 		and description without opening a text editor.
@@ -105,9 +108,10 @@ var (
 	flagPullRequestBase,
 	flagPullRequestHead,
 	flagPullRequestIssue,
-	flagPullRequestMessage,
 	flagPullRequestMilestone,
 	flagPullRequestFile string
+
+	flagPullRequestMessage messageBlocks
 
 	flagPullRequestBrowse,
 	flagPullRequestCopy,
@@ -127,7 +131,7 @@ func init() {
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestIssue, "issue", "i", "", "ISSUE")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestBrowse, "browse", "o", false, "BROWSE")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestCopy, "copy", "c", false, "COPY")
-	cmdPullRequest.Flag.StringVarP(&flagPullRequestMessage, "message", "m", "", "MESSAGE")
+	cmdPullRequest.Flag.VarP(&flagPullRequestMessage, "message", "m", "MESSAGE")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestEdit, "edit", "e", false, "EDIT")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestPush, "push", "p", false, "PUSH")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestForce, "force", "f", false, "FORCE")
@@ -252,8 +256,8 @@ func pullRequest(cmd *Command, args *Args) {
 Write a message for this pull request. The first block
 of text is the title and the rest is the description.`, fullBase, fullHead))
 
-	if cmd.FlagPassed("message") {
-		messageBuilder.Message = flagPullRequestMessage
+	if len(flagPullRequestMessage) > 0 {
+		messageBuilder.Message = flagPullRequestMessage.String()
 		messageBuilder.Edit = flagPullRequestEdit
 	} else if cmd.FlagPassed("file") {
 		messageBuilder.Message, err = msgFromFile(flagPullRequestFile)

--- a/commands/release.go
+++ b/commands/release.go
@@ -73,7 +73,8 @@ With '--exclude-prereleases', exclude non-stable releases from the listing.
 		character is taken as asset label.
 
 	-m, --message <MESSAGE>
-		Use the first line of <MESSAGE> as release title, and the rest as release description.
+		The text up to the first blank line in <MESSAGE> is treated as the release
+		title, and the rest is used as release description in Markdown format.
 
 	-F, --file <FILE>
 		Read the release title and description from <FILE>.

--- a/commands/release.go
+++ b/commands/release.go
@@ -76,6 +76,9 @@ With '--exclude-prereleases', exclude non-stable releases from the listing.
 		The text up to the first blank line in <MESSAGE> is treated as the release
 		title, and the rest is used as release description in Markdown format.
 
+		If multiple <MESSAGE> options are given, their values are concatenated as
+		separate paragraphs.
+
 	-F, --file <FILE>
 		Read the release title and description from <FILE>.
 
@@ -176,11 +179,12 @@ hub(1), git-tag(1)
 	flagReleaseCopy,
 	flagReleasePrerelease bool
 
-	flagReleaseMessage,
 	flagReleaseFile,
 	flagReleaseFormat,
 	flagShowReleaseFormat,
 	flagReleaseCommitish string
+
+	flagReleaseMessage messageBlocks
 
 	flagReleaseAssets stringSliceValue
 
@@ -202,7 +206,7 @@ func init() {
 	cmdCreateRelease.Flag.BoolVarP(&flagReleaseBrowse, "browse", "o", false, "BROWSE")
 	cmdCreateRelease.Flag.BoolVarP(&flagReleaseCopy, "copy", "c", false, "COPY")
 	cmdCreateRelease.Flag.VarP(&flagReleaseAssets, "attach", "a", "ATTACH_ASSETS")
-	cmdCreateRelease.Flag.StringVarP(&flagReleaseMessage, "message", "m", "", "MESSAGE")
+	cmdCreateRelease.Flag.VarP(&flagReleaseMessage, "message", "m", "MESSAGE")
 	cmdCreateRelease.Flag.StringVarP(&flagReleaseFile, "file", "F", "", "FILE")
 	cmdCreateRelease.Flag.StringVarP(&flagReleaseCommitish, "commitish", "t", "", "COMMITISH")
 
@@ -210,7 +214,7 @@ func init() {
 	cmdEditRelease.Flag.BoolVarP(&flagReleaseDraft, "draft", "d", false, "DRAFT")
 	cmdEditRelease.Flag.BoolVarP(&flagReleasePrerelease, "prerelease", "p", false, "PRERELEASE")
 	cmdEditRelease.Flag.VarP(&flagReleaseAssets, "attach", "a", "ATTACH_ASSETS")
-	cmdEditRelease.Flag.StringVarP(&flagReleaseMessage, "message", "m", "", "MESSAGE")
+	cmdEditRelease.Flag.VarP(&flagReleaseMessage, "message", "m", "MESSAGE")
 	cmdEditRelease.Flag.StringVarP(&flagReleaseFile, "file", "F", "", "FILE")
 	cmdEditRelease.Flag.StringVarP(&flagReleaseCommitish, "commitish", "t", "", "COMMITISH")
 
@@ -422,8 +426,8 @@ func createRelease(cmd *Command, args *Args) {
 Write a message for this release. The first block of
 text is the title and the rest is the description.`, tagName, project))
 
-	if cmd.FlagPassed("message") {
-		messageBuilder.Message = flagReleaseMessage
+	if len(flagReleaseMessage) > 0 {
+		messageBuilder.Message = flagReleaseMessage.String()
 		messageBuilder.Edit = flagReleaseEdit
 	} else if cmd.FlagPassed("file") {
 		messageBuilder.Message, err = msgFromFile(flagReleaseFile)
@@ -508,8 +512,8 @@ func editRelease(cmd *Command, args *Args) {
 Write a message for this release. The first block of
 text is the title and the rest is the description.`, tagName, project))
 
-	if cmd.FlagPassed("message") {
-		messageBuilder.Message = flagReleaseMessage
+	if len(flagReleaseMessage) > 0 {
+		messageBuilder.Message = flagReleaseMessage.String()
 		messageBuilder.Edit = flagReleaseEdit
 	} else if cmd.FlagPassed("file") {
 		messageBuilder.Message, err = msgFromFile(flagReleaseFile)

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -39,6 +39,17 @@ func (l *listFlag) Set(value string) error {
 	return nil
 }
 
+type messageBlocks []string
+
+func (m *messageBlocks) String() string {
+	return strings.Join([]string(*m), "\n\n")
+}
+
+func (m *messageBlocks) Set(value string) error {
+	*m = append(*m, value)
+	return nil
+}
+
 func isCloneable(file string) bool {
 	f, err := os.Open(file)
 	if err != nil {

--- a/etc/hub.fish_completion
+++ b/etc/hub.fish_completion
@@ -34,7 +34,7 @@ complete -f -c hub -n '__fish_hub_needs_command' -a sync -d "update local branch
 complete -f -c hub -n ' __fish_hub_using_command alias' -a 'bash zsh sh ksh csh fish' -d "output shell script suitable for eval"
 # pull-request
 complete -f -c hub -n ' __fish_hub_using_command pull-request' -s f -d "Skip the check for unpushed commits"
-complete -f -c hub -n ' __fish_hub_using_command pull-request' -s -m -d "Use the first line of <MESSAGE> as pull request title, and the rest as pull request description"
+complete -f -c hub -n ' __fish_hub_using_command pull-request' -s -m -d "Set the pull request title and description separated by a blank line"
 complete -f -c hub -n ' __fish_hub_using_command pull-request' -s F -d "Read the pull request title and description from <FILE>"
 complete -f -c hub -n ' __fish_hub_using_command pull-request' -s o -d "Open the new pull request in a web browser"
 complete -f -c hub -n ' __fish_hub_using_command pull-request' -l browse -d "Open the new pull request in a web browser"

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -499,6 +499,19 @@ Feature: hub pull-request
     Then the output should contain exactly "https://github.com/mislav/coral/pull/12\n"
     And the file ".git/PULLREQ_EDITMSG" should not exist
 
+  Scenario: Title and body from multiple command-line arguments
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/coral/pulls') {
+        assert :title => 'I am just a pull',
+               :body  => "A little pull\n\nAnd description"
+        status 201
+        json :html_url => "https://github.com/mislav/coral/pull/12"
+      }
+      """
+    When I successfully run `hub pull-request -m "I am just a pull" -m "A little pull" -m "And description"`
+    Then the output should contain exactly "https://github.com/mislav/coral/pull/12\n"
+
   Scenario: Error when implicit head is the same as base
     Given I am on the "master" branch with upstream "origin/master"
     When I run `hub pull-request`

--- a/github/message_builder_test.go
+++ b/github/message_builder_test.go
@@ -1,0 +1,23 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestMessageBuilder_multiline_title(t *testing.T) {
+	builder := &MessageBuilder{
+		Message: `hello
+multiline
+text
+
+the rest is
+description`,
+	}
+
+	title, body, err := builder.Extract()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "hello multiline text", title)
+	assert.Equal(t, "the rest is\ndescription", body)
+}


### PR DESCRIPTION
This is for compatibility with git-commit(1). Also, clarify documentation about what constitutes a title: not just the first line of text, but the entire first paragraph of text (until the first blank line).