### PR TITLE
Tweak Makefile to support older Go versions' backported module support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@ SOURCE_DATE_EPOCH ?= $(shell date +%s)
 BUILD_DATE = $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" '+%d %b %Y' 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" '+%d %b %Y')
 HUB_VERSION = $(shell bin/hub version | tail -1)
 FLAGS_ALL = $(shell go version | grep -q 'go1.[89]' || echo 'all=')
-export MOD_VENDOR_ARG := $(shell go version | grep -q 'go1.1[^0]' && echo '-mod=vendor')
+export MOD_VENDOR_ARG := $(shell go version | grep -q 'go1.1[^01]' && echo '-mod=vendor')
 export LDFLAGS := -extldflags '$(LDFLAGS)'
 export GCFLAGS := $(FLAGS_ALL)-trimpath '$(PWD)'
 export ASMFLAGS := $(FLAGS_ALL)-trimpath '$(PWD)'
 
 ifneq ($(MOD_VENDOR_ARG),)
+	export GO111MODULE=on
 	unexport GOPATH
 endif
 


### PR DESCRIPTION
`go` supports environmentally-toggled support for the module system introduced in `1.11`.

Currently the Makefile checks for go > `1.10` to decide whether or not to use the `-mod` flag; for certain `go` installations, though, this flag is unsupported without setting `GO111MODULE=on` in the environment. 

Compounding this is having a module that depends on go >= `1.12`. If modules are disabled, everything builds fine; if they are enabled any Go version under `1.12` (even if it has backported module support) will fail.

This PR:

- only enables module use for `go` >= `1.12`
- sets `GO111MODULE=on` if modules are enabled