### PR TITLE
Clarify long-form CLI options

### DIFF
--- a/commands/browse.go
+++ b/commands/browse.go
@@ -15,10 +15,10 @@ var cmdBrowse = &Command{
 	Long: `Open a GitHub repository in a web browser.
 
 ## Options:
-	-u
+	-u, --url
 		Print the URL instead of opening it.
 
-	-c
+	-c, --copy
 		Put the URL in clipboard instead of opening it.
 	
 	[<USER>/]<REPOSITORY>
@@ -52,8 +52,8 @@ var (
 )
 
 func init() {
-	cmdBrowse.Flag.BoolVarP(&flagBrowseURLPrint, "url-only", "u", false, "URL")
-	cmdBrowse.Flag.BoolVarP(&flagBrowseURLCopy, "copy-only", "c", false, "COPY")
+	cmdBrowse.Flag.BoolVarP(&flagBrowseURLPrint, "url", "u", false, "URL")
+	cmdBrowse.Flag.BoolVarP(&flagBrowseURLCopy, "copy", "c", false, "COPY")
 
 	CmdRunner.Use(cmdBrowse)
 }

--- a/commands/ci_status.go
+++ b/commands/ci_status.go
@@ -16,7 +16,7 @@ var cmdCiStatus = &Command{
 	Long: `Display status of GitHub checks for a commit.
 
 ## Options:
-	-v
+	-v, --verbose
 		Print detailed report of all status checks and their URLs.
 
 	<COMMIT>

--- a/commands/compare.go
+++ b/commands/compare.go
@@ -22,7 +22,7 @@ var cmdCompare = &Command{
 	-c, --copy
 		Put the URL to clipboard instead of opening it.
 
-	-b <BASE>
+	-b, --base=<BASE>
 		Base branch to compare.
 
 	[<START>...]<END>

--- a/commands/compare.go
+++ b/commands/compare.go
@@ -16,7 +16,7 @@ var cmdCompare = &Command{
 	Long: `Open a GitHub compare page in a web browser.
 
 ## Options:
-	-u
+	-u, --url
 		Print the URL instead of opening it.
 
 	-c, --copy
@@ -56,7 +56,7 @@ var (
 
 func init() {
 	cmdCompare.Flag.BoolVarP(&flagCompareCopy, "copy", "c", false, "COPY")
-	cmdCompare.Flag.BoolVarP(&flagCompareURLOnly, "url-only", "u", false, "URL only")
+	cmdCompare.Flag.BoolVarP(&flagCompareURLOnly, "url", "u", false, "URL only")
 	cmdCompare.Flag.StringVarP(&flagCompareBase, "base", "b", "", "BASE")
 
 	CmdRunner.Use(cmdCompare)

--- a/commands/create.go
+++ b/commands/create.go
@@ -20,10 +20,10 @@ var cmdCreate = &Command{
 	-p
 		Create a private repository.
 
-	-d <DESCRIPTION>
+	-d, --description=<DESCRIPTION>
 		Use this text as the description of the GitHub repository.
 
-	-h <HOMEPAGE>
+	-h, --homepage=<HOMEPAGE>
 		Use this text as the URL of the GitHub repository.
 
 	-o, --browse

--- a/commands/create.go
+++ b/commands/create.go
@@ -17,7 +17,7 @@ var cmdCreate = &Command{
 	Long: `Create a new repository on GitHub and add a git remote for it.
 
 ## Options:
-	-p
+	-p, --private
 		Create a private repository.
 
 	-d, --description=<DESCRIPTION>

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -55,8 +55,8 @@ With no arguments, show a list of open issues.
 
 	-f, --format=<FORMAT>
 		Pretty print the contents of the issues using format <FORMAT> (default:
-		"%sC%>(8)%i%Creset  %t%  l%n"). See the "PRETTY FORMATS" section of the
-		git-log manual for some additional details on how placeholders are used in
+		"%sC%>(8)%i%Creset  %t%  l%n"). See the "PRETTY FORMATS" section of
+		git-log(1) for some additional details on how placeholders are used in
 		format. The available placeholders for issues are:
 
 		%I: issue number

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -38,22 +38,22 @@ With no arguments, show a list of open issues.
 		List the labels available in this repository.
 
 ## Options:
-	-a, --assignee <ASSIGNEE>
+	-a, --assignee=<ASSIGNEE>
 		Display only issues assigned to <ASSIGNEE>.
 
 		When opening an issue, this can be a comma-separated list of people to
 		assign to the new issue.
 
-	-c, --creator <CREATOR>
+	-c, --creator=<CREATOR>
 		Display only issues created by <CREATOR>.
 
-	-@, --mentioned <USER>
+	-@, --mentioned=<USER>
 		Display only issues mentioning <USER>.
 
-	-s, --state <STATE>
+	-s, --state=<STATE>
 		Display issues with state <STATE> (default: "open").
 
-	-f, --format <FORMAT>
+	-f, --format=<FORMAT>
 		Pretty print the contents of the issues using format <FORMAT> (default:
 		"%sC%>(8)%i%Creset  %t%  l%n"). See the "PRETTY FORMATS" section of the
 		git-log manual for some additional details on how placeholders are used in
@@ -105,14 +105,14 @@ With no arguments, show a list of open issues.
 
 		%uI: updated date, ISO 8601 format
 
-	-m, --message <MESSAGE>
+	-m, --message=<MESSAGE>
 		The text up to the first blank line in <MESSAGE> is treated as the issue
 		title, and the rest is used as issue description in Markdown format.
 
 		If multiple <MESSAGE> options are given, their values are concatenated as
 		separate paragraphs.
 
-	-F, --file <FILE>
+	-F, --file=<FILE>
 		Read the issue title and description from <FILE>.
 
 	-e, --edit
@@ -124,26 +124,26 @@ With no arguments, show a list of open issues.
 	-c, --copy
 		Put the URL of the new issue to clipboard instead of printing it.
 
-	-M, --milestone <ID>
+	-M, --milestone=<ID>
 		Display only issues for a GitHub milestone with id <ID>.
 
 		When opening an issue, add this issue to a GitHub milestone with id <ID>.
 
-	-l, --labels <LABELS>
+	-l, --labels=<LABELS>
 		Display only issues with certain labels.
 
 		When opening an issue, add a comma-separated list of labels to this issue.
 
-	-d, --since <DATE>
+	-d, --since=<DATE>
 		Display only issues updated on or after <DATE> in ISO 8601 format.
 
-	-o, --sort <SORT_KEY>
+	-o, --sort=<SORT_KEY>
 		Sort displayed issues by "created" (default), "updated" or "comments".
 
 	-^ --sort-ascending
 		Sort by ascending dates instead of descending.
 
-	-L, --limit <LIMIT>
+	-L, --limit=<LIMIT>
 		Display only the first <LIMIT> issues.
 
 	--include-pulls

--- a/commands/pr.go
+++ b/commands/pr.go
@@ -30,18 +30,18 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 
 ## Options:
 
-	-s, --state <STATE>
+	-s, --state=<STATE>
 		Filter pull requests by <STATE>. Supported values are: "open" (default),
 		"closed", "merged", or "all".
 
-	-h, --head [<OWNER>:]<BRANCH>
+	-h, --head=[<OWNER>:]<BRANCH>
 		Show pull requests started from the specified head <BRANCH>. The default
 		value for <OWNER> is taken from the current repository.
 
-	-b, --base <BRANCH>
+	-b, --base=<BRANCH>
 		Show pull requests based on the specified <BRANCH>.
 
-	-f, --format <FORMAT>
+	-f, --format=<FORMAT>
 		Pretty print the list of pull requests using format <FORMAT> (default:
 		"%sC%>(8)%i%Creset  %t%  l%n"). See the "PRETTY FORMATS" section of the
 		git-log manual for some additional details on how placeholders are used in
@@ -113,13 +113,13 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 
 		%mI: merged date, ISO 8601 format
 
-	-o, --sort <SORT_KEY>
+	-o, --sort=<SORT_KEY>
 		Sort displayed issues by "created" (default), "updated", "popularity", or "long-running".
 
 	-^ --sort-ascending
 		Sort by ascending dates instead of descending.
 
-	-L, --limit <LIMIT>
+	-L, --limit=<LIMIT>
 		Display only the first <LIMIT> issues.
 
 ## See also:

--- a/commands/pr.go
+++ b/commands/pr.go
@@ -43,8 +43,8 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 
 	-f, --format=<FORMAT>
 		Pretty print the list of pull requests using format <FORMAT> (default:
-		"%sC%>(8)%i%Creset  %t%  l%n"). See the "PRETTY FORMATS" section of the
-		git-log manual for some additional details on how placeholders are used in
+		"%sC%>(8)%i%Creset  %t%  l%n"). See the "PRETTY FORMATS" section of
+		git-log(1) for some additional details on how placeholders are used in
 		format. The available placeholders are:
 
 		%I: pull request number

--- a/commands/pr.go
+++ b/commands/pr.go
@@ -34,12 +34,12 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 		Filter pull requests by <STATE>. Supported values are: "open" (default),
 		"closed", "merged", or "all".
 
-	-h, --head=[<OWNER>:]<BRANCH>
-		Show pull requests started from the specified head <BRANCH>. The default
-		value for <OWNER> is taken from the current repository.
+	-h, --head=<BRANCH>
+		Show pull requests started from the specified head <BRANCH>. The
+		"OWNER:BRANCH" format must be used for pull requests from forks.
 
 	-b, --base=<BRANCH>
-		Show pull requests based on the specified <BRANCH>.
+		Show pull requests based off the specified <BRANCH>.
 
 	-f, --format=<FORMAT>
 		Pretty print the list of pull requests using format <FORMAT> (default:

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -28,7 +28,7 @@ pull-request -i <ISSUE>
 	-f, --force
 		Skip the check for unpushed commits.
 
-	-m, --message <MESSAGE>
+	-m, --message=<MESSAGE>
 		The text up to the first blank line in <MESSAGE> is treated as the pull
 		request title, and the rest is used as pull request description in Markdown
 		format.
@@ -40,14 +40,15 @@ pull-request -i <ISSUE>
 		Use the message from the first commit on the branch as pull request title
 		and description without opening a text editor.
 
-	-F, --file <FILE>
+	-F, --file=<FILE>
 		Read the pull request title and description from <FILE>.
 
 	-e, --edit
 		Further edit the contents of <FILE> in a text editor before submitting.
 
-	-i, --issue <ISSUE>, <ISSUE-URL>
-		(Deprecated) Convert <ISSUE> to a pull request.
+	-i, --issue=<ISSUE>
+		(Deprecated) Convert an issue to a pull request. <ISSUE> may be an issue
+		number or a URL.
 
 	-o, --browse
 		Open the new pull request in a web browser.
@@ -58,24 +59,24 @@ pull-request -i <ISSUE>
 	-p, --push
 		Push the current branch to <HEAD> before creating the pull request.
 
-	-b, --base <BASE>
+	-b, --base=<BASE>
 		The base branch in "[OWNER:]BRANCH" format. Defaults to the default branch
 		(usually "master").
 
-	-h, --head <HEAD>
+	-h, --head=<HEAD>
 		The head branch in "[OWNER:]BRANCH" format. Defaults to the current branch.
 
-	-r, --reviewer <USERS>
+	-r, --reviewer=<USERS>
 		A comma-separated list of GitHub handles to request a review from.
 
-	-a, --assign <USERS>
+	-a, --assign=<USERS>
 		A comma-separated list of GitHub handles to assign to this pull request.
 
-	-M, --milestone <NAME>
+	-M, --milestone=<NAME>
 		The milestone name to add to this pull request. Passing the milestone number
 		is deprecated.
 
-	-l, --labels <LABELS>
+	-l, --labels=<LABELS>
 		Add a comma-separated list of labels to this pull request. Labels will be
 		created if they don't already exist.
 

--- a/commands/release.go
+++ b/commands/release.go
@@ -66,20 +66,20 @@ With '--exclude-prereleases', exclude non-stable releases from the listing.
 	-p, --prerelease
 		Create a pre-release.
 
-	-a, --attach <FILE>
+	-a, --attach=<FILE>
 		Attach a file as an asset for this release.
 
 		If <FILE> is in the "<filename>#<text>" format, the text after the '#'
 		character is taken as asset label.
 
-	-m, --message <MESSAGE>
+	-m, --message=<MESSAGE>
 		The text up to the first blank line in <MESSAGE> is treated as the release
 		title, and the rest is used as release description in Markdown format.
 
 		If multiple <MESSAGE> options are given, their values are concatenated as
 		separate paragraphs.
 
-	-F, --file <FILE>
+	-F, --file=<FILE>
 		Read the release title and description from <FILE>.
 
 	-e, --edit
@@ -91,11 +91,11 @@ With '--exclude-prereleases', exclude non-stable releases from the listing.
 	-c, --copy
 		Put the URL of the new release to clipboard instead of printing it.
 
-	-t, --commitish <TARGET>
+	-t, --commitish=<TARGET>
 		A commit SHA or branch name to attach the release to, only used if <TAG>
 		doesn't already exist (default: main branch).
 
-	-f, --format <FORMAT>
+	-f, --format=<FORMAT>
 		Pretty print releases using <FORMAT> (default: "%T%n"). See the "PRETTY
 		FORMATS" section of git-log(1) for some additional details on how
 		placeholders are used in format. The available placeholders for issues are:


### PR DESCRIPTION
Indicate that long-form CLI flags are used like `--message=VALUE`, and other tweaks.

Ref. https://github.com/github/hub/issues/1819 https://github.com/github/hub/issues/1961

/cc @philwinder @devisnik @adamkaplan