### PR TITLE
Add STDIN support as -r / --REMOTE_URL argument for batch processing

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -263,6 +263,7 @@ func listIssues(cmd *Command, args *Args) {
 	if rawRemote := args.Flag.Value("--remote-url"); len(rawRemote) > 0 {
 		if rawRemote == "STDIN" {
 			fetchIssueStatusOnMultipleRepos(cmd, args)
+			return
 		} else {
 			project = calculateProjectFromRFlag(rawRemote)
 		}

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -226,7 +226,7 @@ func init() {
 	CmdRunner.Use(cmdIssue)
 }
 
-func calculateProjectFromRFlag(rawRemote string) (*github.Project) {
+func calculateProjectFromRFlag(rawRemote string) *github.Project {
 	var remote *github.Remote
 
 	if remoteURL, ok := url.Parse(rawRemote); ok == nil {

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -229,15 +229,15 @@ func init() {
 func calculateProjectFromRFlag(rawRemote string) *github.Project {
 	var remote *github.Remote
 
-	if remoteURL, error := url.Parse(rawRemote); error == nil {
+	if remoteURL, err := url.Parse(rawRemote); err == nil {
 		remote = &github.Remote{"origin", remoteURL, remoteURL}
 	} else {
 		fmt.Fprintf(os.Stderr, "invalid remote URL string: %s", rawRemote)
 		os.Exit(1)
 	}
 
-	if _, error := remote.Project(); ok != nil {
-		fmt.Fprintf(os.Stderr, "no project for: %s because %s", rawRemote, ok)
+	if _, err := remote.Project(); err != nil {
+ 		fmt.Fprintf(os.Stderr, "no project for: %s because %s", rawRemote, err)
 		os.Exit(1)
 	}
 

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -17,7 +18,7 @@ var (
 	cmdIssue = &Command{
 		Run: listIssues,
 		Usage: `
-issue [-a <ASSIGNEE>] [-c <CREATOR>] [-@ <USER>] [-s <STATE>] [-f <FORMAT>] [-M <MILESTONE>] [-l <LABELS>] [-d <DATE>] [-o <SORT_KEY> [-^]] [-L <LIMIT>]
+issue [-a <ASSIGNEE>] [-c <CREATOR>] [-@ <USER>] [-s <STATE>] [-f <FORMAT>] [-M <MILESTONE>] [-l <LABELS>] [-d <DATE>] [-o <SORT_KEY> [-^]] [-L <LIMIT>] [-r REMOTE_URL]
 issue show [-f <FORMAT>] <NUMBER>
 issue create [-oc] [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
 issue labels [--color]
@@ -154,6 +155,9 @@ With no arguments, show a list of open issues.
 	-L, --limit <LIMIT>
 		Display only the first <LIMIT> issues.
 
+	-r, --remote-url <REMOTE_URL>
+		Avoid requiring a local clone in order to get issue data. Simply provide REMOTE_URL.
+
 	--include-pulls
 		Include pull requests as well as issues.
 
@@ -177,6 +181,7 @@ hub-pr(1), hub(1)
 		-^, --sort-ascending
 		--include-pulls
 		-L, --limit N
+		-r, --remote-url REMOTE_URL
 		--color
 `,
 	}
@@ -221,12 +226,39 @@ func init() {
 	CmdRunner.Use(cmdIssue)
 }
 
-func listIssues(cmd *Command, args *Args) {
-	localRepo, err := github.LocalRepo()
-	utils.Check(err)
+func calculateProjectFromRFlag(rawRemote string) (*github.Project) {
+	var remote *github.Remote
 
-	project, err := localRepo.MainProject()
-	utils.Check(err)
+	if remoteURL, ok := url.Parse(rawRemote); ok == nil {
+		remote = &github.Remote{"origin", remoteURL, remoteURL}
+	} else {
+		fmt.Fprintf(os.Stderr, "invalid remote URL string: %s", rawRemote)
+		os.Exit(1)
+	}
+
+	if _, ok := remote.Project(); ok != nil {
+		fmt.Fprintf(os.Stderr, "no project for: %s because %s", rawRemote, ok)
+		os.Exit(1)
+	}
+
+	var validProject, _ = remote.Project()
+	return validProject
+}
+
+func listIssues(cmd *Command, args *Args) {
+	var project *github.Project
+
+	if rawRemote := args.Flag.Value("--remote-url"); args.Flag.HasReceived("--remote-url") {
+		project = calculateProjectFromRFlag(rawRemote)
+	}
+
+	if project == nil {
+		localRepo, err := github.LocalRepo()
+		utils.Check(err)
+
+		project, err = localRepo.MainProject()
+		utils.Check(err)
+	}
 
 	gh := github.NewClient(project.Host)
 

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -229,19 +229,19 @@ func init() {
 func calculateProjectFromRFlag(rawRemote string) *github.Project {
 	var remote *github.Remote
 
-	if remoteURL, ok := url.Parse(rawRemote); ok == nil {
+	if remoteURL, error := url.Parse(rawRemote); error == nil {
 		remote = &github.Remote{"origin", remoteURL, remoteURL}
 	} else {
 		fmt.Fprintf(os.Stderr, "invalid remote URL string: %s", rawRemote)
 		os.Exit(1)
 	}
 
-	if _, ok := remote.Project(); ok != nil {
+	if _, error := remote.Project(); ok != nil {
 		fmt.Fprintf(os.Stderr, "no project for: %s because %s", rawRemote, ok)
 		os.Exit(1)
 	}
 
-	var validProject, _ = remote.Project()
+	validProject, _  := remote.Project()
 	return validProject
 }
 

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -226,7 +226,7 @@ func init() {
 	CmdRunner.Use(cmdIssue)
 }
 
-func calculateProjectFromRFlag(rawRemote string) *github.Project {
+func calculateProjectFromRFlag(rawRemote string) (*github.Project) {
 	var remote *github.Remote
 
 	if remoteURL, ok := url.Parse(rawRemote); ok == nil {

--- a/commands/issue_test.go
+++ b/commands/issue_test.go
@@ -23,6 +23,10 @@ func testFormatIssue(t *testing.T, tests []formatIssueTest) {
 	}
 }
 
+func TestRepositoryURLOverride(t *testing.T){
+
+}
+
 func TestFormatIssue(t *testing.T) {
 	format := "%sC%>(8)%i%Creset  %t%  l%n"
 	testFormatIssue(t, []formatIssueTest{

--- a/commands/issue_test.go
+++ b/commands/issue_test.go
@@ -23,10 +23,6 @@ func testFormatIssue(t *testing.T, tests []formatIssueTest) {
 	}
 }
 
-func TestRepositoryURLOverride(t *testing.T){
-
-}
-
 func TestFormatIssue(t *testing.T) {
 	format := "%sC%>(8)%i%Creset  %t%  l%n"
 	testFormatIssue(t, []formatIssueTest{

--- a/utils/args_parser.go
+++ b/utils/args_parser.go
@@ -149,6 +149,13 @@ func (p *ArgsParser) RegisterBool(name string, aliases ...string) {
 	}
 }
 
+func (p *ArgsParser) UpdateValue(name, value string) {
+	if _, found := p.flagMap[name]; found {
+		newFlag := &argsFlag{true, []string{value}}
+		p.flagMap[name] = newFlag
+	}
+}
+
 func (p *ArgsParser) Value(name string) string {
 	if f, found := p.flagMap[name]; found {
 		return f.lastValue()


### PR DESCRIPTION
## Use Case

My team uses `hub` to do issue reporting. The collection of repositories stays pretty static. By leveraging #2159 as the "innards" of a loop of a list of repo URLs delivered via STDIN, we generate a nice report.

## Example Use

`cat list_of_prework_urls.txt |bin/hub issue -r STDIN --include-pulls -f '%U%n' |tee  issues`

## Presentation Note

This PR is built off of #2159, so this particular diff is a bit hairy pending that landing to `master`. The diffset can be more easily grokked [here](https://github.com/sgharms/hub/compare/add-repository-flag-to-issues..add-stdin-support).