### PR TITLE
Support asset arguments after tag argument in release create command

### DIFF
--- a/commands/release.go
+++ b/commands/release.go
@@ -19,7 +19,7 @@ var (
 		Usage: `
 release [--include-drafts] [--exclude-prereleases] [-L <LIMIT>] [-f <FORMAT>]
 release show [-f <FORMAT>] <TAG>
-release create [-dpoc] [-a <FILE>] [-m <MESSAGE>|-F <FILE>] [-t <TARGET>] <TAG>
+release create [-dpoc] [-a <FILE>] [-m <MESSAGE>|-F <FILE>] [-t <TARGET>] <TAG> [<FILE>...]
 release edit [<options>] <TAG>
 release download <TAG> [-i <PATTERN>]
 release delete <TAG>
@@ -75,6 +75,9 @@ With no arguments, shows a list of existing releases.
 
 		If <FILE> is in the "<filename>#<text>" format, the text after the "#"
 		character is taken as asset label.
+
+		Note multiple files can be specified with multiple <FILE> options,
+		or multiple <FILE> arguments after the <TAG> argument.
 
 	-m, --message <MESSAGE>
 		The text up to the first blank line in <MESSAGE> is treated as the release
@@ -453,7 +456,11 @@ func createRelease(cmd *Command, args *Args) {
 		return
 	}
 
-	assetsToUpload, close, err := openAssetFiles(args.Flag.AllValues("--attach"))
+	filenames := args.Flag.AllValues("--attach")
+	if args.ParamsSize() > 1 {
+		filenames = append(filenames, args.Params[1:]...)
+	}
+	assetsToUpload, close, err := openAssetFiles(filenames)
 	utils.Check(err)
 	defer close()
 
@@ -550,7 +557,11 @@ func editRelease(cmd *Command, args *Args) {
 		return
 	}
 
-	assetsToUpload, close, err := openAssetFiles(args.Flag.AllValues("--attach"))
+	filenames := args.Flag.AllValues("--attach")
+	if args.ParamsSize() > 1 {
+		filenames = append(filenames, args.Params[1:]...)
+	}
+	assetsToUpload, close, err := openAssetFiles(filenames)
 	utils.Check(err)
 	defer close()
 


### PR DESCRIPTION
This pull request add support for optional asset `<FILE>` arguments after the `<TAG>` argument in `hub release create` command.

I think it is easier to use asset arguments than asset options because you can specify glob patterns like `*.tar.xz` if the shell support expanding glob patterns.

Also add a note that `-a` option can be specified multiple times in the long help of `hub release create command`.