### PR TITLE
Restore pre-2.20.0 `git help` output

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -357,7 +357,7 @@ func gitCmd(args ...string) *cmd.Cmd {
 }
 
 func IsBuiltInGitCommand(command string) bool {
-	helpCommandOutput, err := gitOutput("help", "-a")
+	helpCommandOutput, err := gitOutput("help", "--no-verbose", "-a")
 	if err != nil {
 		return false
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -359,6 +359,10 @@ func gitCmd(args ...string) *cmd.Cmd {
 func IsBuiltInGitCommand(command string) bool {
 	helpCommandOutput, err := gitOutput("help", "--no-verbose", "-a")
 	if err != nil {
+		// support git versions that don't recognize --no-verbose
+		helpCommandOutput, err = gitOutput("help", "-a")
+	}
+	if err != nil {
 		return false
 	}
 	for _, helpCommandOutputLine := range helpCommandOutput {


### PR DESCRIPTION
After upgrading to Git 2.20.0, all operations that relied on `hub alias`
would indefinitely hang. It can be reproduced using the following:

1. Create a new alias such as `st` for `git status`.
2. Run `hub <alias>` in a git repository.

  ```
  $ hub st

  ... hangs forever
  ```

Inspecting the running process shows that it is executing `git help -a`
and not able to proceed. Digging into the `hub` shows that the `help`
command is called within `IsBuiltInGitCommand`. Once this entrypoint was
found, I started bisecting and found this works in 2.19.x but fails in
2.20.x. Sure enough, the Git 2.20.0 release notes [mention a
corresponding change](https://github.com/git/git/blob/master/Documentation/RelNotes/2.20.0.txt#L17-L18).

>  * "git help -a" now gives verbose output (same as "git help -av").
>    Those who want the old output may say "git help --no-verbose -a".

It was even nice enough to include the backwards compatibility fix :)

To fix the hanging, I've restored the existing behaviour by including
the `--no-verbose` flag that mimics the 2.19.x behaviour.

Fixes #1963