### PR TITLE
ui Printf functions: handle errors by dying

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -23,24 +23,49 @@ var (
 	Default UI = Console{Stdout: Stdout, Stderr: Stderr}
 )
 
-func Print(a ...interface{}) (n int, err error) {
-	return Default.Print(a...)
+func Print(a ...interface{}) (n int) {
+	n, err := Default.Print(a...)
+	if err != nil {
+		// If something as basic as printing to stdout fails, just panic and exit
+		os.Exit(1)
+	}
+	return
 }
 
-func Printf(format string, a ...interface{}) (n int, err error) {
-	return Default.Printf(format, a...)
+func Printf(format string, a ...interface{}) (n int) {
+	n, err := Default.Printf(format, a...)
+	if err != nil {
+		// If something as basic as printing to stdout fails, just panic and exit
+		os.Exit(1)
+	}
+	return
 }
 
-func Println(a ...interface{}) (n int, err error) {
-	return Default.Println(a...)
+func Println(a ...interface{}) (n int) {
+	n, err := Default.Println(a...)
+	if err != nil {
+		// If something as basic as printing to stdout fails, just panic and exit
+		os.Exit(1)
+	}
+	return
 }
 
-func Errorf(format string, a ...interface{}) (n int, err error) {
-	return Default.Errorf(format, a...)
+func Errorf(format string, a ...interface{}) (n int) {
+	n, err := Default.Errorf(format, a...)
+	if err != nil {
+		// If something as basic as printing to stderr fails, just panic and exit
+		os.Exit(1)
+	}
+	return
 }
 
-func Errorln(a ...interface{}) (n int, err error) {
-	return Default.Errorln(a...)
+func Errorln(a ...interface{}) (n int) {
+	n, err := Default.Errorln(a...)
+	if err != nil {
+		// If something as basic as printing to stderr fails, just panic and exit
+		os.Exit(1)
+	}
+	return
 }
 
 func IsTerminal(f *os.File) bool {


### PR DESCRIPTION
The `ui` `Printf` and related functions return an `error` to indicate their status. But none of the call sites that are calling them are catching that returned error. Go linters see this as an un-handled error and complain about it.

What do you think about locally handling errors on stdout/stderr by just panicking and dying, removing the returned `error` from their signatures? This will get rid of the go linter warnings, and seems a little cleaner to me.