### PR TITLE
Trap syscall.SIGTERM instead of os.Kill

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -192,7 +192,7 @@ func getPassword() (string, error) {
 	}
 
 	c := make(chan os.Signal)
-	signal.Notify(c, os.Interrupt, os.Kill)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		s := <-c
 		terminal.Restore(stdin, initialTermState)


### PR DESCRIPTION
os.Kill can not be signal trapped. I assume we want to trap syscall.SIGTERM
instead?