### PR TITLE
Simplify code

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -197,7 +197,7 @@ func customCommands() []string {
 		}
 	}
 
-	sort.Sort(sort.StringSlice(cmds))
+	sort.Strings(cmds)
 
 	return cmds
 }

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -516,8 +516,6 @@ func showIssue(cmd *Command, args *Args) {
 			ui.Printf("\n### comment by @%s on %s\n\n%s\n", comment.User.Login, comment.CreatedAt.String(), comment.Body)
 		}
 	}
-
-	return
 }
 
 func createIssue(cmd *Command, args *Args) {

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -371,7 +371,7 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 					numRetries += 1
 				} else {
 					if numRetries > 0 {
-						duration := time.Now().Sub(startedAt)
+						duration := time.Since(startedAt)
 						err = fmt.Errorf("%s\nGiven up after retrying for %.1f seconds.", err, duration.Seconds())
 					}
 					break

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -134,7 +134,7 @@ func expandAlias(args *Args) {
 }
 
 func isBuiltInHubCommand(command string) bool {
-	for hubCommand, _ := range CmdRunner.All() {
+	for hubCommand := range CmdRunner.All() {
 		if hubCommand == command {
 			return true
 		}

--- a/github/util.go
+++ b/github/util.go
@@ -6,9 +6,5 @@ import (
 
 func IsHttpsProtocol() bool {
 	httpProtocol, _ := git.Config("hub.protocol")
-	if httpProtocol == "https" {
-		return true
-	}
-
-	return false
+	return httpProtocol == "https"
 }

--- a/md2roff/renderer.go
+++ b/md2roff/renderer.go
@@ -107,9 +107,9 @@ func (r *RoffRenderer) RenderNode(buf io.Writer, node *blackfriday.Node, enterin
 
 	leaf := len(node.Literal) > 0
 	if leaf {
-		if bytes.Compare(node.Literal, enterVar) == 0 {
+		if bytes.Equal(node.Literal, enterVar) {
 			io.WriteString(buf, `\fI`)
-		} else if bytes.Compare(node.Literal, closeVar) == 0 {
+		} else if bytes.Equal(node.Literal, closeVar) {
 			io.WriteString(buf, `\fP`)
 		} else {
 			buf.Write(roffText(node.Literal))

--- a/ui/format.go
+++ b/ui/format.go
@@ -254,9 +254,9 @@ func (p *padder) truncate(s string, numReduce int) string {
 
 	switch p.truncing {
 	case truncRight:
-		return ".." + s[len(s)-numLeft:len(s)]
+		return ".." + s[len(s)-numLeft:]
 	case truncMiddle:
-		return s[:numLeft/2] + ".." + s[len(s)-(numLeft+1)/2:len(s)]
+		return s[:numLeft/2] + ".." + s[len(s)-(numLeft+1)/2:]
 	}
 
 	// Trunc left by default.


### PR DESCRIPTION
- Use bytes.Equal instead of bytes.Compare
- Use time.Since instead of manual timestamp subtracting
- Use sort.Strings instead of sort.StringSlice
- No need to specify the len of the slice