### PR TITLE
check head branch exists before creating PR

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -170,6 +170,8 @@ func pullRequest(cmd *Command, args *Args) {
 		}
 	}
 
+	force := args.Flag.Bool("--force")
+
 	if head == "" {
 		if trackedBranch == nil {
 			utils.Check(currentBranchErr)
@@ -182,12 +184,22 @@ func pullRequest(cmd *Command, args *Args) {
 	if headRepo, err := client.Repository(headProject); err == nil {
 		headProject.Owner = headRepo.Owner.Login
 		headProject.Name = headRepo.Name
+
+		remoteBranchName := currentBranch.RemoteName()
+		if remoteBranchName == "" {
+			remoteBranchName = "origin"
+		}
+
+		if !force && !git.Quiet("rev-parse", "--verify", "@{u}") && !git.HasFile("refs", "remotes", remoteBranchName, head) {
+			err = fmt.Errorf("Aborted: Branch not yet pushed")
+			err = fmt.Errorf("%s\nMake sure that %s:%s exists before creating a pull request", err, headRepo.Owner.Login, head)
+			utils.Check(err)
+		}
 	}
 
 	fullBase := fmt.Sprintf("%s:%s", baseProject.Owner, base)
 	fullHead := fmt.Sprintf("%s:%s", headProject.Owner, head)
 
-	force := args.Flag.Bool("--force")
 	if !force && trackedBranch != nil {
 		remoteCommits, err := git.RefList(trackedBranch.LongName(), "")
 		if err == nil && len(remoteCommits) > 0 {

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -660,6 +660,24 @@ Feature: hub pull-request
     And I successfully run `hub pull-request -f -m message`
     Then the output should contain exactly "the://url\n"
 
+  Scenario: Error when trying to create a pull request from an unpushed branch
+    Given I am on the "feature" branch
+    Given the GitHub API server:
+      """
+      get('/repos/mislav/coral') {
+        status 200
+        json :name => 'coral', :owner => { :login => 'mislav' }
+      }
+      """
+    When I make 1 commit
+    And I run `hub pull-request`
+    Then the stderr should contain exactly:
+      """
+      Aborted: Branch not yet pushed
+      Make sure that mislav:feature exists before creating a pull request\n
+      """
+    And the exit status should be 1
+
   Scenario: Pull request fails on the server
     Given I am on the "feature" branch with upstream "origin/feature"
     Given the GitHub API server:

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -120,10 +120,8 @@ Given(/^I am on the "([^"]+)" branch(?: (pushed to|with upstream) "([^"]+)")?$/)
   empty_commit
 
   if upstream
-    unless upstream == 'refs/heads/master'
-      full_upstream = upstream.start_with?('refs/') ? upstream : "refs/remotes/#{upstream}"
-      run_silent %(git update-ref #{shell_escape full_upstream} HEAD)
-    end
+    full_upstream = upstream.start_with?('refs/') ? upstream : "refs/remotes/#{upstream}"
+    run_silent %(git update-ref #{shell_escape full_upstream} HEAD)
 
     if type == 'with upstream'
       run_silent %(git branch --set-upstream-to #{shell_escape upstream})


### PR DESCRIPTION
Previously hub checked that there were [no unpushed commits](https://github.com/github/hub/blob/b3b3ebb8e517acd269489b9bd163de2f8fd309fc/commands/pull_request.go#L219-L223) but this check doesn't work when there is not even a remote branch.

**Before**
<img width="431" alt="screenshot 2019-03-02 at 22 58 28" src="https://user-images.githubusercontent.com/570608/53688632-b8d8e680-3d3e-11e9-86d5-48c654994a31.png">

**After**
<img width="503" alt="screenshot 2019-03-02 at 23 00 22" src="https://user-images.githubusercontent.com/570608/53688643-fb9abe80-3d3e-11e9-8b42-1e84ffe523b0.png">


This fixes #1930.