### PR TITLE
Makefile: fix arguments to go, not matching what go expects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SOURCE_DATE_EPOCH ?= $(shell date +%s)
 BUILD_DATE = $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" '+%d %b %Y' 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" '+%d %b %Y')
 HUB_VERSION = $(shell bin/hub version | tail -1)
 FLAGS_ALL = $(shell go version | grep -q 'go1.[89]' || echo 'all=')
-export LDFLAGS := -extldflags='$(LDFLAGS)'
-export GCFLAGS := $(FLAGS_ALL)-trimpath='$(PWD)'
-export ASMFLAGS := $(FLAGS_ALL)-trimpath='$(PWD)'
+export LDFLAGS := -extldflags '$(LDFLAGS)'
+export GCFLAGS := $(FLAGS_ALL)-trimpath '$(PWD)'
+export ASMFLAGS := $(FLAGS_ALL)-trimpath '$(PWD)'
 
 MIN_COVERAGE = 89.4
 


### PR DESCRIPTION
This caused gcc to receive the actual argument "''" or for example "'-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now'" and then error with
gcc: error: '-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now': No such file or directory

Furthermore, the trimpath arguments tried to trim an actual path resembling "'$PWD'", which did nothing as the literal single quotes were not valid in this context.

The former issue means it is down to the go compiler to interpret -ldflags properly in order to break up the (multiple) flag values and correctly parse the extldflags, possible spaces included.

In the latter case, trimpath only accepts one argument and the shellscript already correctly double-quotes this in order to pass it as one argv[3] to the compiler:
{ "go", "build", "-gcflags", "all=-trimpath=/path/to/pwd" }

And from there the compiler should be able to interpret paths with spaces on its own.