### PR TITLE
Docs: mention that comma-separated lists must not have spaces

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -66,17 +66,17 @@ pull-request -i <ISSUE>
 		The head branch in "[OWNER:]BRANCH" format. Defaults to the current branch.
 
 	-r, --reviewer <USERS>
-		A comma-separated list of GitHub handles to request a review from.
+		A comma-separated list (without spaces) of GitHub handles to request a review from.
 
 	-a, --assign <USERS>
-		A comma-separated list of GitHub handles to assign to this pull request.
+		A comma-separated list (without spaces) of GitHub handles to assign to this pull request.
 
 	-M, --milestone <NAME>
 		The milestone name to add to this pull request. Passing the milestone number
 		is deprecated.
 
 	-l, --labels <LABELS>
-		Add a comma-separated list of labels to this pull request. Labels will be
+		Add a comma-separated list (without spaces) of labels to this pull request. Labels will be
 		created if they don't already exist.
 
 ## Examples:


### PR DESCRIPTION
This was tripping me up for so long. I eventually discovered the problem was my spaces, re. https://github.com/github/hub/issues/1287#issuecomment-250454584.