### PR TITLE
remote name can be specified in the create command

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -128,7 +128,13 @@ func create(command *Command, args *Args) {
 	localRepo, err := github.LocalRepo()
 	utils.Check(err)
 
-	originName := "origin"
+        var originName string
+        if flagOriginRemoteName := args.Flag.Value("--remote-name"); flagOriginRemoteName != "" {
+                originName = flagOriginRemoteName
+        } else {
+                originName = "origin"
+        }
+
 	if originRemote, err := localRepo.RemoteByName(originName); err == nil {
 		originProject, err := originRemote.Project()
 		if err != nil || !originProject.SameAs(project) {

--- a/features/create.feature
+++ b/features/create.feature
@@ -27,6 +27,17 @@ Feature: hub create
       """
     When I successfully run `hub create -p`
     Then the url for "origin" should be "git@github.com:mislav/dotfiles.git"
+  Scenario: Create repo with new remote name specified
+    Given the GitHub API server:
+    """
+    post('/user/repos') {
+      assert :private => false
+      status 201
+      json :full_name => 'mislav/dotfiles'
+    }
+    """
+    When I sucessfully run `hub create --remote-name=work`
+    Then the url for "work" should be "git@github.com:mislav/dotfiles.git"
 
   Scenario: HTTPS is preferred
     Given the GitHub API server:


### PR DESCRIPTION
Hi @mislav, I've never written any go before, but I gave it a shot! Could you see if this works for [github#2025](https://github.com/github/hub/issues/2025)?