### PR TITLE
Implement `hub api --paginate`

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -122,6 +122,7 @@ func (c *Command) HelpText() string {
 	}
 
 	long = strings.Replace(long, "'", "`", -1)
+	long = strings.Replace(long, "``", "'", -1)
 	headingRe := regexp.MustCompile(`(?m)^(## .+):$`)
 	long = headingRe.ReplaceAllString(long, "$1")
 

--- a/features/api.feature
+++ b/features/api.feature
@@ -109,6 +109,24 @@ Feature: hub api
       {"name":"Faye"}
       """
 
+  Scenario: Paginate REST
+    Given the GitHub API server:
+      """
+      get('/comments') {
+        assert :per_page => "6"
+        page = (params[:page] || 1).to_i
+        response.headers["Link"] = %(<#{request.url}&page=#{page+1}>; rel="next") if page < 3
+        json [{:page => page}]
+      }
+      """
+    When I successfully run `hub api --paginate comments?per_page=6`
+    Then the output should contain exactly:
+      """
+      [{"page":1}]
+      [{"page":2}]
+      [{"page":3}]
+      """
+
   Scenario: Avoid leaking token to a 3rd party
     Given the GitHub API server:
       """

--- a/features/api.feature
+++ b/features/api.feature
@@ -127,6 +127,28 @@ Feature: hub api
       [{"page":3}]
       """
 
+  Scenario: Paginate GraphQL
+    Given the GitHub API server:
+      """
+      post('/graphql') {
+        variables = params[:variables] || {}
+        page = (variables["endCursor"] || 1).to_i
+        json :data => {
+          :pageInfo => {
+            :hasNextPage => page < 3,
+            :endCursor => (page+1).to_s
+          }
+        }
+      }
+      """
+    When I successfully run `hub api --paginate graphql -f query=QUERY`
+    Then the output should contain exactly:
+      """
+      {"data":{"pageInfo":{"hasNextPage":true,"endCursor":"2"}}}
+      {"data":{"pageInfo":{"hasNextPage":true,"endCursor":"3"}}}
+      {"data":{"pageInfo":{"hasNextPage":false,"endCursor":"4"}}}
+      """
+
   Scenario: Avoid leaking token to a 3rd party
     Given the GitHub API server:
       """

--- a/github/client.go
+++ b/github/client.go
@@ -29,11 +29,12 @@ func NewClient(h string) *Client {
 }
 
 func NewClientWithHost(host *Host) *Client {
-	return &Client{host}
+	return &Client{Host: host}
 }
 
 type Client struct {
-	Host *Host
+	Host         *Host
+	cachedClient *simpleClient
 }
 
 func (client *Client) FetchPullRequests(project *Project, filterParams map[string]interface{}, limit int, filter func(*PullRequest) bool) (pulls []PullRequest, err error) {
@@ -936,6 +937,11 @@ func (client *Client) simpleApi() (c *simpleClient, err error) {
 		return
 	}
 
+	if client.cachedClient != nil {
+		c = client.cachedClient
+		return
+	}
+
 	c = client.apiClient()
 	c.PrepareRequest = func(req *http.Request) {
 		clientDomain := normalizeHost(client.Host.Host)
@@ -947,6 +953,8 @@ func (client *Client) simpleApi() (c *simpleClient, err error) {
 			req.Header.Set("Authorization", "token "+client.Host.AccessToken)
 		}
 	}
+
+	client.cachedClient = c
 	return
 }
 

--- a/utils/json.go
+++ b/utils/json.go
@@ -29,10 +29,7 @@ func stateKey(s *state) string {
 	}
 }
 
-func printValue(token json.Token) {
-}
-
-func JSONPath(out io.Writer, src io.Reader, colorize bool) {
+func JSONPath(out io.Writer, src io.Reader, colorize bool) (hasNextPage bool, endCursor string) {
 	dec := json.NewDecoder(src)
 	dec.UseNumber()
 
@@ -84,12 +81,18 @@ func JSONPath(out io.Writer, src io.Reader, colorize bool) {
 				switch tt := token.(type) {
 				case string:
 					fmt.Fprintf(out, "%s\n", strings.Replace(tt, "\n", "\\n", -1))
+					if strings.HasSuffix(k, ".pageInfo.endCursor") {
+						endCursor = tt
+					}
 				case json.Number:
 					fmt.Fprintf(out, "%s\n", color("0;35", tt))
 				case nil:
 					fmt.Fprintf(out, "\n")
 				case bool:
 					fmt.Fprintf(out, "%s\n", color("1;33", fmt.Sprintf("%v", tt)))
+					if strings.HasSuffix(k, ".pageInfo.hasNextPage") {
+						hasNextPage = tt
+					}
 				default:
 					panic("unknown type")
 				}
@@ -97,4 +100,5 @@ func JSONPath(out io.Writer, src io.Reader, colorize bool) {
 			}
 		}
 	}
+	return
 }


### PR DESCRIPTION
REST resources are paginated by following the `<next>` link in the "Link" response header.

A GraphQL query has to accept the optional `endCursor` string variable and output `pageInfo`:

```graphql
pageInfo {
  hasNextPage
  endCursor
}
```

Full GraphQL example: find all repositories owned by USER:

```sh
hub api --paginate graphql -f owner="USER" -f query='
  query($owner: String!, $per_page: Int = 100, $endCursor: String) {
    repositoryOwner(login: $owner) {
      repositories(first: $per_page, after: $endCursor, ownerAffiliations: OWNER) {
        nodes {
          nameWithOwner
        }
        pageInfo {
          hasNextPage
          endCursor
        }
      }
    }
  }
'
```

https://developer.github.com/v3/#pagination
https://developer.github.com/v4/guides/resource-limitations/#node-limit