### PR TITLE
Documentation of install on Debian (sid/buster)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ hub version 2.2.9
 
 #### Arch Linux
 
-On Arch Linux you can install `hub` from official repository:
+On Arch Linux you can install `hub` from the official repository:
 
 ```sh
 $ sudo pacman -S hub
@@ -79,10 +79,10 @@ On FreeBSD you can install a prebuilt `hub` package with
 
 #### Debian
 
-On Debian (versions sid and buster) you can install `hub` from official repository:
+On Debian (versions sid and buster) you can install `hub` from the official repository:
 
 ```sh
-# apt install hub
+$ sudo apt install hub
 ```
 
 #### Standalone

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ On FreeBSD you can install a prebuilt `hub` package with
 # pkg install hub
 ```
 
+#### Debian
+
+On Debian (versions sid and buster) you can install `hub` from official repository:
+
+```sh
+# apt install hub
+```
+
 #### Standalone
 
 `hub` can be easily installed as an executable. Download the latest


### PR DESCRIPTION
Fixes #718 by documenting that the package is in the official repository now, or perhaps there is also a need for a package for the current stable Debian version.