### PR TITLE
Allow hub used in Actions by specifying GITHUB_USER

### DIFF
--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -261,8 +261,33 @@ Feature: OAuth authentication
     And the stderr should contain exactly:
       """
       Error getting current user: Forbidden (HTTP 403)
-      Resource not accessible by integration\n
+      Resource not accessible by integration
+      You must specify GITHUB_USER via environment variable.\n
       """
+
+  Scenario: Credentials from GITHUB_TOKEN and GITHUB_USER
+    Given I am in "git://github.com/monalisa/playground.git" git repo
+    Given the GitHub API server:
+      """
+      get('/user') {
+        status 403
+        json :message => "Resource not accessible by integration",
+             :documentation_url => "https://developer.github.com/v3/users/#get-the-authenticated-user"
+      }
+      get('/repos/monalisa/playground/releases') {
+        halt 401 unless request.env["HTTP_AUTHORIZATION"] == "token OTOKEN"
+        json [
+          { tag_name: 'v1.2.0',
+          }
+        ]
+      }
+      """
+    Given $GITHUB_TOKEN is "OTOKEN"
+    Given $GITHUB_USER is "hubot"
+    When I successfully run `hub release show v1.2.0`
+    Then the output should not contain "github.com password"
+    And the output should not contain "github.com username"
+    And the file "../home/.config/hub" should not exist
 
   Scenario: Credentials from GITHUB_TOKEN override those from config file
     Given I am "mislav" on github.com with OAuth token "OTOKEN"

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -241,6 +241,29 @@ Feature: OAuth authentication
     And the output should not contain "github.com username"
     And the file "../home/.config/hub" should not exist
 
+  Scenario: Credentials from GITHUB_TOKEN when obtaining username fails
+    Given I am in "git://github.com/monalisa/playground.git" git repo
+    Given the GitHub API server:
+      """
+      get('/user') {
+        status 403
+        json :message => "Resource not accessible by integration",
+             :documentation_url => "https://developer.github.com/v3/users/#get-the-authenticated-user"
+      }
+      """
+    Given $GITHUB_TOKEN is "OTOKEN"
+    Given $GITHUB_USER is ""
+    When I run `hub release show v1.2.0`
+    Then the output should not contain "github.com password"
+    And the output should not contain "github.com username"
+    And the file "../home/.config/hub" should not exist
+    And the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      Error getting current user: Forbidden (HTTP 403)
+      Resource not accessible by integration\n
+      """
+
   Scenario: Credentials from GITHUB_TOKEN override those from config file
     Given I am "mislav" on github.com with OAuth token "OTOKEN"
     Given the GitHub API server:

--- a/github/client.go
+++ b/github/client.go
@@ -1044,6 +1044,9 @@ func FormatError(action string, err error) (ee error) {
 			errorMessage = strings.Join(errorSentences, "\n")
 		} else {
 			errorMessage = e.Message
+			if action == "getting current user" && e.Message == "Resource not accessible by integration" {
+				errorMessage = errorMessage + "\nYou must specify GITHUB_USER via environment variable."
+			}
 		}
 
 		if errorMessage != "" {

--- a/github/client.go
+++ b/github/client.go
@@ -921,14 +921,15 @@ func (client *Client) FindOrCreateToken(user, password, twoFactorCode string) (t
 	return
 }
 
-func (client *Client) ensureAccessToken() (err error) {
+func (client *Client) ensureAccessToken() error {
 	if client.Host.AccessToken == "" {
 		host, err := CurrentConfig().PromptForHost(client.Host.Host)
-		if err == nil {
-			client.Host = host
+		if err != nil {
+			return err
 		}
+		client.Host = host
 	}
-	return
+	return nil
 }
 
 func (client *Client) simpleApi() (c *simpleClient, err error) {

--- a/github/config.go
+++ b/github/config.go
@@ -87,11 +87,17 @@ func (c *Config) PromptForHost(host string) (h *Host, err error) {
 		}
 	}
 
-	currentUser, err := client.CurrentUser()
-	if err != nil {
-		return
+	userFromEnv := os.Getenv("GITHUB_USER")
+	if tokenFromEnv && userFromEnv != "" {
+		h.User = userFromEnv
+	} else {
+		var currentUser *User
+		currentUser, err = client.CurrentUser()
+		if err != nil {
+			return
+		}
+		h.User = currentUser.Login
 	}
-	h.User = currentUser.Login
 
 	if !tokenFromEnv {
 		err = newConfigService().Save(configsFile(), c)


### PR DESCRIPTION
When supplied with GITHUB_TOKEN, hub will attempt to request the `user` API resource which isn't available in the context of Actions.

To work around this, scripts may now set GITHUB_USER to avoid hitting the unavailable API resource.

The actual value of GITHUB_USER is not used in most commands; therefore, it can be a name of an organization or even a dummy value.

Fixes #2149