### PR TITLE
Fix alphabetical sort of `hub issue labels` output

### DIFF
--- a/features/issue.feature
+++ b/features/issue.feature
@@ -514,7 +514,12 @@ Feature: hub issue
     Given the GitHub API server:
     """
     get('/repos/github/hub/labels') {
+      response.headers["Link"] = %(<https://api.github.com/repositories/12345/labels?per_page=100&page=2>; rel="next")
+      assert :per_page => "100", :page => nil
       json [
+        { :name => "Discuss",
+          :color => "0000ff",
+        },
         { :name => "bug",
           :color => "ff0000",
         },
@@ -523,11 +528,21 @@ Feature: hub issue
         },
       ]
     }
+    get('/repositories/12345/labels') {
+      assert :per_page => "100", :page => "2"
+      json [
+        { :name => "affects",
+          :color => "ffffff",
+        },
+      ]
+    }
     """
     When I successfully run `hub issue labels`
     Then the output should contain exactly:
       """
+      affects
       bug
+      Discuss
       feature\n
       """
 

--- a/github/client.go
+++ b/github/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -723,6 +724,18 @@ func (client *Client) UpdateIssue(project *Project, issueNumber int, params map[
 	return
 }
 
+type sortedLabels []IssueLabel
+
+func (s sortedLabels) Len() int {
+	return len(s)
+}
+func (s sortedLabels) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s sortedLabels) Less(i, j int) bool {
+	return strings.Compare(strings.ToLower(s[i].Name), strings.ToLower(s[j].Name)) < 0
+}
+
 func (client *Client) FetchLabels(project *Project) (labels []IssueLabel, err error) {
 	api, err := client.simpleApi()
 	if err != nil {
@@ -747,6 +760,8 @@ func (client *Client) FetchLabels(project *Project) (labels []IssueLabel, err er
 		}
 		labels = append(labels, labelsPage...)
 	}
+
+	sort.Sort(sortedLabels(labels))
 
 	return
 }


### PR DESCRIPTION
The API result isn't guaranteed to be sorted case-insensitive, so we perform the sort in memory before displaying.

Ref. #1980