### PR TITLE
Consistent ordering and `--format` support for `ci-status`

### DIFF
--- a/commands/ci_status.go
+++ b/commands/ci_status.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/github/hub/git"
 	"github.com/github/hub/github"
@@ -130,6 +131,10 @@ func verboseFormat(statuses []github.CIStatus) {
 		}
 	}
 
+	sort.SliceStable(statuses, func(a, b int) bool {
+		return stateRank(statuses[a].State) < stateRank(statuses[b].State)
+	})
+
 	for _, status := range statuses {
 		var color int
 		var stateMarker string
@@ -157,5 +162,16 @@ func verboseFormat(statuses []github.CIStatus) {
 		} else {
 			ui.Printf("%s\t%-*s\t%s\n", stateMarker, contextWidth, status.Context, status.TargetUrl)
 		}
+	}
+}
+
+func stateRank(state string) uint32 {
+	switch state {
+	case "failure", "error", "action_required", "cancelled", "timed_out":
+		return 1
+	case "success", "neutral":
+		return 3
+	default:
+		return 2
 	}
 }

--- a/features/ci_status.feature
+++ b/features/ci_status.feature
@@ -55,6 +55,40 @@ Feature: hub ci-status
       """
     And the exit status should be 1
 
+  Scenario: Multiple statuses with format string
+    Given there is a commit named "the_sha"
+    Given the remote commit states of "michiels/pencilbox" "the_sha" are:
+      """
+      { :state => "error",
+        :statuses => [
+          { :state => "success",
+            :context => "continuous-integration/travis-ci/push",
+            :target_url => "https://travis-ci.org/michiels/pencilbox/builds/1234567" },
+          { :state => "success",
+            :context => "continuous-integration/travis-ci/ants",
+            :target_url => "https://travis-ci.org/michiels/pencilbox/builds/1234568" },
+          { :state => "pending",
+            :context => "continuous-integration/travis-ci/merge",
+            :target_url => nil },
+          { :state => "error",
+            :context => "whatevs!" },
+          { :state => "failure",
+            :context => "GitHub CLA",
+            :target_url => "https://cla.github.com/michiels/pencilbox/accept/mislav" },
+        ]
+      }
+      """
+    When I run `hub ci-status the_sha --format '%S: %t (%U)%n'`
+    Then the output should contain exactly:
+      """
+      failure: GitHub CLA (https://cla.github.com/michiels/pencilbox/accept/mislav)
+      error: whatevs! ()
+      pending: continuous-integration/travis-ci/merge ()
+      success: continuous-integration/travis-ci/ants (https://travis-ci.org/michiels/pencilbox/builds/1234568)
+      success: continuous-integration/travis-ci/push (https://travis-ci.org/michiels/pencilbox/builds/1234567)\n
+      """
+    And the exit status should be 1
+
   Scenario: Exit status 1 for 'error' and 'failure'
     Given the remote commit state of "michiels/pencilbox" "HEAD" is "error"
     When I run `hub ci-status`

--- a/features/ci_status.feature
+++ b/features/ci_status.feature
@@ -30,24 +30,28 @@ Feature: hub ci-status
           { :state => "success",
             :context => "continuous-integration/travis-ci/push",
             :target_url => "https://travis-ci.org/michiels/pencilbox/builds/1234567" },
+          { :state => "success",
+            :context => "continuous-integration/travis-ci/ants",
+            :target_url => "https://travis-ci.org/michiels/pencilbox/builds/1234568" },
           { :state => "pending",
             :context => "continuous-integration/travis-ci/merge",
             :target_url => nil },
+          { :state => "error",
+            :context => "whatevs!" },
           { :state => "failure",
             :context => "GitHub CLA",
             :target_url => "https://cla.github.com/michiels/pencilbox/accept/mislav" },
-          { :state => "error",
-            :context => "whatevs!" }
         ]
       }
       """
     When I run `hub ci-status -v the_sha`
     Then the output should contain exactly:
       """
-      ✔︎	continuous-integration/travis-ci/push 	https://travis-ci.org/michiels/pencilbox/builds/1234567
-      ●	continuous-integration/travis-ci/merge
       ✖︎	GitHub CLA                            	https://cla.github.com/michiels/pencilbox/accept/mislav
-      ✖︎	whatevs!\n
+      ✖︎	whatevs!
+      ●	continuous-integration/travis-ci/merge
+      ✔︎	continuous-integration/travis-ci/ants 	https://travis-ci.org/michiels/pencilbox/builds/1234568
+      ✔︎	continuous-integration/travis-ci/push 	https://travis-ci.org/michiels/pencilbox/builds/1234567\n
       """
     And the exit status should be 1
 

--- a/github/client.go
+++ b/github/client.go
@@ -463,6 +463,20 @@ func (client *Client) FetchCIStatus(project *Project, sha string) (status *CISta
 		return
 	}
 
+	sortStatuses := func() {
+		sort.Slice(status.Statuses, func(a, b int) bool {
+			sA := status.Statuses[a]
+			sB := status.Statuses[b]
+			cmp := strings.Compare(strings.ToLower(sA.Context), strings.ToLower(sB.Context))
+			if cmp == 0 {
+				return strings.Compare(sA.TargetUrl, sB.TargetUrl) < 0
+			} else {
+				return cmp < 0
+			}
+		})
+	}
+	sortStatuses()
+
 	res, err = api.GetFile(fmt.Sprintf("repos/%s/%s/commits/%s/check-runs", project.Owner, project.Name, sha), checksType)
 	if err == nil && (res.StatusCode == 403 || res.StatusCode == 404 || res.StatusCode == 422) {
 		return
@@ -488,6 +502,8 @@ func (client *Client) FetchCIStatus(project *Project, sha string) (status *CISta
 		}
 		status.Statuses = append(status.Statuses, checkStatus)
 	}
+
+	sortStatuses()
 
 	return
 }


### PR DESCRIPTION
Statuses are now sorted the same as in the GitHub web interface:

- failing first;
- then pending;
- then success/neutral;
- everything in-between is sorted alphabetically.

Fixes #2021