### PR TITLE
Improve push target detection for `push.default=upstream`

### DIFF
--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -947,11 +947,12 @@ Feature: hub pull-request
     Then the output should contain exactly "the://url\n"
 
   Scenario: Current branch is pushed to remote without upstream configuration
-    Given git "push.default" is set to "upstream"
+    Given the "upstream" remote has url "git://github.com/lestephane/coral.git"
     And I am on the "feature" branch pushed to "origin/feature"
+    And git "push.default" is set to "upstream"
     Given the GitHub API server:
       """
-      post('/repos/mislav/coral/pulls') {
+      post('/repos/lestephane/coral/pulls') {
         assert :base  => 'master',
                :head  => 'mislav:feature'
         status 201

--- a/github/branch.go
+++ b/github/branch.go
@@ -23,45 +23,6 @@ func (b *Branch) LongName() string {
 	return reg.ReplaceAllString(b.Name, "")
 }
 
-// see also RemoteForBranch()
-func (b *Branch) PushTarget(owner string, preferUpstream bool) (branch *Branch) {
-	var err error
-	pushDefault, _ := git.Config("push.default")
-	if pushDefault == "upstream" || pushDefault == "tracking" {
-		branch, err = b.Upstream()
-		if err != nil {
-			return
-		}
-	} else {
-		shortName := b.ShortName()
-		remotes := b.Repo.remotesForPublish(owner)
-
-		var remotesInOrder []Remote
-		if preferUpstream {
-			// reverse the remote lookup order
-			// see OriginNamesInLookupOrder
-			for i := len(remotes) - 1; i >= 0; i-- {
-				remotesInOrder = append(remotesInOrder, remotes[i])
-			}
-		} else {
-			remotesInOrder = remotes
-		}
-
-		for _, remote := range remotesInOrder {
-			if _, err := remote.Project(); err != nil {
-				continue
-			}
-			if git.HasFile("refs", "remotes", remote.Name, shortName) {
-				name := fmt.Sprintf("refs/remotes/%s/%s", remote.Name, shortName)
-				branch = &Branch{b.Repo, name}
-				break
-			}
-		}
-	}
-
-	return
-}
-
 func (b *Branch) RemoteName() string {
 	reg := regexp.MustCompile("^refs/remotes/([^/]+)")
 	if reg.MatchString(b.Name) {


### PR DESCRIPTION
When `git config push.default` is "upstream" or "tracking", but the current branch is pushed to a remote _without_ having upstream configuration set up (for example, via `git push <REMOTE> HEAD` without `-u`), this change makes it so that the remote tracking branch (the push target) is still discovered via the same mechanism as if `push.default` wasn't set (i.e. iterating through all the remotes).

Fixes https://github.com/github/hub/issues/189#issuecomment-508122178 /cc @lestephane