### PR TITLE
update issue.go documentation for %n

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -85,6 +85,8 @@ With no arguments, show a list of open issues.
 
 		%Mt: milestone title
 
+		%n: newline (\n)
+
 		%NC: number of comments
 
 		%Nc: number of comments wrapped in parentheses, or blank string if zero.


### PR DESCRIPTION
Closes #1972 

## Summary of change

 - Adds a line explaining the use of `%n` to the `--format` description.