### PR TITLE
Don't choke on literal `%` output from `--format` use

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -298,7 +298,7 @@ func listIssues(cmd *Command, args *Args) {
 
 		colorize := ui.IsTerminal(os.Stdout)
 		for _, issue := range issues {
-			ui.Printf(formatIssue(issue, flagIssueFormat, colorize))
+			ui.Print(formatIssue(issue, flagIssueFormat, colorize))
 		}
 	}
 
@@ -455,7 +455,7 @@ func showIssue(cmd *Command, args *Args) {
 
 	colorize := ui.IsTerminal(os.Stdout)
 	if flagShowIssueFormat != "" {
-		ui.Printf(formatIssue(*issue, flagShowIssueFormat, colorize))
+		ui.Print(formatIssue(*issue, flagShowIssueFormat, colorize))
 		return
 	}
 
@@ -585,7 +585,7 @@ func listLabels(cmd *Command, args *Args) {
 	utils.Check(err)
 
 	for _, label := range labels {
-		ui.Printf(formatLabel(label, flagLabelsColorize))
+		ui.Print(formatLabel(label, flagLabelsColorize))
 	}
 }
 

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -105,6 +105,10 @@ With no arguments, show a list of open issues.
 
 		%uI: updated date, ISO 8601 format
 
+		%n: newline
+
+		%%: a literal %
+
 	-m, --message=<MESSAGE>
 		The text up to the first blank line in <MESSAGE> is treated as the issue
 		title, and the rest is used as issue description in Markdown format.

--- a/commands/pr.go
+++ b/commands/pr.go
@@ -220,7 +220,7 @@ func listPulls(cmd *Command, args *Args) {
 
 	colorize := ui.IsTerminal(os.Stdout)
 	for _, pr := range pulls {
-		ui.Printf(formatPullRequest(pr, flagPullRequestFormat, colorize))
+		ui.Print(formatPullRequest(pr, flagPullRequestFormat, colorize))
 	}
 }
 

--- a/commands/pr.go
+++ b/commands/pr.go
@@ -113,6 +113,10 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 
 		%mI: merged date, ISO 8601 format
 
+		%n: newline
+
+		%%: a literal %
+
 	-o, --sort=<SORT_KEY>
 		Sort displayed issues by "created" (default), "updated", "popularity", or "long-running".
 

--- a/commands/release.go
+++ b/commands/release.go
@@ -136,6 +136,10 @@ With '--exclude-prereleases', exclude non-stable releases from the listing.
 
 		%pI: published date, ISO 8601 format
 
+		%n: newline
+
+		%%: a literal %
+
 	<TAG>
 		The git tag name for this release.
 

--- a/commands/release.go
+++ b/commands/release.go
@@ -250,7 +250,7 @@ func listReleases(cmd *Command, args *Args) {
 
 		colorize := ui.IsTerminal(os.Stdout)
 		for _, release := range releases {
-			ui.Printf(formatRelease(release, flagReleaseFormat, colorize))
+			ui.Print(formatRelease(release, flagReleaseFormat, colorize))
 		}
 	}
 
@@ -338,7 +338,7 @@ func showRelease(cmd *Command, args *Args) {
 
 		colorize := ui.IsTerminal(os.Stdout)
 		if flagShowReleaseFormat != "" {
-			ui.Printf(formatRelease(*release, flagShowReleaseFormat, colorize))
+			ui.Print(formatRelease(*release, flagShowReleaseFormat, colorize))
 			return
 		}
 

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -614,6 +614,26 @@ Feature: hub issue
       I want this feature\n
       """
 
+  Scenario: Format with literal % characters
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/102') {
+        json \
+          :number => 102,
+          :state => "open",
+          :title => "Feature request % hub",
+          :user => { :login => "alexfornuto" }
+      }
+      get('/repos/github/hub/issues/102/comments') {
+        json []
+      }
+      """
+    When I successfully run `hub issue show 102 --format='%t%%t%%n%n'`
+    Then the output should contain exactly:
+      """
+      Feature request % hub%t%n\n
+      """
+
   Scenario: Did not supply an issue number
     When I run `hub issue show`
     Then the exit status should be 1

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -10,6 +10,7 @@ import (
 )
 
 type UI interface {
+	Print(a ...interface{}) (n int, err error)
 	Printf(format string, a ...interface{}) (n int, err error)
 	Println(a ...interface{}) (n int, err error)
 	Errorf(format string, a ...interface{}) (n int, err error)
@@ -21,6 +22,10 @@ var (
 	Stderr     = colorable.NewColorableStderr()
 	Default UI = Console{Stdout: Stdout, Stderr: Stderr}
 )
+
+func Print(a ...interface{}) (n int, err error) {
+	return Default.Print(a...)
+}
 
 func Printf(format string, a ...interface{}) (n int, err error) {
 	return Default.Printf(format, a...)
@@ -45,6 +50,10 @@ func IsTerminal(f *os.File) bool {
 type Console struct {
 	Stdout io.Writer
 	Stderr io.Writer
+}
+
+func (c Console) Print(a ...interface{}) (n int, err error) {
+	return fmt.Fprint(c.Stdout, a...)
 }
 
 func (c Console) Printf(format string, a ...interface{}) (n int, err error) {


### PR DESCRIPTION
- In general, avoid using Printf without a static format string.
- Add documentation about `%n` and `%%` tokens for `--format`

Fixes https://github.com/github/hub/issues/1972