### PR TITLE
Added Chocolatey as Windows install method in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ hub version 2.2.3
 > scoop install hub
 ```
 
+or alternatively `hub` can be installed through [Chocolatey](https://chocolatey.org/):
+
+``` sh
+> choco install hub
+```
+
 #### Fedora Linux
 
 On Fedora you can install `hub` through DNF:


### PR DESCRIPTION
Updated the readme to also include Chocolatey as an install method for Windows, instead of only listing Scoop.