### PR TITLE
Fix detecting pull-request base with multi-remote setup

### DIFF
--- a/commands/fork.go
+++ b/commands/fork.go
@@ -64,7 +64,7 @@ func fork(cmd *Command, args *Args) {
 	host, err := config.PromptForHost(project.Host)
 	utils.Check(github.FormatError("forking repository", err))
 
-	originRemote, err := localRepo.MainRemote()
+	originRemote, err := localRepo.RemoteForProject(project)
 	utils.Check(err)
 
 	params := map[string]interface{}{}

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -185,9 +185,9 @@ func pullRequest(cmd *Command, args *Args) {
 		flagPullRequestIssue = parsePullRequestIssueNumber(arg)
 	}
 
-	if base == "" {
-		masterBranch := localRepo.MasterBranch()
-		base = masterBranch.ShortName()
+	baseRemote, _ := localRepo.RemoteForProject(baseProject)
+	if base == "" && baseRemote != nil {
+		base = localRepo.DefaultBranch(baseRemote).ShortName()
 	}
 
 	if head == "" && trackedBranch != nil {
@@ -237,12 +237,12 @@ func pullRequest(cmd *Command, args *Args) {
 	baseTracking := base
 	headTracking := head
 
-	remote := gitRemoteForProject(baseProject)
+	remote := baseRemote
 	if remote != nil {
 		baseTracking = fmt.Sprintf("%s/%s", remote.Name, base)
 	}
 	if remote == nil || !baseProject.SameAs(headProject) {
-		remote = gitRemoteForProject(headProject)
+		remote, _ = localRepo.RemoteForProject(headProject)
 	}
 	if remote != nil {
 		headTracking = fmt.Sprintf("%s/%s", remote.Name, head)

--- a/commands/sync.go
+++ b/commands/sync.go
@@ -41,7 +41,7 @@ func sync(cmd *Command, args *Args) {
 	remote, err := localRepo.MainRemote()
 	utils.Check(err)
 
-	defaultBranch := localRepo.MasterBranch().ShortName()
+	defaultBranch := localRepo.DefaultBranch(remote).ShortName()
 	fullDefaultBranch := fmt.Sprintf("refs/remotes/%s/%s", remote.Name, defaultBranch)
 	currentBranch := ""
 	if curBranch, err := localRepo.CurrentBranch(); err == nil {

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/atotto/clipboard"
 	"github.com/github/hub/git"
-	"github.com/github/hub/github"
 	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
@@ -79,20 +78,6 @@ func isCloneable(file string) bool {
 			return false
 		}
 	}
-}
-
-func gitRemoteForProject(project *github.Project) (foundRemote *github.Remote) {
-	remotes, err := github.Remotes()
-	utils.Check(err)
-	for _, remote := range remotes {
-		remoteProject, pErr := remote.Project()
-		if pErr == nil && remoteProject.SameAs(project) {
-			foundRemote = &remote
-			return
-		}
-	}
-
-	return nil
 }
 
 func isEmptyDir(path string) bool {

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -76,7 +76,7 @@ Feature: hub checkout <PULLREQ-URL>
     Then the exit status should be 1
     And the stderr should contain exactly:
       """
-      could not find git remote for mislav/jekyll\n
+      could not find a git remote for 'mislav/jekyll'\n
       """
 
   Scenario: Custom name for new branch

--- a/features/ci_status.feature
+++ b/features/ci_status.feature
@@ -85,7 +85,10 @@ Feature: hub ci-status
   Scenario: Non-GitHub repo
     Given the "origin" remote has url "mygh:Manganeez/repo.git"
     When I run `hub ci-status`
-    Then the stderr should contain "Aborted: the origin remote doesn't point to a GitHub repository.\n"
+    Then the stderr should contain exactly:
+      """
+      Aborted: could not find any git remote pointing to a GitHub repository\n
+      """
     And the exit status should be 1
 
   Scenario: Enterprise CI statuses

--- a/features/compare.feature
+++ b/features/compare.feature
@@ -152,7 +152,7 @@ Feature: hub compare
     Then the stdout should contain exactly ""
     And the stderr should contain exactly:
       """
-      Aborted: the origin remote doesn't point to a GitHub repository.\n
+      Aborted: could not find any git remote pointing to a GitHub repository\n
       """
     And the exit status should be 1
 

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -250,7 +250,7 @@ Feature: hub fork
     Then the exit status should be 1
     And the stderr should contain exactly:
       """
-      Aborted: the origin remote doesn't point to a GitHub repository.\n
+      Aborted: could not find any git remote pointing to a GitHub repository\n
       """
     And there should be no "origin" remote
 
@@ -260,7 +260,7 @@ Feature: hub fork
     Then the exit status should be 1
     And the stderr should contain exactly:
       """
-      Aborted: the origin remote doesn't point to a GitHub repository.\n
+      Aborted: could not find any git remote pointing to a GitHub repository\n
       """
 
   Scenario: Enterprise fork

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -805,6 +805,23 @@ Feature: hub pull-request
     When I successfully run `hub pull-request -m hereyougo`
     Then the output should contain exactly "the://url\n"
 
+  Scenario: Create pull request to "upstream" remote with differently-named default branch
+    Given I am on the "master" branch pushed to "origin/master"
+    And the "upstream" remote has url "git://github.com/github/coral.git"
+    And the default branch for "upstream" is "develop"
+    Given the GitHub API server:
+      """
+      post('/repos/github/coral/pulls') {
+        assert :base  => 'develop',
+               :head  => 'mislav:master',
+               :title => 'hereyougo'
+        status 201
+        json :html_url => "the://url"
+      }
+      """
+    When I successfully run `hub pull-request -m hereyougo`
+    Then the output should contain exactly "the://url\n"
+
   Scenario: Open pull request in web browser
     Given the GitHub API server:
       """

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -13,7 +13,10 @@ Feature: hub pull-request
   Scenario: Non-GitHub repo
     Given the "origin" remote has url "mygh:Manganeez/repo.git"
     When I run `hub pull-request`
-    Then the stderr should contain "Aborted: the origin remote doesn't point to a GitHub repository.\n"
+    Then the stderr should contain exactly:
+      """
+      Aborted: could not find any git remote pointing to a GitHub repository\n
+      """
     And the exit status should be 1
 
   Scenario: Create pull request respecting "insteadOf" configuration
@@ -813,6 +816,23 @@ Feature: hub pull-request
       """
       post('/repos/github/coral/pulls') {
         assert :base  => 'develop',
+               :head  => 'mislav:master',
+               :title => 'hereyougo'
+        status 201
+        json :html_url => "the://url"
+      }
+      """
+    When I successfully run `hub pull-request -m hereyougo`
+    Then the output should contain exactly "the://url\n"
+
+  Scenario: Create pull request to "github" remote when "upstream" is non-GitHub
+    Given I am on the "master" branch pushed to "origin/master"
+    And the "github" remote has url "git://github.com/github/coral.git"
+    And the "upstream" remote has url "git://example.com/coral.git"
+    Given the GitHub API server:
+      """
+      post('/repos/github/coral/pulls') {
+        assert :base  => 'master',
                :head  => 'mislav:master',
                :title => 'hereyougo'
         status 201

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -132,11 +132,13 @@ Given(/^I am on the "([^"]+)" branch(?: (pushed to|with upstream) "([^"]+)")?$/)
 end
 
 Given(/^the default branch for "([^"]+)" is "([^"]+)"$/) do |remote, branch|
-  empty_commit
-  ref_file = ".git/refs/remotes/#{remote}/#{branch}"
   in_current_dir do
-    FileUtils.mkdir_p File.dirname(ref_file)
-    FileUtils.cp '.git/refs/heads/master', ref_file
+    ref_file = ".git/refs/remotes/#{remote}/#{branch}"
+    unless File.exist? ref_file
+      empty_commit unless File.exist? '.git/refs/heads/master'
+      FileUtils.mkdir_p File.dirname(ref_file)
+      FileUtils.cp '.git/refs/heads/master', ref_file
+    end
   end
   run_silent %(git remote set-head #{remote} #{branch})
 end

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -102,20 +102,23 @@ func (r *GitHubRepo) CurrentBranch() (branch *Branch, err error) {
 	return
 }
 
-func (r *GitHubRepo) MasterBranch() (branch *Branch) {
-	origin, e := r.RemoteByName("origin")
-	var name string
-	if e == nil {
-		name, _ = git.BranchAtRef("refs", "remotes", origin.Name, "HEAD")
+func (r *GitHubRepo) MasterBranch() *Branch {
+	if remote, err := r.MainRemote(); err == nil {
+		return r.DefaultBranch(remote)
+	} else {
+		return r.DefaultBranch(nil)
 	}
+}
 
+func (r *GitHubRepo) DefaultBranch(remote *Remote) *Branch {
+	var name string
+	if remote != nil {
+		name, _ = git.BranchAtRef("refs", "remotes", remote.Name, "HEAD")
+	}
 	if name == "" {
 		name = "refs/heads/master"
 	}
-
-	branch = &Branch{r, name}
-
-	return
+	return &Branch{r, name}
 }
 
 func (r *GitHubRepo) RemoteBranchAndProject(owner string, preferUpstream bool) (branch *Branch, project *Project, err error) {

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -39,7 +39,9 @@ func (r *GitHubRepo) loadRemotes() error {
 }
 
 func (r *GitHubRepo) RemoteByName(name string) (*Remote, error) {
-	r.loadRemotes()
+	if err := r.loadRemotes(); err != nil {
+		return nil, err
+	}
 
 	for _, remote := range r.remotes {
 		if remote.Name == name {
@@ -122,7 +124,9 @@ func (r *GitHubRepo) DefaultBranch(remote *Remote) *Branch {
 }
 
 func (r *GitHubRepo) RemoteBranchAndProject(owner string, preferUpstream bool) (branch *Branch, project *Project, err error) {
-	r.loadRemotes()
+	if err = r.loadRemotes(); err != nil {
+		return
+	}
 
 	for _, remote := range r.remotes {
 		if p, err := remote.Project(); err == nil {
@@ -153,7 +157,9 @@ func (r *GitHubRepo) RemoteBranchAndProject(owner string, preferUpstream bool) (
 }
 
 func (r *GitHubRepo) RemoteForRepo(repo *Repository) (*Remote, error) {
-	r.loadRemotes()
+	if err := r.loadRemotes(); err != nil {
+		return nil, err
+	}
 
 	repoUrl, err := url.Parse(repo.HtmlUrl)
 	if err != nil {

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -169,8 +169,21 @@ func (r *GitHubRepo) RemoteForRepo(repo *Repository) (*Remote, error) {
 			}
 		}
 	}
+	return nil, fmt.Errorf("could not find a git remote for '%s/%s'", repo.Owner.Login, repo.Name)
+}
 
-	return nil, fmt.Errorf("could not find git remote for %s/%s", repo.Owner.Login, repo.Name)
+func (r *GitHubRepo) RemoteForProject(project *Project) (*Remote, error) {
+	if err := r.loadRemotes(); err != nil {
+		return nil, err
+	}
+
+	for _, remote := range r.remotes {
+		remoteProject, err := remote.Project()
+		if err == nil && remoteProject.SameAs(project) {
+			return &remote, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find a git remote for '%s'", project)
 }
 
 func (r *GitHubRepo) MainRemote() (remote *Remote, err error) {

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -192,34 +192,25 @@ func (r *GitHubRepo) RemoteForProject(project *Project) (*Remote, error) {
 	return nil, fmt.Errorf("could not find a git remote for '%s'", project)
 }
 
-func (r *GitHubRepo) MainRemote() (remote *Remote, err error) {
+func (r *GitHubRepo) MainRemote() (*Remote, error) {
 	r.loadRemotes()
 
 	if len(r.remotes) > 0 {
-		remote = &r.remotes[0]
+		return &r.remotes[0], nil
+	} else {
+		return nil, fmt.Errorf("no git remotes found")
 	}
-
-	if remote == nil {
-		err = fmt.Errorf("Can't find git remote origin")
-	}
-
-	return
 }
 
-func (r *GitHubRepo) MainProject() (project *Project, err error) {
-	origin, err := r.MainRemote()
-	if err != nil {
-		err = fmt.Errorf("Aborted: the origin remote doesn't point to a GitHub repository.")
+func (r *GitHubRepo) MainProject() (*Project, error) {
+	r.loadRemotes()
 
-		return
+	for _, remote := range r.remotes {
+		if project, err := remote.Project(); err == nil {
+			return project, nil
+		}
 	}
-
-	project, err = origin.Project()
-	if err != nil {
-		err = fmt.Errorf("Aborted: the origin remote doesn't point to a GitHub repository.")
-	}
-
-	return
+	return nil, fmt.Errorf("Aborted: could not find any git remote pointing to a GitHub repository")
 }
 
 func (r *GitHubRepo) CurrentProject() (project *Project, err error) {


### PR DESCRIPTION
When running `hub pull-request` with this git remote setup:
* origin:   `github.com/myuser/myfork`
* github:   `github.com/owner/repo`
* upstream: `example.com/other-repo`

this error would be shown:

    Aborted: the origin remote doesn't point to a GitHub repository.

The error is both unfortunate (the existence of "upstream" shouldn't have aborted the whole operation) and misleading (it wasn't the "origin" remote that was the problem).

This changes `MainProject()` so it skips over non-GitHub remotes until it finds one that points to a GitHub project.

* * *

Fix detecting default `pull-request` base branch name.

This changes the `MasterBranch()` implementation to consider upstream remotes that might be named differently than "origin". The new `DefaultBranch(remote)` function is now the preferred alternative.

* * *

Affected hub commands:
- `hub browse`
- `hub cherry-pick`
- `hub ci-status`
- `hub fork`
- `hub issue`
- `hub pr`
- `hub pull-request`
- `hub release`
- `hub remote add`

fixes #1955
fixes #1784
fixes #1544
closes #1306