### PR TITLE
Propagate global git arguments to Before/After chains

### DIFF
--- a/commands/args.go
+++ b/commands/args.go
@@ -59,13 +59,28 @@ func (a *Args) Replace(executable, command string, params ...string) {
 }
 
 func (a *Args) Commands() []*cmd.Cmd {
-	result := a.beforeChain
+	result := []*cmd.Cmd{}
+	appendFromChain := func(c *cmd.Cmd) {
+		if c.Name == "git" {
+			ga := []string{c.Name}
+			ga = append(ga, a.GlobalFlags...)
+			ga = append(ga, c.Args...)
+			result = append(result, cmd.NewWithArray(ga))
+		} else {
+			result = append(result, c)
+		}
+	}
 
+	for _, c := range a.beforeChain {
+		appendFromChain(c)
+	}
 	if !a.noForward {
 		result = append(result, a.ToCmd())
 	}
+	for _, c := range a.afterChain {
+		appendFromChain(c)
+	}
 
-	result = append(result, a.afterChain...)
 	return result
 }
 

--- a/commands/args_test.go
+++ b/commands/args_test.go
@@ -119,3 +119,16 @@ func TestArgs_GlobalFlags_Replaced(t *testing.T) {
 	assert.Equal(t, "open", cmd.Name)
 	assert.Equal(t, []string{"-a", "http://example.com"}, cmd.Args)
 }
+
+func TestArgs_GlobalFlags_BeforeAfterChain(t *testing.T) {
+	args := NewArgs([]string{"-c", "key=value", "-C", "dir", "status"})
+	args.Before("git", "remote", "add")
+	args.After("git", "clean")
+	args.After("echo", "done!")
+	cmds := args.Commands()
+	assert.Equal(t, 4, len(cmds))
+	assert.Equal(t, "git -c key=value -C dir remote add", cmds[0].String())
+	assert.Equal(t, "git -c key=value -C dir status", cmds[1].String())
+	assert.Equal(t, "git -c key=value -C dir clean", cmds[2].String())
+	assert.Equal(t, "echo done!", cmds[3].String())
+}


### PR DESCRIPTION
This fixes `hub -C mydir merge <URL>` and other commands that might be invoked with git global arguments by ensuring that those global arguments are also fowarded to any accompanying `git` commands found in `Before()` and `After()` chains.

This affects `create`, `fetch`, `fork`, `checkout`, `cherry-pick`, and `merge` hub commands.

Fixes https://github.com/github/hub/issues/2058