### PR TITLE
commands/api: add support for reading array fields

### DIFF
--- a/commands/api.go
+++ b/commands/api.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/csv"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -248,12 +249,16 @@ func readFile(file string) (content []byte) {
 
 func readArray(input string) []interface{} {
 	input = strings.TrimRight(strings.TrimLeft(input, "["), "]")
-	values := []interface{}{}
-	for _, v := range strings.Split(input, ",") {
-		v = strings.TrimSpace(v)
-		if v != "" {
-			values = append(values, magicValue(v))
-		}
+	r := csv.NewReader(strings.NewReader(input))
+	r.TrimLeadingSpace = true
+	r.LazyQuotes = true
+	parts, err := r.Read()
+	if err != nil && err != io.EOF {
+		utils.Check(fmt.Errorf("invalid array value %q: %v", input, err))
+	}
+	values := make([]interface{}, len(parts))
+	for i, v := range parts {
+		values[i] = magicValue(v)
 	}
 	return values
 }

--- a/commands/api.go
+++ b/commands/api.go
@@ -246,13 +246,13 @@ func readFile(file string) (content []byte) {
 	return
 }
 
-func readArray(input string) []string {
+func readArray(input string) []interface{} {
 	input = strings.TrimRight(strings.TrimLeft(input, "["), "]")
-	values := []string{}
+	values := []interface{}{}
 	for _, v := range strings.Split(input, ",") {
 		v = strings.TrimSpace(v)
 		if v != "" {
-			values = append(values, v)
+			values = append(values, magicValue(v))
 		}
 	}
 	return values

--- a/commands/api.go
+++ b/commands/api.go
@@ -248,7 +248,7 @@ func readFile(file string) (content []byte) {
 
 func readArray(input string) []string {
 	input = strings.TrimRight(strings.TrimLeft(input, "["), "]")
-	var values []string
+	values := []string{}
 	for _, v := range strings.Split(input, ",") {
 		v = strings.TrimSpace(v)
 		if v != "" {

--- a/commands/api.go
+++ b/commands/api.go
@@ -66,7 +66,7 @@ var cmdApi = &Command{
 
 	<ENDPOINT>
 		The GitHub API endpoint to send the HTTP request to (default: "/").
-		
+
 		To learn about available endpoints, see <https://developer.github.com/v3/>.
 		To make GraphQL queries, use "graphql" as <ENDPOINT> and pass '-F query=QUERY'.
 
@@ -227,6 +227,8 @@ func magicValue(value string) interface{} {
 			return string(readFile(value[1:]))
 		} else if i, err := strconv.Atoi(value); err == nil {
 			return i
+		} else if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+			return readArray(value)
 		} else {
 			return value
 		}
@@ -242,6 +244,18 @@ func readFile(file string) (content []byte) {
 	}
 	utils.Check(err)
 	return
+}
+
+func readArray(input string) []string {
+	input = strings.TrimRight(strings.TrimLeft(input, "["), "]")
+	var values []string
+	for _, v := range strings.Split(input, ",") {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			values = append(values, v)
+		}
+	}
+	return values
 }
 
 func quote(s string) string {

--- a/commands/api_test.go
+++ b/commands/api_test.go
@@ -38,11 +38,15 @@ func TestMagicValue(t *testing.T) {
 		},
 		{
 			"[v1, v2]",
-			[]string{"v1", "v2"},
+			[]interface{}{"v1", "v2"},
+		},
+		{
+			"[1, true, false, v5]",
+			[]interface{}{1, true, false, "v5"},
 		},
 		{
 			"[]",
-			[]string{},
+			[]interface{}{},
 		},
 	}
 

--- a/commands/api_test.go
+++ b/commands/api_test.go
@@ -42,7 +42,7 @@ func TestMagicValue(t *testing.T) {
 		},
 		{
 			"[]",
-			[]string(nil),
+			[]string{},
 		},
 	}
 

--- a/commands/api_test.go
+++ b/commands/api_test.go
@@ -48,6 +48,18 @@ func TestMagicValue(t *testing.T) {
 			"[]",
 			[]interface{}{},
 		},
+		{
+			`[v1, v2, "v3,v4"]`,
+			[]interface{}{"v1", "v2", "v3,v4"},
+		},
+		{
+			`[v1, v2, v3"]`,
+			[]interface{}{"v1", "v2", `v3"`},
+		},
+		{
+			`[v1,    , v3"]`,
+			[]interface{}{"v1", "", `v3"`},
+		},
 	}
 
 	for _, test := range tests {
@@ -55,6 +67,7 @@ func TestMagicValue(t *testing.T) {
 		t.Run(test.input, func(t *testing.T) {
 			t.Parallel()
 			value := magicValue(test.input)
+			t.Log(value)
 			assert.Equal(t, test.expected, value)
 		})
 	}

--- a/commands/api_test.go
+++ b/commands/api_test.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestMagicValue(t *testing.T) {
+	t.Parallel()
+	var tests = []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			"true",
+			true,
+		},
+		{
+			"false",
+			false,
+		},
+		{
+			"null",
+			nil,
+		},
+		{
+			"50",
+			50,
+		},
+		{
+			"@testdata/some-file.txt",
+			"this\nis\na\ntest\nfile\n",
+		},
+		{
+			"whatever",
+			"whatever",
+		},
+		{
+			"[v1, v2]",
+			[]string{"v1", "v2"},
+		},
+		{
+			"[]",
+			[]string(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
+			value := magicValue(test.input)
+			assert.Equal(t, test.expected, value)
+		})
+	}
+}

--- a/commands/testdata/some-file.txt
+++ b/commands/testdata/some-file.txt
@@ -1,0 +1,5 @@
+this
+is
+a
+test
+file


### PR DESCRIPTION
Not sure if the syntax is the best? I just hit this as part of some integration work with deployments and thought that maybe this could be an acceptable solution for taking arrays of strings (for ``required_contexts``).

Later I saw #2028, so maybe we need something that will work for more cases than just a slice of strings (or we could make it ``[]interface{}`` and call ``magicValue`` for each item in the array, don't know). 