### PR TITLE
[pr] add ability to open Pull Request in the browser

### DIFF
--- a/commands/pr.go
+++ b/commands/pr.go
@@ -16,6 +16,7 @@ var (
 		Usage: `
 pr list [-s <STATE>] [-h <HEAD>] [-b <BASE>] [-o <SORT_KEY> [-^]] [-f <FORMAT>] [-L <LIMIT>]
 pr checkout <PR-NUMBER> [<BRANCH>]
+pr show [-uc] [-h <HEAD>]
 `,
 		Long: `Manage GitHub Pull Requests for the current repository.
 
@@ -26,6 +27,9 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 
 	* _checkout_:
 		Check out the head of a pull request in a new branch.
+
+	* _show_:
+		Open the GitHub pull request page in a web browser.
 
 ## Options:
 
@@ -133,6 +137,12 @@ pr checkout <PR-NUMBER> [<BRANCH>]
 	-L, --limit <LIMIT>
 		Display only the first <LIMIT> issues.
 
+	-u, --url
+		Print the URL instead of opening it.
+
+	-c, --copy
+		Put the URL in clipboard instead of opening it.
+
 ## See also:
 
 hub-issue(1), hub-pull-request(1), hub(1)
@@ -150,11 +160,22 @@ hub-issue(1), hub-pull-request(1), hub(1)
 		Run:  listPulls,
 		Long: cmdPr.Long,
 	}
+
+	cmdShowPr = &Command{
+		Key: "show",
+		Run: showPr,
+		KnownFlags: `
+		-h, --head HEAD
+		-u, --url
+		-c, --copy
+`,
+	}
 )
 
 func init() {
 	cmdPr.Use(cmdListPulls)
 	cmdPr.Use(cmdCheckoutPr)
+	cmdPr.Use(cmdShowPr)
 	CmdRunner.Use(cmdPr)
 }
 
@@ -253,6 +274,66 @@ func checkoutPr(command *Command, args *Args) {
 	utils.Check(err)
 
 	args.Replace(args.Executable, "checkout", newArgs...)
+}
+
+func showPr(command *Command, args *Args) {
+	localRepo, err := github.LocalRepo()
+	utils.Check(err)
+
+	project, err := localRepo.MainProject()
+	utils.Check(err)
+
+	gh := github.NewClient(project.Host)
+
+	filterParams := make(map[string]interface{})
+	filterParams["state"] = "open"
+
+	var owner, branch string
+
+	if args.Flag.HasReceived("--head") {
+		head := args.Flag.Value("--head")
+
+		if strings.Contains(head, ":") {
+			s := strings.Split(head, ":")
+			owner, branch = s[0], s[1]
+			// chagne the project in case of pull request from fork
+			repo, err := gh.Repository(project)
+			utils.Check(err)
+			parent := repo.Parent
+			if parent == nil {
+				utils.Check(fmt.Errorf("Aborting due to repository not having a parent"))
+			}
+			project, err = github.NewProjectFromRepo(parent)
+			utils.Check(err)
+		} else {
+			owner, branch = project.Owner, head
+		}
+	} else {
+		if r, _ := localRepo.MainRemote(); r.Name == github.OriginNamesInLookupOrder[0] {
+			// look for origin's project owner
+			r, err := localRepo.RemoteByName("origin")
+			utils.Check(err)
+			p, err := r.Project()
+			utils.Check(err)
+			owner = p.Owner
+
+		} else {
+			owner = project.Owner
+		}
+		cb, err := localRepo.CurrentBranch()
+		utils.Check(err)
+		branch = cb.ShortName()
+	}
+	filterParams["head"] = fmt.Sprintf("%s:%s", owner, branch)
+	pulls, err := gh.FetchPullRequests(project, filterParams, 1, nil)
+
+	if len(pulls) == 1 {
+		pr := pulls[0]
+		args.NoForward()
+		flagBrowseURLPrint := args.Flag.Bool("--url")
+		flagBrowseURLCopy := args.Flag.Bool("--copy")
+		printBrowseOrCopy(args, pr.HtmlUrl, !flagBrowseURLPrint && !flagBrowseURLCopy, flagBrowseURLCopy)
+	}
 }
 
 func formatPullRequest(pr github.PullRequest, format string, colorize bool) string {

--- a/commands/pr.go
+++ b/commands/pr.go
@@ -319,6 +319,8 @@ func showPr(command *Command, args *Args) {
 		flagBrowseURLPrint := args.Flag.Bool("--url")
 		flagBrowseURLCopy := args.Flag.Bool("--copy")
 		printBrowseOrCopy(args, pr.HtmlUrl, !flagBrowseURLPrint && !flagBrowseURLCopy, flagBrowseURLCopy)
+	} else {
+		utils.Check(fmt.Errorf("no open pull requests found for branch '%s'", headWithOwner))
 	}
 }
 

--- a/features/pr-show.feature
+++ b/features/pr-show.feature
@@ -80,3 +80,17 @@ Feature: hub pr show
       """
     When I successfully run `hub pr show --head github:topic`
     Then "open https://github.com/ashemesh/hub/pull/102" should be run
+
+  Scenario: No pull request found
+    Given the GitHub API server:
+      """
+      get('/repos/ashemesh/hub/pulls'){
+        json []
+      }
+      """
+    When I run `hub pr show --head topic`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      no open pull requests found for branch 'ashemesh:topic'\n
+      """

--- a/features/pr-show.feature
+++ b/features/pr-show.feature
@@ -1,0 +1,79 @@
+Feature: hub pr show
+    Background:
+        Given I am in "git://github.com/ashemesh/hub.git" git repo
+        And I am "ashemesh" on github.com with OAuth token "OTOKEN"
+
+    Scenario: Open Current Branch Pull Request
+        Given I am on the "topic" branch
+        Given the GitHub API server:
+            """
+            get('/repos/ashemesh/hub/pulls'){
+                assert  :state => "open",
+                        :head => "ashemesh:topic"
+                json [
+                    {
+                        :html_url => "https://github.com/ashemesh/hub/pull/1",
+                    },
+                ]
+            }
+            """
+        When I successfully run `hub pr show`
+        Then "open https://github.com/ashemesh/hub/pull/1" should be run
+
+    Scenario: Open Current Branch Pull Request In Upstream
+    Given the "upstream" remote has url "git@github.com:github/hub.git" 
+    And I am on the "topic" branch
+    Given the GitHub API server:
+        """
+        get('/repos/github/hub/pulls'){
+            assert  :state => "open",
+                    :head => "ashemesh:topic"
+            json [
+                {
+                    :html_url => "https://github.com/github/hub/pull/1",
+                },
+            ]
+        }
+        """
+    When I successfully run `hub pr show`
+    Then "open https://github.com/github/hub/pull/1" should be run
+
+    Scenario: Open Pull Request For Given Head
+        Given the GitHub API server:
+            """
+            get('/repos/ashemesh/hub/pulls'){
+                assert  :state => "open",
+                        :head => "ashemesh:topic"
+                json [
+                    {
+                        :html_url => "https://github.com/ashemesh/hub/pull/1",
+                    },
+                ]
+            }
+            """
+        When I successfully run `hub pr show --head topic`
+        Then "open https://github.com/ashemesh/hub/pull/1" should be run
+
+    Scenario: Open Pull Request In Fork Repository Given Head
+        Given the GitHub API server:
+            """
+            get('/repos/ashemesh/hub'){
+                json :html_url => "https://github.com/ashemesh/hub",
+                     :parent => { 
+                                    :html_url => "https://github.com/github/hub",
+                                    :name => "hub",
+                                    :owner => { :login => "github" }
+                                }
+            }
+            get('/repos/github/hub/pulls'){
+                assert  :state => "open",
+                        :head => "ashemesh:topic"
+                json [
+                    {
+                        :html_url => "https://github.com/github/hub/pull/1",
+                    },
+                ]
+            }
+            """
+        When I successfully run `hub pr show --head ashemesh:topic`
+        Then "open https://github.com/github/hub/pull/1" should be run

--- a/features/pr-show.feature
+++ b/features/pr-show.feature
@@ -94,3 +94,15 @@ Feature: hub pr show
       """
       no open pull requests found for branch 'ashemesh:topic'\n
       """
+
+  Scenario: Show pull request by number
+    When I successfully run `hub pr show 102`
+    Then "open https://github.com/ashemesh/hub/pull/102" should be run
+
+  Scenario: Show pull request by invalid number
+    When I run `hub pr show XYZ`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      invalid pull request number: 'XYZ'\n
+      """

--- a/features/pr-show.feature
+++ b/features/pr-show.feature
@@ -53,6 +53,53 @@ Feature: hub pr show
     When I successfully run `hub pr show`
     Then "open https://github.com/github/hub/pull/102" should be run
 
+  Scenario: Differently named branch in fork
+    Given the "upstream" remote has url "git@github.com:github/hub.git"
+    And I am on the "local-topic" branch with upstream "origin/remote-topic"
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/pulls'){
+        assert :head => "ashemesh:remote-topic"
+        json [
+          { :html_url => "https://github.com/github/hub/pull/102" },
+        ]
+      }
+      """
+    When I successfully run `hub pr show`
+    Then "open https://github.com/github/hub/pull/102" should be run
+
+  Scenario: Upstream configuration with HTTPS URL
+    Given I am on the "local-topic" branch
+    When I successfully run `git config branch.local-topic.remote https://github.com/octocat/hub.git`
+    When I successfully run `git config branch.local-topic.merge refs/remotes/remote-topic`
+    Given the GitHub API server:
+      """
+      get('/repos/ashemesh/hub/pulls'){
+        assert :head => "octocat:remote-topic"
+        json [
+          { :html_url => "https://github.com/github/hub/pull/102" },
+        ]
+      }
+      """
+    When I successfully run `hub pr show`
+    Then "open https://github.com/github/hub/pull/102" should be run
+
+  Scenario: Upstream configuration with SSH URL
+    Given I am on the "local-topic" branch
+    When I successfully run `git config branch.local-topic.remote git@github.com:octocat/hub.git`
+    When I successfully run `git config branch.local-topic.merge refs/remotes/remote-topic`
+    Given the GitHub API server:
+      """
+      get('/repos/ashemesh/hub/pulls'){
+        assert :head => "octocat:remote-topic"
+        json [
+          { :html_url => "https://github.com/github/hub/pull/102" },
+        ]
+      }
+      """
+    When I successfully run `hub pr show`
+    Then "open https://github.com/github/hub/pull/102" should be run
+
   Scenario: Explicit head branch
     Given the GitHub API server:
       """

--- a/features/pr-show.feature
+++ b/features/pr-show.feature
@@ -39,7 +39,7 @@ Feature: hub pr show
 
   Scenario: Current branch in fork
     Given the "upstream" remote has url "git@github.com:github/hub.git"
-    And I am on the "topic" branch
+    And I am on the "topic" branch pushed to "origin/topic"
     Given the GitHub API server:
       """
       get('/repos/github/hub/pulls'){

--- a/features/pr-show.feature
+++ b/features/pr-show.feature
@@ -1,79 +1,82 @@
 Feature: hub pr show
-    Background:
-        Given I am in "git://github.com/ashemesh/hub.git" git repo
-        And I am "ashemesh" on github.com with OAuth token "OTOKEN"
+  Background:
+    Given I am in "git://github.com/ashemesh/hub.git" git repo
+    And I am "ashemesh" on github.com with OAuth token "OTOKEN"
 
-    Scenario: Open Current Branch Pull Request
-        Given I am on the "topic" branch
-        Given the GitHub API server:
-            """
-            get('/repos/ashemesh/hub/pulls'){
-                assert  :state => "open",
-                        :head => "ashemesh:topic"
-                json [
-                    {
-                        :html_url => "https://github.com/ashemesh/hub/pull/1",
-                    },
-                ]
-            }
-            """
-        When I successfully run `hub pr show`
-        Then "open https://github.com/ashemesh/hub/pull/1" should be run
+  Scenario: Current branch
+    Given I am on the "topic" branch
+    Given the GitHub API server:
+      """
+      get('/repos/ashemesh/hub/pulls'){
+        assert :state => "open",
+               :head => "ashemesh:topic"
+        json [
+          { :html_url => "https://github.com/ashemesh/hub/pull/102" },
+        ]
+      }
+      """
+    When I successfully run `hub pr show`
+    Then "open https://github.com/ashemesh/hub/pull/102" should be run
 
-    Scenario: Open Current Branch Pull Request In Upstream
-    Given the "upstream" remote has url "git@github.com:github/hub.git" 
+  Scenario: Current branch output URL
+    Given I am on the "topic" branch
+    Given the GitHub API server:
+      """
+      get('/repos/ashemesh/hub/pulls'){
+        assert :state => "open",
+               :head => "ashemesh:topic"
+        json [
+          { :html_url => "https://github.com/ashemesh/hub/pull/102" },
+        ]
+      }
+      """
+    When I successfully run `hub pr show -u`
+    Then "open https://github.com/ashemesh/hub/pull/102" should not be run
+    And the output should contain exactly:
+      """
+      https://github.com/ashemesh/hub/pull/102\n
+      """
+
+  Scenario: Current branch in fork
+    Given the "upstream" remote has url "git@github.com:github/hub.git"
     And I am on the "topic" branch
     Given the GitHub API server:
-        """
-        get('/repos/github/hub/pulls'){
-            assert  :state => "open",
-                    :head => "ashemesh:topic"
-            json [
-                {
-                    :html_url => "https://github.com/github/hub/pull/1",
-                },
-            ]
-        }
-        """
+      """
+      get('/repos/github/hub/pulls'){
+        assert :state => "open",
+               :head => "ashemesh:topic"
+        json [
+          { :html_url => "https://github.com/github/hub/pull/102" },
+        ]
+      }
+      """
     When I successfully run `hub pr show`
-    Then "open https://github.com/github/hub/pull/1" should be run
+    Then "open https://github.com/github/hub/pull/102" should be run
 
-    Scenario: Open Pull Request For Given Head
-        Given the GitHub API server:
-            """
-            get('/repos/ashemesh/hub/pulls'){
-                assert  :state => "open",
-                        :head => "ashemesh:topic"
-                json [
-                    {
-                        :html_url => "https://github.com/ashemesh/hub/pull/1",
-                    },
-                ]
-            }
-            """
-        When I successfully run `hub pr show --head topic`
-        Then "open https://github.com/ashemesh/hub/pull/1" should be run
+  Scenario: Explicit head branch
+    Given the GitHub API server:
+      """
+      get('/repos/ashemesh/hub/pulls'){
+        assert :state => "open",
+               :head => "ashemesh:topic"
+        json [
+          { :html_url => "https://github.com/ashemesh/hub/pull/102" },
+        ]
+      }
+      """
+    When I successfully run `hub pr show --head topic`
+    Then "open https://github.com/ashemesh/hub/pull/102" should be run
 
-    Scenario: Open Pull Request In Fork Repository Given Head
-        Given the GitHub API server:
-            """
-            get('/repos/ashemesh/hub'){
-                json :html_url => "https://github.com/ashemesh/hub",
-                     :parent => { 
-                                    :html_url => "https://github.com/github/hub",
-                                    :name => "hub",
-                                    :owner => { :login => "github" }
-                                }
-            }
-            get('/repos/github/hub/pulls'){
-                assert  :state => "open",
-                        :head => "ashemesh:topic"
-                json [
-                    {
-                        :html_url => "https://github.com/github/hub/pull/1",
-                    },
-                ]
-            }
-            """
-        When I successfully run `hub pr show --head ashemesh:topic`
-        Then "open https://github.com/github/hub/pull/1" should be run
+  Scenario: Explicit head branch with owner
+    Given the GitHub API server:
+      """
+      get('/repos/ashemesh/hub/pulls'){
+        assert :state => "open",
+               :head => "github:topic"
+        json [
+          { :html_url => "https://github.com/ashemesh/hub/pull/102" },
+        ]
+      }
+      """
+    When I successfully run `hub pr show --head github:topic`
+    Then "open https://github.com/ashemesh/hub/pull/102" should be run

--- a/github/branch.go
+++ b/github/branch.go
@@ -23,6 +23,7 @@ func (b *Branch) LongName() string {
 	return reg.ReplaceAllString(b.Name, "")
 }
 
+// see also RemoteForBranch()
 func (b *Branch) PushTarget(owner string, preferUpstream bool) (branch *Branch) {
 	var err error
 	pushDefault, _ := git.Config("push.default")

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -156,6 +156,17 @@ func (r *GitHubRepo) RemoteBranchAndProject(owner string, preferUpstream bool) (
 	return
 }
 
+// duplicates logic from PushTarget()
+func (r *GitHubRepo) RemoteForBranch(branch *Branch, owner string) *Remote {
+	branchName := branch.ShortName()
+	for _, remote := range r.remotesForPublish(owner) {
+		if git.HasFile("refs", "remotes", remote.Name, branchName) {
+			return &remote
+		}
+	}
+	return nil
+}
+
 func (r *GitHubRepo) RemoteForRepo(repo *Repository) (*Remote, error) {
 	if err := r.loadRemotes(); err != nil {
 		return nil, err


### PR DESCRIPTION
add the ability to open a PR page in browser (also copy & URL print to screen).
ability to open the forked PR by pass the `head` flag.
<img width="310" alt="Screenshot 2019-05-18 at 22 41 31" src="https://user-images.githubusercontent.com/16662713/57974828-b8a3cb00-79be-11e9-82ab-da772e5440fe.png">
in the example above `hub` is a fork of `github/hub`.