### PR TITLE
Enable GIT_TRACE

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -39,6 +39,15 @@ func (cmd *Cmd) WithArgs(args ...string) *Cmd {
 	return cmd
 }
 
+func (cmd *Cmd) Output() (string, error) {
+	verboseLog(cmd)
+	c := exec.Command(cmd.Name, cmd.Args...)
+	c.Stderr = cmd.Stderr
+	output, err := c.Output()
+
+	return string(output), err
+}
+
 func (cmd *Cmd) CombinedOutput() (string, error) {
 	verboseLog(cmd)
 	output, err := exec.Command(cmd.Name, cmd.Args...).CombinedOutput()

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -187,8 +187,8 @@ func pullRequest(cmd *Command, args *Args) {
 
 	force := args.Flag.Bool("--force")
 	if !force && trackedBranch != nil {
-		remoteCommits, _ := git.RefList(trackedBranch.LongName(), "")
-		if len(remoteCommits) > 0 {
+		remoteCommits, err := git.RefList(trackedBranch.LongName(), "")
+		if err == nil && len(remoteCommits) > 0 {
 			err = fmt.Errorf("Aborted: %d commits are not yet pushed to %s", len(remoteCommits), trackedBranch.LongName())
 			err = fmt.Errorf("%s\n(use `-f` to force submit a pull request anyway)", err)
 			utils.Check(err)

--- a/github/util.go
+++ b/github/util.go
@@ -10,10 +10,5 @@ func IsHttpsProtocol() bool {
 		return true
 	}
 
-	httpClone, _ := git.Config("--bool hub.http-clone")
-	if httpClone == "true" {
-		return true
-	}
-
 	return false
 }


### PR DESCRIPTION
Only process stdout when shelling out to git instead of combined stdout + stderr. In most cases, we want to silence stderr because we attach a custom error message to failure scenarios. In some other cases, have stderr be attached to stderr of parent process.

Fixes https://github.com/github/hub/issues/2134