### PR TITLE
build: respect environment LDFLAGS and strip the build path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ SOURCES = $(shell script/build files)
 SOURCE_DATE_EPOCH ?= $(shell date +%s)
 BUILD_DATE = $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" '+%d %b %Y' 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" '+%d %b %Y')
 HUB_VERSION = $(shell hub version | tail -1)
+export LDFLAGS := -extldflags=$(LDFLAGS)
+export GCFLAGS := all=-trimpath=$(PWD)
+export ASMFLAGS := all=-trimpath=$(PWD)
 
 MIN_COVERAGE = 89.4
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@ SOURCES = $(shell script/build files)
 SOURCE_DATE_EPOCH ?= $(shell date +%s)
 BUILD_DATE = $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" '+%d %b %Y' 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" '+%d %b %Y')
 HUB_VERSION = $(shell hub version | tail -1)
+FLAGS_ALL = $(shell go version | grep -q 'go1.[89]' || echo 'all=')
 export LDFLAGS := -extldflags='$(LDFLAGS)'
-export GCFLAGS := all=-trimpath=$(PWD)
-export ASMFLAGS := all=-trimpath=$(PWD)
+export GCFLAGS := $(FLAGS_ALL)-trimpath='$(PWD)'
+export ASMFLAGS := $(FLAGS_ALL)-trimpath='$(PWD)'
 
 MIN_COVERAGE = 89.4
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SOURCES = $(shell script/build files)
 SOURCE_DATE_EPOCH ?= $(shell date +%s)
 BUILD_DATE = $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" '+%d %b %Y' 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" '+%d %b %Y')
 HUB_VERSION = $(shell hub version | tail -1)
-export LDFLAGS := -extldflags=$(LDFLAGS)
+export LDFLAGS := -extldflags='$(LDFLAGS)'
 export GCFLAGS := all=-trimpath=$(PWD)
 export ASMFLAGS := all=-trimpath=$(PWD)
 

--- a/script/build
+++ b/script/build
@@ -13,7 +13,11 @@ find_source_files() {
 
 build_hub() {
   mkdir -p "$(dirname "$1")"
-  go build -ldflags "-X github.com/github/hub/version.Version=`./script/version`" -o "$1"
+  go build \
+	  -ldflags "-X github.com/github/hub/version.Version=`./script/version` $LDFLAGS" \
+	  -gcflags "$GCFLAGS" \
+	  -asmflags "$ASMFLAGS" \
+	  -o "$1"
 }
 
 [ $# -gt 0 ] || set -- -o "bin/hub${windows:+.exe}"


### PR DESCRIPTION
golang does not natively respect LDFLAGS, but you can pass them on the command line using -ldflags=-extldflags=...
This is important for distributions, in order to provide common functionality such as hardening flags.

Also strip the prefixed root source directory from the embedded source file paths. This is not important information for the debugger, which should only care about paths relative to $GOPATH, and results in less build environment metadata leaking into the final binary. (This also aids in reproducible builds when using different build directories, see e.g. https://github.com/golang/go/issues/16860)