### PR TITLE
Rename local variables to avoid collisions with package names

### DIFF
--- a/commands/compare.go
+++ b/commands/compare.go
@@ -120,10 +120,10 @@ func compare(command *Command, args *Args) {
 	}
 
 	subpage := utils.ConcatPaths("compare", rangeQueryEscape(r))
-	url := project.WebURL("", "", subpage)
+	myUrl := project.WebURL("", "", subpage)
 
 	args.NoForward()
-	printBrowseOrCopy(args, url, !flagCompareURLOnly && !flagCompareCopy, flagCompareCopy)
+	printBrowseOrCopy(args, myUrl, !flagCompareURLOnly && !flagCompareCopy, flagCompareCopy)
 }
 
 func parseCompareRange(r string) string {

--- a/commands/help.go
+++ b/commands/help.go
@@ -165,9 +165,9 @@ func lookupCmd(name string) *Command {
 	if strings.HasPrefix(name, "hub-") {
 		return CmdRunner.Lookup(strings.TrimPrefix(name, "hub-"))
 	} else {
-		cmd := CmdRunner.Lookup(name)
-		if cmd != nil && !cmd.GitExtension {
-			return cmd
+		myCmd := CmdRunner.Lookup(name)
+		if myCmd != nil && !myCmd.GitExtension {
+			return myCmd
 		} else {
 			return nil
 		}

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -95,9 +95,9 @@ func (r *Runner) Execute() ExecError {
 		cmdName = args.Command
 	}
 
-	cmd := r.Lookup(cmdName)
-	if cmd != nil && cmd.Runnable() {
-		execErr := r.Call(cmd, args)
+	myCmd := r.Lookup(cmdName)
+	if myCmd != nil && myCmd.Runnable() {
+		execErr := r.Call(myCmd, args)
 		if execErr.ExitCode == 0 && forceFail {
 			execErr = newExecError(fmt.Errorf(""))
 		}
@@ -164,10 +164,10 @@ func executeCommands(cmds []*cmd.Cmd, execFinal bool) error {
 }
 
 func expandAlias(args *Args) {
-	cmd := args.Command
-	expandedCmd, err := git.Alias(cmd)
+	myCmd := args.Command
+	expandedCmd, err := git.Alias(myCmd)
 
-	if err == nil && expandedCmd != "" && !git.IsBuiltInGitCommand(cmd) {
+	if err == nil && expandedCmd != "" && !git.IsBuiltInGitCommand(myCmd) {
 		words, e := splitAliasCmd(expandedCmd)
 		if e == nil {
 			args.Command = words[0]

--- a/fixtures/test_repo.go
+++ b/fixtures/test_repo.go
@@ -56,9 +56,9 @@ func SetupTestRepo() *TestRepo {
 	overrideEnv("XDG_CONFIG_DIRS", "")
 
 	targetPath := filepath.Join(home, "test.git")
-	cmd := cmd.New("git").WithArgs("clone", remotePath, targetPath)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		panic(fmt.Errorf("error running %s\n%s\n%s", cmd, err, output))
+	myCmd := cmd.New("git").WithArgs("clone", remotePath, targetPath)
+	if output, err := myCmd.CombinedOutput(); err != nil {
+		panic(fmt.Errorf("error running %s\n%s\n%s", myCmd, err, output))
 	}
 
 	if err = os.Chdir(targetPath); err != nil {

--- a/git/git.go
+++ b/git/git.go
@@ -188,8 +188,8 @@ func (r *Range) IsIdentical() bool {
 }
 
 func (r *Range) IsAncestor() bool {
-	cmd := gitCmd("merge-base", "--is-ancestor", r.A, r.B)
-	return cmd.Success()
+	myCmd := gitCmd("merge-base", "--is-ancestor", r.A, r.B)
+	return myCmd.Success()
 }
 
 func CommentChar(text string) (string, error) {
@@ -215,11 +215,11 @@ func CommentChar(text string) (string, error) {
 }
 
 func Show(sha string) (string, error) {
-	cmd := cmd.New("git")
-	cmd.WithArg("-c").WithArg("log.showSignature=false")
-	cmd.WithArg("show").WithArg("-s").WithArg("--format=%s%n%+b").WithArg(sha)
+	myCmd := cmd.New("git")
+	myCmd.WithArg("-c").WithArg("log.showSignature=false")
+	myCmd.WithArg("show").WithArg("-s").WithArg("--format=%s%n%+b").WithArg(sha)
 
-	output, err := cmd.CombinedOutput()
+	output, err := myCmd.CombinedOutput()
 	output = strings.TrimSpace(output)
 
 	return output, err
@@ -289,8 +289,8 @@ func gitConfig(args ...string) ([]string, error) {
 }
 
 func gitConfigCommand(args []string) []string {
-	cmd := []string{"config"}
-	return append(cmd, args...)
+	myCmd := []string{"config"}
+	return append(myCmd, args...)
 }
 
 func Alias(name string) (string, error) {
@@ -298,24 +298,21 @@ func Alias(name string) (string, error) {
 }
 
 func Run(args ...string) error {
-	cmd := gitCmd(args...)
-	return cmd.Run()
+	return gitCmd(args...).Run()
 }
 
 func Spawn(args ...string) error {
-	cmd := gitCmd(args...)
-	return cmd.Spawn()
+	return gitCmd(args...).Spawn()
 }
 
 func Quiet(args ...string) bool {
-	cmd := gitCmd(args...)
-	return cmd.Success()
+	return gitCmd(args...).Success()
 }
 
 func IsGitDir(dir string) bool {
-	cmd := cmd.New("git")
-	cmd.WithArgs("--git-dir="+dir, "rev-parse", "--git-dir")
-	return cmd.Success()
+	myCmd := cmd.New("git")
+	myCmd.WithArgs("--git-dir="+dir, "rev-parse", "--git-dir")
+	return myCmd.Success()
 }
 
 func LocalBranches() ([]string, error) {
@@ -330,9 +327,9 @@ func LocalBranches() ([]string, error) {
 }
 
 func gitOutput(input ...string) (outputs []string, err error) {
-	cmd := gitCmd(input...)
+	myCmd := gitCmd(input...)
 
-	out, err := cmd.CombinedOutput()
+	out, err := myCmd.CombinedOutput()
 	for _, line := range strings.Split(out, "\n") {
 		if strings.TrimSpace(line) != "" {
 			outputs = append(outputs, string(line))
@@ -343,17 +340,17 @@ func gitOutput(input ...string) (outputs []string, err error) {
 }
 
 func gitCmd(args ...string) *cmd.Cmd {
-	cmd := cmd.New("git")
+	myCmd := cmd.New("git")
 
 	for _, v := range GlobalFlags {
-		cmd.WithArg(v)
+		myCmd.WithArg(v)
 	}
 
 	for _, a := range args {
-		cmd.WithArg(a)
+		myCmd.WithArg(a)
 	}
 
-	return cmd
+	return myCmd
 }
 
 func IsBuiltInGitCommand(command string) bool {

--- a/github/http.go
+++ b/github/http.go
@@ -217,10 +217,10 @@ type simpleClient struct {
 }
 
 func (c *simpleClient) performRequest(method, path string, body io.Reader, configure func(*http.Request)) (*simpleResponse, error) {
-	url, err := url.Parse(path)
+	myUrl, err := url.Parse(path)
 	if err == nil {
-		url = c.rootUrl.ResolveReference(url)
-		return c.performRequestUrl(method, url, body, configure)
+		myUrl = c.rootUrl.ResolveReference(myUrl)
+		return c.performRequestUrl(method, myUrl, body, configure)
 	} else {
 		return nil, err
 	}
@@ -258,11 +258,11 @@ func (c *simpleClient) performRequestUrl(method string, url *url.URL, body io.Re
 }
 
 func (c *simpleClient) jsonRequest(method, path string, body interface{}, configure func(*http.Request)) (*simpleResponse, error) {
-	json, err := json.Marshal(body)
+	jsonStr, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
-	buf := bytes.NewBuffer(json)
+	buf := bytes.NewBuffer(jsonStr)
 
 	return c.performRequest(method, path, buf, func(req *http.Request) {
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")

--- a/github/localrepo_test.go
+++ b/github/localrepo_test.go
@@ -21,11 +21,11 @@ func TestGitHubRepo_OriginRemote(t *testing.T) {
 }
 
 func TestGitHubRepo_remotesForPublish(t *testing.T) {
-	url, _ := url.Parse("ssh://git@github.com/Owner/repo.git")
+	myUrl, _ := url.Parse("ssh://git@github.com/Owner/repo.git")
 	remotes := []Remote{
 		{
 			Name: "Owner",
-			URL:  url,
+			URL:  myUrl,
 		},
 	}
 	repo := GitHubRepo{remotes}
@@ -33,5 +33,5 @@ func TestGitHubRepo_remotesForPublish(t *testing.T) {
 
 	assert.Equal(t, 1, len(remotesForPublish))
 	assert.Equal(t, "Owner", remotesForPublish[0].Name)
-	assert.Equal(t, url.String(), remotesForPublish[0].URL.String())
+	assert.Equal(t, myUrl.String(), remotesForPublish[0].URL.String())
 }

--- a/github/project.go
+++ b/github/project.go
@@ -54,12 +54,12 @@ func (p *Project) WebURL(name, owner, path string) string {
 		}
 	}
 
-	url := fmt.Sprintf("%s://%s", p.Protocol, utils.ConcatPaths(p.Host, ownerWithName))
+	myUrl := fmt.Sprintf("%s://%s", p.Protocol, utils.ConcatPaths(p.Host, ownerWithName))
 	if path != "" {
-		url = utils.ConcatPaths(url, path)
+		myUrl = utils.ConcatPaths(myUrl, path)
 	}
 
-	return url
+	return myUrl
 }
 
 func (p *Project) GitURL(name, owner string, isSSH bool) (url string) {
@@ -104,12 +104,12 @@ func preferredProtocol() string {
 }
 
 func NewProjectFromRepo(repo *Repository) (p *Project, err error) {
-	url, err := url.Parse(repo.HtmlUrl)
+	repoUrl, err := url.Parse(repo.HtmlUrl)
 	if err != nil {
 		return
 	}
 
-	p, err = NewProjectFromURL(url)
+	p, err = NewProjectFromURL(repoUrl)
 	return
 }
 

--- a/github/project_test.go
+++ b/github/project_test.go
@@ -17,20 +17,20 @@ func TestProject_WebURL(t *testing.T) {
 		Protocol: "https",
 	}
 
-	url := project.WebURL("", "", "baz")
-	assert.Equal(t, "https://github.com/bar/foo/baz", url)
+	myUrl := project.WebURL("", "", "baz")
+	assert.Equal(t, "https://github.com/bar/foo/baz", myUrl)
 
-	url = project.WebURL("1", "2", "")
-	assert.Equal(t, "https://github.com/2/1", url)
+	myUrl = project.WebURL("1", "2", "")
+	assert.Equal(t, "https://github.com/2/1", myUrl)
 
-	url = project.WebURL("hub.wiki", "defunkt", "")
-	assert.Equal(t, "https://github.com/defunkt/hub/wiki", url)
+	myUrl = project.WebURL("hub.wiki", "defunkt", "")
+	assert.Equal(t, "https://github.com/defunkt/hub/wiki", myUrl)
 
-	url = project.WebURL("hub.wiki", "defunkt", "commits")
-	assert.Equal(t, "https://github.com/defunkt/hub/wiki/_history", url)
+	myUrl = project.WebURL("hub.wiki", "defunkt", "commits")
+	assert.Equal(t, "https://github.com/defunkt/hub/wiki/_history", myUrl)
 
-	url = project.WebURL("hub.wiki", "defunkt", "pages")
-	assert.Equal(t, "https://github.com/defunkt/hub/wiki/_pages", url)
+	myUrl = project.WebURL("hub.wiki", "defunkt", "pages")
+	assert.Equal(t, "https://github.com/defunkt/hub/wiki/_pages", myUrl)
 }
 
 func TestProject_GitURL(t *testing.T) {
@@ -43,19 +43,19 @@ func TestProject_GitURL(t *testing.T) {
 		Host:  "github.com",
 	}
 
-	url := project.GitURL("gh", "jingweno", false)
-	assert.Equal(t, "https://github.com/jingweno/gh.git", url)
+	myUrl := project.GitURL("gh", "jingweno", false)
+	assert.Equal(t, "https://github.com/jingweno/gh.git", myUrl)
 
 	os.Setenv("HUB_PROTOCOL", "git")
-	url = project.GitURL("gh", "jingweno", false)
-	assert.Equal(t, "git://github.com/jingweno/gh.git", url)
+	myUrl = project.GitURL("gh", "jingweno", false)
+	assert.Equal(t, "git://github.com/jingweno/gh.git", myUrl)
 
 	os.Setenv("HUB_PROTOCOL", "ssh")
-	url = project.GitURL("gh", "jingweno", true)
-	assert.Equal(t, "git@github.com:jingweno/gh.git", url)
+	myUrl = project.GitURL("gh", "jingweno", true)
+	assert.Equal(t, "git@github.com:jingweno/gh.git", myUrl)
 
-	url = project.GitURL("gh", "jingweno", true)
-	assert.Equal(t, "git@github.com:jingweno/gh.git", url)
+	myUrl = project.GitURL("gh", "jingweno", true)
+	assert.Equal(t, "git@github.com:jingweno/gh.git", myUrl)
 }
 
 func TestProject_GitURLEnterprise(t *testing.T) {
@@ -68,19 +68,19 @@ func TestProject_GitURLEnterprise(t *testing.T) {
 	defer os.Setenv("HUB_PROTOCOL", "")
 
 	os.Setenv("HUB_PROTOCOL", "https")
-	url := project.GitURL("gh", "jingweno", false)
-	assert.Equal(t, "https://github.corporate.com/jingweno/gh.git", url)
+	myUrl := project.GitURL("gh", "jingweno", false)
+	assert.Equal(t, "https://github.corporate.com/jingweno/gh.git", myUrl)
 
 	os.Setenv("HUB_PROTOCOL", "ssh")
-	url = project.GitURL("gh", "jingweno", false)
-	assert.Equal(t, "git@github.corporate.com:jingweno/gh.git", url)
+	myUrl = project.GitURL("gh", "jingweno", false)
+	assert.Equal(t, "git@github.corporate.com:jingweno/gh.git", myUrl)
 
 	os.Setenv("HUB_PROTOCOL", "git")
-	url = project.GitURL("gh", "jingweno", false)
-	assert.Equal(t, "git://github.corporate.com/jingweno/gh.git", url)
+	myUrl = project.GitURL("gh", "jingweno", false)
+	assert.Equal(t, "git://github.corporate.com/jingweno/gh.git", myUrl)
 
-	url = project.GitURL("gh", "jingweno", true)
-	assert.Equal(t, "git@github.corporate.com:jingweno/gh.git", url)
+	myUrl = project.GitURL("gh", "jingweno", true)
+	assert.Equal(t, "git@github.corporate.com:jingweno/gh.git", myUrl)
 }
 
 func TestProject_NewProjectFromURL(t *testing.T) {

--- a/github/remote.go
+++ b/github/remote.go
@@ -46,14 +46,14 @@ func Remotes() (remotes []Remote, err error) {
 		if re.MatchString(r) {
 			match := re.FindStringSubmatch(r)
 			name := strings.TrimSpace(match[1])
-			url := strings.TrimSpace(match[2])
+			theUrl := strings.TrimSpace(match[2])
 			urlType := strings.TrimSpace(match[3])
 			utm, ok := remotesMap[name]
 			if !ok {
 				utm = make(map[string]string)
 				remotesMap[name] = utm
 			}
-			utm[urlType] = url
+			utm[urlType] = theUrl
 		}
 	}
 

--- a/github/url.go
+++ b/github/url.go
@@ -20,15 +20,15 @@ func (url URL) ProjectPath() (projectPath string) {
 }
 
 func ParseURL(rawurl string) (*URL, error) {
-	url, err := url.Parse(rawurl)
+	repoUrl, err := url.Parse(rawurl)
 	if err != nil {
 		return nil, err
 	}
 
-	project, err := NewProjectFromURL(url)
+	project, err := NewProjectFromURL(repoUrl)
 	if err != nil {
 		return nil, err
 	}
 
-	return &URL{Project: project, URL: *url}, nil
+	return &URL{Project: project, URL: *repoUrl}, nil
 }


### PR DESCRIPTION
golint is issuing some warnings about local variable names colliding with imported package names. Are you interested in getting rid of those warnings by renaming the local variables?

(Or maybe rename the `cmd` package to the longer `command`, and preserve `cmd` as a local variable name?)