### PR TITLE
Capitalize GitHub in doco

### DIFF
--- a/commands/fork.go
+++ b/commands/fork.go
@@ -29,7 +29,7 @@ var cmdFork = &Command{
 		> git remote add -f USER git@github.com:USER/REPO.git
 
 		$ hub fork --org=ORGANIZATION
-		[ repo forked on Github into the ORGANIZATION organization]
+		[ repo forked on GitHub into the ORGANIZATION organization]
 		> git remote add -f ORGANIZATION git@github.com:ORGANIZATION/REPO.git
 
 ## See also:

--- a/share/man/man1/hub.1.ronn
+++ b/share/man/man1/hub.1.ronn
@@ -68,7 +68,7 @@ git but that are extended through hub, and custom ones that hub provides.
     Create a new repository on GitHub and add a git remote for it.
 
   * hub-delete(1):
-    Delete a repository on Github.
+    Delete a repository on GitHub.
 
   * hub-fork(1):
     Fork the current project on GitHub and add a git remote for it.


### PR DESCRIPTION
There's a couple places in the man pages where "GitHub" is mis-capitalized as "Github". This PR corrects them.