### PR TITLE
Improve `hub create` dealing with an existing "origin" remote

### DIFF
--- a/features/create.feature
+++ b/features/create.feature
@@ -111,6 +111,7 @@ Feature: hub create
     And the "origin" remote has url "git://github.com/mislav/dotfiles.git"
     When I successfully run `hub create`
     Then the url for "origin" should be "git://github.com/mislav/dotfiles.git"
+    And the output should contain exactly "https://github.com/mislav/dotfiles\n"
 
   Scenario: Unrelated origin remote already exists
     Given the GitHub API server:
@@ -122,8 +123,12 @@ Feature: hub create
       """
     And the "origin" remote has url "git://example.com/unrelated.git"
     When I successfully run `hub create`
-    Then the output should contain exactly "https://github.com/mislav/dotfiles\n"
-    And the url for "origin" should be "git://example.com/unrelated.git"
+    Then the url for "origin" should be "git://example.com/unrelated.git"
+    And the stdout should contain exactly "https://github.com/mislav/dotfiles\n"
+    And the stderr should contain exactly:
+      """
+      A git remote named "origin" already exists and is set to push to 'git://example.com/unrelated.git'.\n
+      """
 
   Scenario: Another remote already exists
     Given the GitHub API server:
@@ -145,7 +150,7 @@ Feature: hub create
       }
       """
     When I successfully run `hub create`
-    Then the output should contain "Existing repository detected. Updating git remote\n"
+    Then the output should contain "Existing repository detected\n"
     And the url for "origin" should be "git@github.com:mislav/dotfiles.git"
 
   Scenario: GitHub repo already exists and is not private

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -170,10 +170,6 @@ func (r *GitHubRepo) RemoteForRepo(repo *Repository) (*Remote, error) {
 	return nil, fmt.Errorf("could not find git remote for %s/%s", repo.Owner.Login, repo.Name)
 }
 
-func (r *GitHubRepo) OriginRemote() (remote *Remote, err error) {
-	return r.RemoteByName("origin")
-}
-
 func (r *GitHubRepo) MainRemote() (remote *Remote, err error) {
 	r.loadRemotes()
 

--- a/github/localrepo_test.go
+++ b/github/localrepo_test.go
@@ -5,20 +5,7 @@ import (
 	"testing"
 
 	"github.com/bmizerany/assert"
-	"github.com/github/hub/fixtures"
 )
-
-func TestGitHubRepo_OriginRemote(t *testing.T) {
-	repo := fixtures.SetupTestRepo()
-	defer repo.TearDown()
-
-	localRepo, _ := LocalRepo()
-	gitRemote, _ := localRepo.OriginRemote()
-	assert.Equal(t, "origin", gitRemote.Name)
-
-	u, _ := url.Parse(repo.Remote)
-	assert.Equal(t, u, gitRemote.URL)
-}
 
 func TestGitHubRepo_remotesForPublish(t *testing.T) {
 	url, _ := url.Parse("ssh://git@github.com/Owner/repo.git")


### PR DESCRIPTION
- No longer says "updating git remote", but not actually doing anything
- Shows a helpful warning about "origin" pointing to a possibly unrelated repo

Fixes #1849