### PR TITLE
Fixes bash completion for unaliased `hub`

### DIFF
--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -366,7 +366,21 @@ EOF
     fi
   }
 
+  __hub_main() {
+    local can_unalias
+
+    if [ "$(type -t git)" != alias ]; then
+      alias git=hub
+      can_unalias=true
+    fi
+
+    __git_main "$@"
+
+    if [ -n "$can_unalias" ]; then
+      unalias git
+    fi
+  }
+
   # Enable completion for hub even when not using the alias
-  complete -o bashdefault -o default -o nospace -F _git hub 2>/dev/null \
-    || complete -o default -o nospace -F _git hub
+  __git_complete hub __hub_main
 fi


### PR DESCRIPTION
Since git v2.18, git no longer uses a `__git_list_all_commands` function
to get the list of subcommands to complete. That function was being wrapped
by hub to add hub's own subcommands to the output.

As of git v2.18, git's completion function invokes `git --list-cmds...`
instead of the `__git_list_all_commands` function.
Hub v2.5.0 introduces support for the --list-cmds option, so if
git is aliased to hub, the completion includes hub's subcommands.
However, this only works when git is aliased to hub.

This change introduces a corresponding function `__hub_main` as a
correlary to git's `__git_main` completion function.

Hub's function wraps git's function, but temporarily aliases git to hub
before invoking `__git_main`.
(This way, `git --list-cmds` will actually invoke hub, and therefore include
hub's own subcommands.)

After invoking `__git_main`, it then unaliases `git`, so as to not
have a side effect of creating an alias.

Caveat: if git is already aliased to something prior to the invocation
of `__hub_main`, then the alias is not disturbed; `__git_main` is
invoked regardless so at the very least, `hub` will complete git's
builtin subcommands.