### PR TITLE
List PR "Draft" state using the `--format` string

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -385,7 +385,30 @@ func formatIssuePlaceholders(issue github.Issue, colorize bool) map[string]strin
 	}
 }
 
-func formatPullRequestPlaceholders(pr github.PullRequest) map[string]string {
+func formatPullRequestPlaceholders(pr github.PullRequest, colorize bool) map[string]string {
+	prState := pr.State
+	if prState == "open" && pr.Draft {
+		prState = "draft"
+	} else if !pr.MergedAt.IsZero() {
+		prState = "merged"
+	}
+
+	var stateColorSwitch string
+	var prColor int
+	if colorize {
+		switch prState {
+		case "draft":
+			prColor = 37
+		case "merged":
+			prColor = 35
+		case "closed":
+			prColor = 31
+		default:
+			prColor = 32
+		}
+		stateColorSwitch = fmt.Sprintf("\033[%dm", prColor)
+	}
+
 	base := pr.Base.Ref
 	head := pr.Head.Label
 	if pr.IsSameRepo() {
@@ -410,6 +433,8 @@ func formatPullRequestPlaceholders(pr github.PullRequest) map[string]string {
 	}
 
 	return map[string]string{
+		"pS": prState,
+		"pC": stateColorSwitch,
 		"B":  base,
 		"H":  head,
 		"sB": pr.Base.Sha,

--- a/commands/pr.go
+++ b/commands/pr.go
@@ -42,7 +42,7 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 
 	-f, --format <FORMAT>
 		Pretty print the list of pull requests using format <FORMAT> (default:
-		"%sC%>(8)%i%Creset  %t%  l%n"). See the "PRETTY FORMATS" section of
+		"%pC%>(8)%i%Creset  %t%  l%n"). See the "PRETTY FORMATS" section of
 		git-log(1) for some additional details on how placeholders are used in
 		format. The available placeholders are:
 
@@ -54,7 +54,11 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 
 		%S: state ("open" or "closed")
 
-		%sC: set color to red or green, depending on pull request state.
+		%pS: pull request state ("open", "draft", "merged", or "closed")
+
+		%sC: set color to red or green, depending on state
+
+		%pC: set color according to pull request state
 
 		%t: title
 
@@ -206,7 +210,7 @@ func listPulls(cmd *Command, args *Args) {
 	flagPullRequestLimit := args.Flag.Int("--limit")
 	flagPullRequestFormat := args.Flag.Value("--format")
 	if !args.Flag.HasReceived("--format") {
-		flagPullRequestFormat = "%sC%>(8)%i%Creset  %t%  l%n"
+		flagPullRequestFormat = "%pC%>(8)%i%Creset  %t%  l%n"
 	}
 
 	pulls, err := gh.FetchPullRequests(project, filters, flagPullRequestLimit, func(pr *github.PullRequest) bool {
@@ -253,7 +257,7 @@ func checkoutPr(command *Command, args *Args) {
 
 func formatPullRequest(pr github.PullRequest, format string, colorize bool) string {
 	placeholders := formatIssuePlaceholders(github.Issue(pr), colorize)
-	for key, value := range formatPullRequestPlaceholders(pr) {
+	for key, value := range formatPullRequestPlaceholders(pr, colorize) {
 		placeholders[key] = value
 	}
 	return ui.Expand(format, placeholders, colorize)

--- a/features/pr-list.feature
+++ b/features/pr-list.feature
@@ -112,6 +112,57 @@ Feature: hub pr list
           #102 luke, jyn\n
       """
 
+  Scenario: List draft status
+    Given the GitHub API server:
+    """
+    get('/repos/github/hub/pulls') {
+      halt 400 unless env['HTTP_ACCEPT'] == 'application/vnd.github.shadow-cat-preview+json;charset=utf-8'
+
+      json [
+        { :number => 999,
+          :state => "open",
+          :draft => true,
+          :merged_at => nil,
+          :base => { :ref => "master", :label => "github:master" },
+          :head => { :ref => "patch-2", :label => "octocat:patch-2" },
+          :user => { :login => "octocat" },
+        },
+        { :number => 102,
+          :state => "open",
+          :draft => false,
+          :merged_at => nil,
+          :base => { :ref => "master", :label => "github:master" },
+          :head => { :ref => "patch-1", :label => "octocat:patch-1" },
+          :user => { :login => "octocat" },
+        },
+        { :number => 42,
+          :state => "closed",
+          :draft => false,
+          :merged_at => "2018-12-11T10:50:33Z",
+          :base => { :ref => "master", :label => "github:master" },
+          :head => { :ref => "patch-3", :label => "octocat:patch-3" },
+          :user => { :login => "octocat" },
+        },
+        { :number => 8,
+          :state => "closed",
+          :draft => false,
+          :merged_at => nil,
+          :base => { :ref => "master", :label => "github:master" },
+          :head => { :ref => "patch-4", :label => "octocat:patch-4" },
+          :user => { :login => "octocat" },
+        },
+      ]
+    }
+    """
+    When I successfully run `hub pr list --format "%I %pC %pS %Creset%n" --color`
+    Then the output should contain exactly:
+      """
+      999 \e[37m draft \e[m
+      102 \e[32m open \e[m
+      42 \e[35m merged \e[m
+      8 \e[31m closed \e[m\n
+      """
+
   Scenario: Sort by number of comments ascending
     Given the GitHub API server:
     """

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -58,6 +58,8 @@ Before do
 
   # increase process exit timeout from the default of 3 seconds
   @aruba_timeout_seconds = 10
+  # don't be "helpful"
+  @aruba_keep_ansi = true
 end
 
 After do

--- a/github/client.go
+++ b/github/client.go
@@ -58,7 +58,7 @@ func (client *Client) FetchPullRequests(project *Project, filterParams map[strin
 	var res *simpleResponse
 
 	for path != "" {
-		res, err = api.Get(path)
+		res, err = api.GetFile(path, draftsType)
 		if err = checkStatus(200, "fetching pull requests", res, err); err != nil {
 			return
 		}
@@ -563,6 +563,7 @@ type Issue struct {
 
 	MergeCommitSha      string `json:"merge_commit_sha"`
 	MaintainerCanModify bool   `json:"maintainer_can_modify"`
+	Draft               bool   `json:"draft"`
 
 	Comments  int          `json:"comments"`
 	Labels    []IssueLabel `json:"labels"`

--- a/github/http.go
+++ b/github/http.go
@@ -28,6 +28,7 @@ const apiPayloadVersion = "application/vnd.github.v3+json;charset=utf-8"
 const patchMediaType = "application/vnd.github.v3.patch;charset=utf-8"
 const textMediaType = "text/plain;charset=utf-8"
 const checksType = "application/vnd.github.antiope-preview+json;charset=utf-8"
+const draftsType = "application/vnd.github.shadow-cat-preview+json;charset=utf-8"
 
 var inspectHeaders = []string{
 	"Authorization",


### PR DESCRIPTION
Using `%pS` outputs "draft" if the PR is in Draft state.

This still doesn't allow *creating* Draft PRs since the GitHub API doesn't expose this functionality yet.

Ref. #2038