### PR TITLE
build: pass mod vendoring flag on newer versions of go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ export LDFLAGS := -extldflags '$(LDFLAGS)'
 export GCFLAGS := $(FLAGS_ALL)-trimpath '$(PWD)'
 export ASMFLAGS := $(FLAGS_ALL)-trimpath '$(PWD)'
 
+ifneq ($(MOD_VENDOR_ARG),)
+	unexport GOPATH
+endif
+
 MIN_COVERAGE = 89.4
 
 HELP_CMD = \

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SOURCE_DATE_EPOCH ?= $(shell date +%s)
 BUILD_DATE = $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" '+%d %b %Y' 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" '+%d %b %Y')
 HUB_VERSION = $(shell bin/hub version | tail -1)
 FLAGS_ALL = $(shell go version | grep -q 'go1.[89]' || echo 'all=')
+export MOD_VENDOR_ARG := $(shell go version | grep -q 'go1.1[^0]' && echo '-mod=vendor')
 export LDFLAGS := -extldflags '$(LDFLAGS)'
 export GCFLAGS := $(FLAGS_ALL)-trimpath '$(PWD)'
 export ASMFLAGS := $(FLAGS_ALL)-trimpath '$(PWD)'
@@ -46,7 +47,7 @@ bin/hub: $(SOURCES)
 	script/build -o $@
 
 bin/md2roff: $(SOURCES)
-	go build -o $@ github.com/github/hub/md2roff-bin
+	go build $(MOD_VENDOR_ARG) -o $@ github.com/github/hub/md2roff-bin
 
 test:
 	go test ./...

--- a/script/build
+++ b/script/build
@@ -14,6 +14,7 @@ find_source_files() {
 build_hub() {
   mkdir -p "$(dirname "$1")"
   go build \
+	  $MOD_VENDOR_ARG \
 	  -ldflags "-X github.com/github/hub/version.Version=`./script/version` $LDFLAGS" \
 	  -gcflags "$GCFLAGS" \
 	  -asmflags "$ASMFLAGS" \


### PR DESCRIPTION
When go autodetects that it is being run as a go mod, and that there is a vendor directory, it will still try to redownload all sources over the network, unless you use -mod=vendor to tell it to use that. Additionally, when using -mod=vendor the compiler will nicely avoid messing with $GOPATH at all, since it can operate in a completely self-contained manner.

Take advantage of this, when the detected go version is at least 1.11 (when the -mod flag was introduced).