### PR TITLE
256-color terminal support

### DIFF
--- a/commands/internal-print-color-test.go
+++ b/commands/internal-print-color-test.go
@@ -1,0 +1,18 @@
+package commands
+
+import "github.com/github/hub/utils"
+
+var cmdInternalPrintColorTest = &Command{
+	Run:   internalPrintColorTest,
+	Usage: "internal-print-color-test",
+	Long: "Print a terminal color test swatch",
+}
+
+func init() {
+	CmdRunner.Use(cmdInternalPrintColorTest)
+}
+
+func internalPrintColorTest(_ *Command, args *Args) {
+	args.NoForward()
+	utils.PrintColorCube()
+}

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -595,8 +595,9 @@ func formatLabel(label github.IssueLabel, colorize bool) string {
 }
 
 func colorizeLabel(label github.IssueLabel, color *utils.Color) string {
-	return fmt.Sprintf("\033[38;5;%d;48;2;%d;%d;%dm %s \033[m",
-		getSuitableLabelTextColor(color), color.Red, color.Green, color.Blue, label.Name)
+	bgColorCode := utils.RgbToTermColorCode(color)
+	return fmt.Sprintf("\033[38;5;%d;48;%sm %s \033[0m",
+		getSuitableLabelTextColor(color), bgColorCode, label.Name)
 }
 
 func getSuitableLabelTextColor(color *utils.Color) int {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,10 @@ import (
 
 	"github.com/github/hub/ui"
 )
+
+func init() {
+	initColorCube()
+}
 
 var timeNow = time.Now
 
@@ -114,6 +119,10 @@ func (c *Color) Brightness() float32 {
 	return (0.299*float32(c.Red) + 0.587*float32(c.Green) + 0.114*float32(c.Blue)) / 255
 }
 
+func (c *Color) Distance(other *Color) float64 {
+	return math.Sqrt(float64(math.Pow(float64(c.Red - other.Red), 2) + math.Pow(float64(c.Green - other.Green), 2) + math.Pow(float64(c.Blue - other.Blue), 2)))
+}
+
 func TimeAgo(t time.Time) string {
 	duration := timeNow().Sub(t)
 	minutes := duration.Minutes()
@@ -149,4 +158,74 @@ func TimeAgo(t time.Time) string {
 		plural = "s"
 	}
 	return fmt.Sprintf("%d %s%s ago", val, unit, plural)
+}
+
+
+var x6colorIndexes = [6]int64{ 0, 95, 135, 175, 215, 255 }
+var x6colorCube [216]Color
+
+func initColorCube() {
+	i := 0
+	for iR := 0; iR < 6; iR++ {
+		for iG := 0; iG < 6; iG++ {
+			for iB := 0; iB < 6; iB++ {
+				x6colorCube[i] = Color{x6colorIndexes[iR], x6colorIndexes[iG], x6colorIndexes[iB]}
+				i++
+			}
+		}
+	}
+}
+
+func PrintColorCube() {
+	for i := 0; i < 216; i++ {
+		color := x6colorCube[i];
+		intCode := i + 16
+		code := fmt.Sprintf("5;%d", intCode)
+		ui.Printf("\033[48;%sm %3d %02x %02x %02x \033[0m ",
+			code, intCode, color.Red, color.Green, color.Blue)
+		if i % 6 == 5 {
+			ui.Printf("\n")
+		}
+	}
+}
+
+func ditherTo256ColorCode(color *Color) (code int) {
+	iMatch := -1
+	minDistance := float64(99999)
+	for i := 0; i < 216; i++ {
+		distance := color.Distance(&x6colorCube[i])
+		if distance < minDistance {
+			iMatch = i
+			minDistance = distance
+		}
+	}
+	return iMatch + 16
+}
+
+var non24bitColorTerms = []string{ "Apple_Terminal" }
+var isTerm24bitColorCapableCache bool
+var isTerm24bitColorCapableCacheIsInit bool = false
+func isTerm24bitColorCapable() (tf bool) {
+	if !isTerm24bitColorCapableCacheIsInit {
+		isTerm24bitColorCapableCache = true
+		myTermProg := os.Getenv("TERM_PROGRAM")
+		for i := 0; i < len(non24bitColorTerms); i++ {
+			if myTermProg == non24bitColorTerms[i] {
+				isTerm24bitColorCapableCache = false
+				break
+			}
+		}
+		isTerm24bitColorCapableCacheIsInit = true
+	}
+	return isTerm24bitColorCapableCache
+}
+
+func RgbToTermColorCode(color *Color) (code string) {
+	if isTerm24bitColorCapable() {
+		code = fmt.Sprintf("2;%d;%d;%d", color.Red, color.Green, color.Blue)
+	} else {
+		intCode := ditherTo256ColorCode(color)
+		code = fmt.Sprintf("5;%d", intCode)
+	}
+	return
 }


### PR DESCRIPTION
Fixes #1560.

Here's a PR to add 256-color support for terminals like Terminal.app, which don't support 24-bit ("true") color.

This is a work in progress: the logic is there, but the colors aren't coming out right. They're too blue.

I added a test command `hub internal-print-color-test` so you can see a swatch of the color cube it's working with. Suggestions welcome on what I'm doing wrong here.

<img width="830" alt="screen shot 2018-12-22 at 4 55 19 am" src="https://user-images.githubusercontent.com/2618447/50372976-e4548d80-05a5-11e9-9220-7ccd5cc96653.png">


<img width="830" alt="screen shot 2018-12-22 at 4 46 41 am" src="https://user-images.githubusercontent.com/2618447/50372898-9ee39080-05a4-11e9-916a-1b7f33880af8.png">
