### PR TITLE
Make man pages parseable with `whatis`

### DIFF
--- a/man-template.html
+++ b/man-template.html
@@ -7,7 +7,7 @@ body {
   margin: 0;
   font: 15px/1.4 -apple-system,Segoe UI,Helvetica,Arial,sans-serif;
 }
-pre, code, var, dt, .man-head {
+pre, code, var, dt, .man-head, [id="synopsis"] + p {
   font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;
 }
 header, footer {
@@ -56,9 +56,13 @@ dt {
 dd {
   margin-bottom: 1em;
 }
-pre {
+pre, [id="synopsis"] + p {
   background: #eee;
   padding: 1em 1.5em;
+}
+[id="synopsis"] + p {
+  white-space: nowrap;
+  overflow-x: auto;
 }
 pre code {
   color: inherit;

--- a/md2roff-bin/cmd.go
+++ b/md2roff-bin/cmd.go
@@ -65,6 +65,7 @@ func generateFromFile(mdFile string) error {
 		Flags: blackfriday.HTMLFlagsNone,
 	})
 	roff := &md2roff.RoffRenderer{
+		Manual:  flagManual,
 		Version: flagVersion,
 		Date:    flagDate,
 	}

--- a/md2roff/renderer.go
+++ b/md2roff/renderer.go
@@ -37,6 +37,7 @@ func escape(src []byte, re *regexp.Regexp) []byte {
 }
 
 type RoffRenderer struct {
+	Manual  string
 	Version string
 	Date    string
 	Title   string
@@ -171,10 +172,15 @@ func (r *RoffRenderer) renderHeading(buf io.Writer, node *blackfriday.Node) {
 			num,
 			escape([]byte(r.Date), headingEscape),
 			escape([]byte(r.Version), headingEscape),
-			escape(text, headingEscape),
+			escape([]byte(r.Manual), headingEscape),
 		)
 		io.WriteString(buf, ".nh\n")   // disable hyphenation
 		io.WriteString(buf, ".ad l\n") // disable justification
+		io.WriteString(buf, ".SH \"NAME\"\n")
+		fmt.Fprintf(buf, "%s \\- %s\n",
+			escape(name, roffEscape),
+			escape(text, roffEscape),
+		)
 	case 2:
 		fmt.Fprintf(buf, ".SH \"%s\"\n", strings.ToUpper(string(escape(text, headingEscape))))
 	case 3:


### PR DESCRIPTION
Outputs the "NAME" section in roff format to fix the following:

    mandb: warning: ... whatis parse for hub-alias(1) failed

Fixes #2044