### PR TITLE
Make `checkout` work independently of remote refspec

### DIFF
--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -101,7 +101,9 @@ func transformCheckoutArgs(args *Args, pullRequest *github.PullRequest, newBranc
 			newArgs = append(newArgs, newBranchName)
 			args.After("git", "merge", "--ff-only", fmt.Sprintf("refs/remotes/%s", remoteBranch))
 		} else {
-			newArgs = append(newArgs, "-b", newBranchName, "--track", remoteBranch)
+			newArgs = append(newArgs, "-b", newBranchName, "--no-track", remoteBranch)
+			args.After("git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), headRemote.Name)
+			args.After("git", "config", fmt.Sprintf("branch.%s.merge", newBranchName), "refs/heads/"+pullRequest.Head.Ref)
 		}
 		args.Before("git", "fetch", headRemote.Name, refSpec)
 	} else {
@@ -128,8 +130,8 @@ func transformCheckoutArgs(args *Args, pullRequest *github.PullRequest, newBranc
 			remote = project.GitURL("", "", true)
 			mergeRef = fmt.Sprintf("refs/heads/%s", pullRequest.Head.Ref)
 		}
-		args.Before("git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), remote)
-		args.Before("git", "config", fmt.Sprintf("branch.%s.merge", newBranchName), mergeRef)
+		args.After("git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), remote)
+		args.After("git", "config", fmt.Sprintf("branch.%s.merge", newBranchName), mergeRef)
 	}
 	return
 }

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -28,7 +28,7 @@ Feature: hub checkout <PULLREQ-URL>
         }, :maintainer_can_modify => false
       }
       """
-    When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
+    When I successfully run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
     Then "git fetch origin refs/pull/77/head:fixes" should be run
     And "git checkout -f fixes -q" should be run
     And "fixes" should merge "refs/pull/77/head" from remote "origin"
@@ -54,7 +54,7 @@ Feature: hub checkout <PULLREQ-URL>
         }, :maintainer_can_modify => false
       }
       """
-    When I run `hub checkout https://github.com/mojombo/jekyll/pull/77`
+    When I successfully run `hub checkout https://github.com/mojombo/jekyll/pull/77`
     Then "git fetch origin refs/pull/77/head:mislav-master" should be run
     And "git checkout mislav-master" should be run
     And "mislav-master" should merge "refs/pull/77/head" from remote "origin"
@@ -98,7 +98,7 @@ Feature: hub checkout <PULLREQ-URL>
         }, :maintainer_can_modify => false
       }
       """
-    When I run `hub checkout https://github.com/mojombo/jekyll/pull/77 fixes-from-mislav`
+    When I successfully run `hub checkout https://github.com/mojombo/jekyll/pull/77 fixes-from-mislav`
     Then "git fetch origin refs/pull/77/head:fixes-from-mislav" should be run
     And "git checkout fixes-from-mislav" should be run
     And "fixes-from-mislav" should merge "refs/pull/77/head" from remote "origin"
@@ -122,9 +122,10 @@ Feature: hub checkout <PULLREQ-URL>
         }
       }
       """
-    When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
+    When I successfully run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
     Then "git fetch origin +refs/heads/fixes:refs/remotes/origin/fixes" should be run
-    And "git checkout -f -b fixes --track origin/fixes -q" should be run
+    And "git checkout -f -b fixes --no-track origin/fixes -q" should be run
+    And "fixes" should merge "refs/heads/fixes" from remote "origin"
 
   Scenario: Same-repo with custom branch name
     Given the GitHub API server:
@@ -145,9 +146,10 @@ Feature: hub checkout <PULLREQ-URL>
         }
       }
       """
-    When I run `hub checkout https://github.com/mojombo/jekyll/pull/77 mycustombranch`
+    When I successfully run `hub checkout https://github.com/mojombo/jekyll/pull/77 mycustombranch`
     Then "git fetch origin +refs/heads/fixes:refs/remotes/origin/fixes" should be run
-    And "git checkout -b mycustombranch --track origin/fixes" should be run
+    And "git checkout -b mycustombranch --no-track origin/fixes" should be run
+    And "mycustombranch" should merge "refs/heads/fixes" from remote "origin"
 
   Scenario: Unavailable fork
     Given the GitHub API server:
@@ -165,7 +167,7 @@ Feature: hub checkout <PULLREQ-URL>
         }
       }
       """
-    When I run `hub checkout https://github.com/mojombo/jekyll/pull/77`
+    When I successfully run `hub checkout https://github.com/mojombo/jekyll/pull/77`
     Then "git fetch origin refs/pull/77/head:fixes" should be run
     And "git checkout fixes" should be run
     And "fixes" should merge "refs/pull/77/head" from remote "origin"
@@ -191,9 +193,10 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     And the "mislav" remote has url "git://github.com/mislav/jekyll.git"
-    When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
+    When I successfully run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
     Then "git fetch mislav +refs/heads/fixes:refs/remotes/mislav/fixes" should be run
-    And "git checkout -f -b fixes --track mislav/fixes -q" should be run
+    And "git checkout -f -b fixes --no-track mislav/fixes -q" should be run
+    And "fixes" should merge "refs/heads/fixes" from remote "mislav"
 
   Scenario: Reuse existing remote and branch
     Given the GitHub API server:
@@ -217,7 +220,7 @@ Feature: hub checkout <PULLREQ-URL>
       """
     And the "mislav" remote has url "git://github.com/mislav/jekyll.git"
     And I am on the "fixes" branch
-    When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
+    When I successfully run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
     Then "git fetch mislav +refs/heads/fixes:refs/remotes/mislav/fixes" should be run
     And "git checkout -f fixes -q" should be run
     And "git merge --ff-only refs/remotes/mislav/fixes" should be run
@@ -243,7 +246,7 @@ Feature: hub checkout <PULLREQ-URL>
         }, :maintainer_can_modify => true
       }
       """
-    When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
+    When I successfully run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
     Then "git fetch origin refs/pull/77/head:fixes" should be run
     And "git checkout -f fixes -q" should be run
     And "fixes" should merge "refs/heads/fixes" from remote "git@github.com:mislav/jekyll.git"
@@ -270,7 +273,7 @@ Feature: hub checkout <PULLREQ-URL>
       }
       """
     And HTTPS is preferred
-    When I run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
+    When I successfully run `hub checkout -f https://github.com/mojombo/jekyll/pull/77 -q`
     Then "git fetch origin refs/pull/77/head:fixes" should be run
     And "git checkout -f fixes -q" should be run
     And "fixes" should merge "refs/heads/fixes" from remote "https://github.com/mislav/jekyll.git"

--- a/features/pr-checkout.feature
+++ b/features/pr-checkout.feature
@@ -25,7 +25,7 @@ Feature: hub pr checkout <PULLREQ-NUMBER>
         :html_url => 'https://github.com/mojombo/jekyll/pull/77'
       }
       """
-    When I run `hub pr checkout 77`
+    When I successfully run `hub pr checkout 77`
     Then "git fetch origin refs/pull/77/head:fixes" should be run
     And "git checkout fixes" should be run
     And "fixes" should merge "refs/pull/77/head" from remote "origin"
@@ -51,7 +51,7 @@ Feature: hub pr checkout <PULLREQ-NUMBER>
         :html_url => 'https://github.com/mojombo/jekyll/pull/77'
       }
       """
-    When I run `hub pr checkout 77 fixes-from-mislav`
+    When I successfully run `hub pr checkout 77 fixes-from-mislav`
     Then "git fetch origin refs/pull/77/head:fixes-from-mislav" should be run
     And "git checkout fixes-from-mislav" should be run
     And "fixes-from-mislav" should merge "refs/pull/77/head" from remote "origin"
@@ -76,6 +76,7 @@ Feature: hub pr checkout <PULLREQ-NUMBER>
         :html_url => 'https://github.com/mojombo/jekyll/pull/77'
       }
       """
-    When I run `hub pr checkout 77`
+    When I successfully run `hub pr checkout 77`
     Then "git fetch origin +refs/heads/fixes:refs/remotes/origin/fixes" should be run
-    And "git checkout -b fixes --track origin/fixes" should be run
+    And "git checkout -b fixes --no-track origin/fixes" should be run
+    And "fixes" should merge "refs/heads/fixes" from remote "origin"

--- a/features/support/fakebin/git
+++ b/features/support/fakebin/git
@@ -2,6 +2,7 @@
 # A wrapper for system git that prevents commands such as `clone` or `fetch` to be
 # executed in testing. It logs commands to "~/.history" so afterwards it can be
 # asserted that they ran.
+set -e
 
 command="$1"
 [ "$command" = "config" ] || echo git "$@" >> "$HOME"/.history
@@ -12,7 +13,25 @@ case "$command" in
     echo branch
     echo commit
     ;;
-  "clone" | "fetch" | "pull" | "push" )
+  "fetch" )
+    refspec="$3"
+    dest="${refspec#*:}"
+    head="$(git rev-parse --verify -q HEAD || true)"
+    if [ -z "$head" ]; then
+      git commit --allow-empty -m "auto-commit"
+      head="$(git rev-parse --verify -q HEAD)"
+    fi
+    if [[ $dest == refs/remotes/* ]]; then
+      mkdir -p ".git/${dest%/*}"
+      cat >".git/${dest}" <<<"$head"
+      cat >".git/FETCH_HEAD" <<<"$head"
+    else
+      "$HUB_SYSTEM_GIT" checkout -b "${dest#refs/heads/}" HEAD
+      cat >".git/FETCH_HEAD" <<<"$head"
+    fi
+    exit
+    ;;
+  "clone" | "pull" | "push" )
     # don't actually execute these commands
     exit
     ;;

--- a/features/support/fakebin/git
+++ b/features/support/fakebin/git
@@ -14,6 +14,7 @@ case "$command" in
     echo commit
     ;;
   "fetch" )
+    [[ $2 != -* && $3 == *:* && $3 != -* ]] || exit 0
     refspec="$3"
     dest="${refspec#*:}"
     head="$(git rev-parse --verify -q HEAD || true)"
@@ -29,11 +30,11 @@ case "$command" in
       "$HUB_SYSTEM_GIT" checkout -b "${dest#refs/heads/}" HEAD
       cat >".git/FETCH_HEAD" <<<"$head"
     fi
-    exit
+    exit 0
     ;;
   "clone" | "pull" | "push" )
     # don't actually execute these commands
-    exit
+    exit 0
     ;;
   * )
     # note: `submodule add` also initiates a clone, but we work around it


### PR DESCRIPTION
This fixes:

    fatal: Cannot setup tracking information; starting point 'BRANCH' is not a branch.

if the remote refspec is set up to only fetch specific branches and NOT like the default `+refs/heads/*:refs/remotes/origin/*`.

I don't understand why would git, after fetching into `refs/remotes/origin/BRANCH`, complain that `origin/BRANCH` is not a branch, but there we have it. Setting up upstream tracking manually works around this problem.

Fixes #1708