### PR TITLE
New `hub api` command for making GitHub API requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ MIN_COVERAGE = 89.4
 
 HELP_CMD = \
 	share/man/man1/hub-alias.1 \
+	share/man/man1/hub-api.1 \
 	share/man/man1/hub-browse.1 \
 	share/man/man1/hub-ci-status.1 \
 	share/man/man1/hub-compare.1 \

--- a/commands/api.go
+++ b/commands/api.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/github/hub/github"
+	"github.com/github/hub/ui"
+	"github.com/github/hub/utils"
+)
+
+var cmdApi = &Command{
+	Run:   apiCommand,
+	Usage: "api <RESOURCE>",
+	Long: `Interact with the GitHub API.
+
+## Options:
+	-X, --method <METHOD>
+	-F, --field <KEY-VALUE>
+	-t, --flat
+	--cache <TTL>
+`,
+}
+
+func init() {
+	CmdRunner.Use(cmdApi)
+}
+
+func apiCommand(cmd *Command, args *Args) {
+	path := ""
+	if !args.IsParamsEmpty() {
+		path = args.GetParam(0)
+	}
+
+	method := "GET"
+	if args.Flag.HasReceived("--method") {
+		method = args.Flag.Value("--method")
+	} else if args.Flag.HasReceived("--field") {
+		method = "POST"
+	}
+	cacheTTL := args.Flag.Int("--cache")
+
+	params := make(map[string]interface{})
+	for _, val := range args.Flag.AllValues("--field") {
+		parts := strings.SplitN(val, "=", 2)
+		if len(parts) >= 2 {
+			value := parts[1]
+			if strings.HasPrefix(value, "@") {
+				file := strings.TrimPrefix(value, "@")
+				var content []byte
+				var err error
+				if file == "-" {
+					content, err = ioutil.ReadAll(os.Stdin)
+				} else {
+					content, err = ioutil.ReadFile(file)
+				}
+				if err != nil {
+					utils.Check(err)
+				}
+				value = string(content)
+			}
+			params[parts[0]] = value
+		}
+	}
+
+	host := ""
+	owner := ""
+	repo := ""
+	localRepo, localRepoErr := github.LocalRepo()
+	if localRepoErr == nil {
+		var project *github.Project
+		if project, localRepoErr = localRepo.MainProject(); localRepoErr == nil {
+			host = project.Host
+			owner = project.Owner
+			repo = project.Name
+		}
+	}
+	if host == "" {
+		defHost, err := github.CurrentConfig().DefaultHost()
+		utils.Check(err)
+		host = defHost.Host
+	}
+	path = strings.Replace(path, "{owner}", owner, 1)
+	path = strings.Replace(path, "{repo}", repo, 1)
+
+	gh := github.NewClient(host)
+	response, err := gh.GenericAPIRequest(method, path, params, cacheTTL)
+	utils.Check(err)
+	defer response.Body.Close()
+
+	colorize := ui.IsTerminal(os.Stdout)
+	if args.Flag.Bool("--flat") {
+		utils.JSONPath(ui.Stdout, response.Body, colorize)
+	} else {
+		io.Copy(ui.Stdout, response.Body)
+		ui.Println()
+	}
+
+	args.NoForward()
+}

--- a/commands/api.go
+++ b/commands/api.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -74,8 +75,16 @@ func apiCommand(cmd *Command, args *Args) {
 		utils.Check(err)
 		host = defHost.Host
 	}
-	path = strings.Replace(path, "{owner}", owner, 1)
-	path = strings.Replace(path, "{repo}", repo, 1)
+
+	if path == "graphql" && params["query"] != nil {
+		query := params["query"].(string)
+		query = strings.Replace(query, quote("{owner}"), quote(owner), 1)
+		query = strings.Replace(query, quote("{repo}"), quote(repo), 1)
+		params["query"] = query
+	} else {
+		path = strings.Replace(path, "{owner}", owner, 1)
+		path = strings.Replace(path, "{repo}", repo, 1)
+	}
 
 	gh := github.NewClient(host)
 	response, err := gh.GenericAPIRequest(method, path, params, cacheTTL)
@@ -110,4 +119,8 @@ func valueOrFileContents(value string) string {
 	} else {
 		return value
 	}
+}
+
+func quote(s string) string {
+	return fmt.Sprintf("%q", s)
 }

--- a/commands/api.go
+++ b/commands/api.go
@@ -130,7 +130,7 @@ func apiCommand(cmd *Command, args *Args) {
 		}
 	}
 	if host == "" {
-		defHost, err := github.CurrentConfig().DefaultHost()
+		defHost, err := github.CurrentConfig().DefaultHostNoPrompt()
 		utils.Check(err)
 		host = defHost.Host
 	}

--- a/commands/api.go
+++ b/commands/api.go
@@ -15,15 +15,66 @@ import (
 
 var cmdApi = &Command{
 	Run:   apiCommand,
-	Usage: "api <RESOURCE>",
-	Long: `Interact with the GitHub API.
+	Usage: "api [-t] [-X <METHOD>] [--cache <TTL>] <ENDPOINT> [-F <KEY-VALUE>]",
+	Long: `Low-level GitHub API request interface.
 
 ## Options:
 	-X, --method <METHOD>
+		The HTTP method to use for the request (default: "GET"). The method is
+		automatically set to "POST" if '--field' or '--raw-field' are used.
+
+		Use '-XGET' to force serializing fields into the query string for the GET
+		request instead of JSON body of the POST request.
+
 	-F, --field <KEY-VALUE>
+		Send data in 'KEY=VALUE' format. If <VALUE> starts with "@", the rest of
+		the value is interpreted as a filename to read the value from. Use "@-" to
+		read from standard input.
+
+		Unless '-XGET' was used, all fields are sent serialized as JSON within the
+		request body.
+
 	-f, --raw-field <KEY-VALUE>
+		Same as '--field', except that it allows values starting with "@".
+
 	-t, --flat
+		Parse response JSON and output the data in a line-based key-value format
+		suitable for use in shell scripts.
+
 	--cache <TTL>
+		Cache successful responses to GET requests for <TTL> seconds.
+
+		When using "graphql" as <ENDPOINT>, caching will apply to responses to POST
+		requests as well. Just make sure to not use '--cache' for any GraphQL
+		mutations.
+
+	<ENDPOINT>
+		The GitHub API endpoint to send the HTTP request to (default: "/").
+		
+		To learn about available endpoints, see <https://developer.github.com/v3/>.
+		To make GraphQL queries, use "graphql" as endpoint and pass '-F query=QUERY'.
+
+		If the literal strings "{owner}" or "{repo}" appear in endpoint or in the
+		GraphQL query, fill in those placeholders with values read from the git
+		remote configuration of the current git repository.
+
+## Examples:
+
+		# fetch information about the currently authenticated user as JSON
+		$ hub api user
+
+		# list user repositories as line-based output
+		$ hub api --flat users/octocat/repos
+
+		# post a comment to issue #23 of the current repository
+		$ hub api repos/{owner}/{repo}/issues/23/comments --raw-field "body=Nice job!"
+
+		# perform a GraphQL query read from a file
+		$ hub api graphql -F query=@path/to/myquery.graphql
+
+## See also:
+
+hub(1)
 `,
 }
 

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 
 	"github.com/github/hub/github"
@@ -96,7 +97,10 @@ func transformApplyArgs(args *Args) {
 			continue
 		}
 
-		patchFile, err := ioutil.TempFile("", "hub")
+		tempDir := os.TempDir()
+		err = os.MkdirAll(tempDir, 0775)
+		utils.Check(err)
+		patchFile, err := ioutil.TempFile(tempDir, "hub")
 		utils.Check(err)
 
 		_, err = io.Copy(patchFile, patch)

--- a/features/api.feature
+++ b/features/api.feature
@@ -1,0 +1,92 @@
+Feature: hub api
+  Background:
+    Given I am "octokitten" on github.com with OAuth token "OTOKEN"
+
+  Scenario: GET resource
+    Given the GitHub API server:
+      """
+      get('/hello/world') {
+        json :name => "Ed"
+      }
+      """
+    When I successfully run `hub api hello/world`
+    Then the output should contain exactly:
+      """
+      {"name":"Ed"}\n
+      """
+
+  Scenario: GET query string
+    Given the GitHub API server:
+      """
+      get('/hello/world') {
+        json :name => params[:name]
+      }
+      """
+    When I successfully run `hub api -XGET -F name=Ed hello/world`
+    Then the output should contain exactly:
+      """
+      {"name":"Ed"}\n
+      """
+
+  Scenario: GET full URL
+    Given the GitHub API server:
+      """
+      get('/hello/world') {
+        json :name => "Faye"
+      }
+      """
+    When I successfully run `hub api https://api.github.com/hello/world`
+    Then the output should contain exactly:
+      """
+      {"name":"Faye"}\n
+      """
+
+  Scenario: POST fields
+    Given the GitHub API server:
+      """
+      post('/hello/world') {
+        json :name => params[:name],
+             :value => params[:a],
+             :params => params.size
+      }
+      """
+    When I successfully run `hub api -t -F name=Ed -F a=b=c hello/world`
+    Then the output should contain exactly:
+      """
+      .name	Ed
+      .value	b=c
+      .params	2\n
+      """
+
+  Scenario: POST from stdin
+    Given the GitHub API server:
+      """
+      post('/graphql') {
+        json :query => params[:query]
+      }
+      """
+    When I run `hub api -t -F query=@- graphql` interactively
+    And I pass in:
+      """
+      query {
+        repository
+      }
+      """
+    Then the output should contain exactly:
+      """
+      .query	query {\n  repository\n}\n\n
+      """
+
+  Scenario: Repo context
+    Given I am in "git://github.com/octocat/Hello-World.git" git repo
+    Given the GitHub API server:
+      """
+      get('/repos/octocat/Hello-World/commits') {
+        json :commits => 12
+      }
+      """
+    When I successfully run `hub api repos/{owner}/{repo}/commits`
+    Then the output should contain exactly:
+      """
+      {"commits":12}\n
+      """

--- a/features/api.feature
+++ b/features/api.feature
@@ -90,3 +90,21 @@ Feature: hub api
       """
       {"commits":12}\n
       """
+
+  Scenario: Repo context in graphql
+    Given I am in "git://github.com/octocat/Hello-World.git" git repo
+    Given the GitHub API server:
+      """
+      post('/graphql') {
+        json :query => params[:query]
+      }
+      """
+    When I run `hub api -t -F query=@- graphql` interactively
+    And I pass in:
+      """
+      repository(owner: "{owner}", name: "{repo}")
+      """
+    Then the output should contain exactly:
+      """
+      .query	repository(owner: "octocat", name: "Hello-World")\n\n
+      """

--- a/features/api.feature
+++ b/features/api.feature
@@ -16,6 +16,22 @@ Feature: hub api
       {"name":"Ed"}\n
       """
 
+  Scenario: GET Enterprise resource
+    Given I am "octokitten" on git.my.org with OAuth token "FITOKEN"
+    Given the GitHub API server:
+      """
+      get('/api/v3/hello/world', :host_name => 'git.my.org') {
+        halt 401 unless request.env['HTTP_AUTHORIZATION'] == 'token FITOKEN'
+        json :name => "Ed"
+      }
+      """
+    And $GITHUB_HOST is "git.my.org"
+    When I successfully run `hub api hello/world`
+    Then the output should contain exactly:
+      """
+      {"name":"Ed"}\n
+      """
+
   Scenario: Non-success response
     Given the GitHub API server:
       """

--- a/features/api.feature
+++ b/features/api.feature
@@ -72,13 +72,13 @@ Feature: hub api
     Given the GitHub API server:
       """
       get('/hello/world') {
-        json :name => params[:name]
+        json Hash[*params.sort.flatten]
       }
       """
-    When I successfully run `hub api -XGET -F name=Ed hello/world`
+    When I successfully run `hub api -XGET -Fname=Ed -Fnum=12 -Fbool=false -Fvoid=null hello/world`
     Then the output should contain exactly:
       """
-      {"name":"Ed"}\n
+      {"bool":"false","name":"Ed","num":"12","void":""}\n
       """
 
   Scenario: GET full URL
@@ -113,17 +113,13 @@ Feature: hub api
     Given the GitHub API server:
       """
       post('/hello/world') {
-        json :name => params[:name],
-             :value => params[:a],
-             :params => params.size
+        json Hash[*params.sort.flatten]
       }
       """
-    When I successfully run `hub api -t -f name=@hubot -F a=b=c hello/world`
+    When I successfully run `hub api -f name=@hubot -Fnum=12 -Fbool=false -Fvoid=null hello/world`
     Then the output should contain exactly:
       """
-      .name	@hubot
-      .value	b=c
-      .params	2\n
+      {"bool":false,"name":"@hubot","num":12,"void":null}\n
       """
 
   Scenario: POST from stdin
@@ -143,6 +139,19 @@ Feature: hub api
     Then the output should contain exactly:
       """
       .query	query {\n  repository\n}\n\n
+      """
+
+  Scenario: Pass extra GraphQL variables
+    Given the GitHub API server:
+      """
+      post('/graphql') {
+        json(params[:variables])
+      }
+      """
+    When I successfully run `hub api -F query='query {}' -Fname=Jet -Fsize=2 graphql`
+    Then the output should contain exactly:
+      """
+      {"name":"Jet","size":2}\n
       """
 
   Scenario: Repo context

--- a/features/api.feature
+++ b/features/api.feature
@@ -15,6 +15,58 @@ Feature: hub api
       {"name":"Ed"}\n
       """
 
+  Scenario: Non-success response
+    Given the GitHub API server:
+      """
+      get('/hello/world') {
+        status 400
+        json :name => "Ed"
+      }
+      """
+    When I run `hub api hello/world`
+    Then the exit status should be 1
+    And the stdout should contain exactly ""
+    And the stderr should contain exactly:
+      """
+      Error: HTTP 400 Bad Request
+      {"name":"Ed"}\n
+      """
+
+  Scenario: Non-success response flat output
+    Given the GitHub API server:
+      """
+      get('/hello/world') {
+        status 400
+        json :name => "Ed"
+      }
+      """
+    When I run `hub api -t hello/world`
+    Then the exit status should be 1
+    And the stdout should contain exactly ""
+    And the stderr should contain exactly:
+      """
+      Error: HTTP 400 Bad Request
+      .name	Ed\n
+      """
+
+  Scenario: Non-success response doesn't choke on non-JSON
+    Given the GitHub API server:
+      """
+      get('/hello/world') {
+        status 400
+        content_type :text
+        'Something went wrong'
+      }
+      """
+    When I run `hub api -t hello/world`
+    Then the exit status should be 1
+    And the stdout should contain exactly ""
+    And the stderr should contain exactly:
+      """
+      Error: HTTP 400 Bad Request
+      Something went wrong\n
+      """
+
   Scenario: GET query string
     Given the GitHub API server:
       """

--- a/features/api.feature
+++ b/features/api.feature
@@ -50,10 +50,10 @@ Feature: hub api
              :params => params.size
       }
       """
-    When I successfully run `hub api -t -F name=Ed -F a=b=c hello/world`
+    When I successfully run `hub api -t -f name=@hubot -F a=b=c hello/world`
     Then the output should contain exactly:
       """
-      .name	Ed
+      .name	@hubot
       .value	b=c
       .params	2\n
       """

--- a/features/git_compatibility.feature
+++ b/features/git_compatibility.feature
@@ -14,6 +14,7 @@ Feature: git-hub compatibility
       branch
       commit
       alias
+      api
       browse
       ci-status
       compare

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,6 +21,7 @@ Before do
   set_env 'GIT_PROXY_COMMAND', 'echo'
   # avoids reading from current user's "~/.gitconfig"
   set_env 'HOME', File.expand_path(File.join(current_dir, 'home'))
+  set_env 'TMPDIR', File.expand_path(File.join(current_dir, 'tmp'))
   # https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
   set_env 'XDG_CONFIG_HOME', nil
   set_env 'XDG_CONFIG_DIRS', nil

--- a/github/client.go
+++ b/github/client.go
@@ -940,7 +940,9 @@ func (client *Client) simpleApi() (c *simpleClient, err error) {
 
 	c = client.apiClient()
 	c.PrepareRequest = func(req *http.Request) {
-		req.Header.Set("Authorization", "token "+client.Host.AccessToken)
+		if strings.EqualFold(req.URL.Host, normalizeHost(client.Host.Host)) {
+			req.Header.Set("Authorization", "token "+client.Host.AccessToken)
+		}
 	}
 	return
 }

--- a/github/client.go
+++ b/github/client.go
@@ -811,6 +811,12 @@ func (client *Client) GenericAPIRequest(method, path string, params map[string]i
 				switch v := value.(type) {
 				case string:
 					query.Add(key, v)
+				case nil:
+					query.Add(key, "")
+				case int:
+					query.Add(key, fmt.Sprintf("%d", v))
+				case bool:
+					query.Add(key, fmt.Sprintf("%v", v))
 				}
 			}
 			sep := "?"

--- a/github/config.go
+++ b/github/config.go
@@ -323,6 +323,18 @@ func (c *Config) DefaultHost() (host *Host, err error) {
 	return
 }
 
+func (c *Config) DefaultHostNoPrompt() (*Host, error) {
+	if GitHubHostEnv != "" {
+		return c.PromptForHost(GitHubHostEnv)
+	} else if len(c.Hosts) > 0 {
+		host := c.Hosts[0]
+		// HACK: forces host to inherit GITHUB_TOKEN if applicable
+		return c.PromptForHost(host.Host)
+	} else {
+		return c.PromptForHost(GitHubHost)
+	}
+}
+
 // CheckWriteable checks if config file is writeable. This should
 // be called before asking for credentials and only if current
 // operation needs to update the file. See issue #1314 for details.

--- a/share/man/man1/hub.1.md
+++ b/share/man/man1/hub.1.md
@@ -57,6 +57,9 @@ hub-submodule(1)
 hub-alias(1)
 :   Show shell instructions for wrapping git.
 
+hub-api(1)
+:   Low-level GitHub API request interface.
+
 hub-browse(1)
 :   Open a GitHub repository in a web browser.
 

--- a/utils/json.go
+++ b/utils/json.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type state struct {
+	isObject    bool
+	isArray     bool
+	arrayIndex  int
+	objectKey   string
+	parentState *state
+}
+
+func stateKey(s *state) string {
+	k := ""
+	if s.parentState != nil {
+		k = stateKey(s.parentState)
+	}
+	if s.isObject {
+		return fmt.Sprintf("%s.%s", k, s.objectKey)
+	} else if s.isArray {
+		return fmt.Sprintf("%s.[%d]", k, s.arrayIndex)
+	} else {
+		return k
+	}
+}
+
+func printValue(token json.Token) {
+}
+
+func JSONPath(out io.Writer, src io.Reader, colorize bool) {
+	dec := json.NewDecoder(src)
+	dec.UseNumber()
+
+	s := &state{}
+	postEmit := func() {
+		if s.isObject {
+			s.objectKey = ""
+		} else if s.isArray {
+			s.arrayIndex++
+		}
+	}
+
+	color := func(c string, t interface{}) string {
+		if colorize {
+			return fmt.Sprintf("\033[%sm%s\033[m", c, t)
+		} else if tt, ok := t.(string); ok {
+			return tt
+		} else {
+			return fmt.Sprintf("%s", t)
+		}
+	}
+
+	for {
+		token, err := dec.Token()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			panic(err)
+		}
+		if delim, ok := token.(json.Delim); ok {
+			switch delim {
+			case '{':
+				s = &state{isObject: true, parentState: s}
+			case '[':
+				s = &state{isArray: true, parentState: s}
+			case '}', ']':
+				s = s.parentState
+				postEmit()
+			default:
+				panic("unknown delim")
+			}
+		} else {
+			if s.isObject && s.objectKey == "" {
+				s.objectKey = token.(string)
+			} else {
+				k := stateKey(s)
+				fmt.Fprintf(out, "%s\t", color("0;36", k))
+
+				switch tt := token.(type) {
+				case string:
+					fmt.Fprintf(out, "%s\n", strings.Replace(tt, "\n", "\\n", -1))
+				case json.Number:
+					fmt.Fprintf(out, "%s\n", color("0;35", tt))
+				case nil:
+					fmt.Fprintf(out, "\n")
+				case bool:
+					fmt.Fprintf(out, "%s\n", color("1;33", fmt.Sprintf("%v", tt)))
+				default:
+					panic("unknown type")
+				}
+				postEmit()
+			}
+		}
+	}
+}


### PR DESCRIPTION
```
Usage: hub api [-t] [-X <METHOD>] [--cache <TTL>] <ENDPOINT> [-F <KEY-VALUE>]
```

## Goals:

- provide a low-level interface to the GitHub API that empowers GitHub users to automate their workflows via shell scripts
- close many [outstanding feature requests](https://github.com/github/hub/issues?q=is%3Aissue+is%3Aopen+label%3Afeature) in this repository that are unlikely to be implemented in hub core in the near future, but which can be easily implemented as a simple shell script using `hub api`

## Features:

- make arbitrary HTTP requests to the GitHub API
- serialize GET data into query string
- serialize POST/PUT data as JSON
- read data to serialize from a file or standard input
- parse response JSON into line-based output
- cache sucessful responses
- replace `{owner}` and `{repo}` placeholders with values from current repository

The above abilities also make it possible to make GraphQL queries, since that simply involves encoding/decoding JSON from the `/graphql` endpoint.

## Examples:

```sh
# fetch information about the currently authenticated user as JSON
$ hub api user

# list user repositories as line-based output
$ hub api --flat users/octocat/repos

# post a comment to issue #23 of the current repository
$ hub api repos/{owner}/{repo}/issues/23/comments --raw-field "body=Nice job!"

# perform a GraphQL query read from a file
$ hub api graphql -F query=@path/to/myquery.graphql
```