### PR TITLE
Fix compatibility with git when run with no arguments

### DIFF
--- a/commands/runner.go
+++ b/commands/runner.go
@@ -65,7 +65,10 @@ func (r *Runner) Execute(cliArgs []string) error {
 		return err
 	}
 
-	gitArgs := []string{args.Command}
+	gitArgs := []string{}
+	if args.Command != "" {
+		gitArgs = append(gitArgs, args.Command)
+	}
 	gitArgs = append(gitArgs, args.Params...)
 
 	return git.Run(gitArgs...)

--- a/features/git_compatibility.feature
+++ b/features/git_compatibility.feature
@@ -31,3 +31,8 @@ Feature: git-hub compatibility
   Scenario: Doesn't sabotage --exec-path
     When I successfully run `hub --exec-path`
     Then the output should not contain "These GitHub commands"
+
+  Scenario: Shows help with --git-dir
+    When I run `hub --git-dir=.git`
+    Then the exit status should be 1
+    And the output should contain "usage: git "


### PR DESCRIPTION
Fixes this error:

    $ hub --git-dir=.git
    git: '' is not a git command. See 'git --help'.

Instead, help text is shown just like with normal git.

Fixes #2095