### PR TITLE
Pass $EDITOR to the shell

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"testing"
 
 	"github.com/bmizerany/assert"
@@ -17,4 +18,32 @@ func TestWithArg(t *testing.T) {
 	execCmd.WithArg("command").WithArg("--amend").WithArg("-m").WithArg(`""`)
 	assert.Equal(t, "git", execCmd.Name)
 	assert.Equal(t, 4, len(execCmd.Args))
+}
+
+func TestInvokingShell(t *testing.T) {
+	sh := NewWithShell([]string{"$FOO", "hello"})
+	sh.WithArg("happy world")
+	defer func() {
+		os.Unsetenv("FOO")
+	}()
+
+	os.Setenv("FOO", "echo")
+
+	output, err := sh.Output()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "hello happy world\n", output)
+}
+
+func TestInvokingShellComplex(t *testing.T) {
+	sh := NewWithShell([]string{"$FOO hey", "hello"})
+	sh.WithArg("happy world")
+	defer func() {
+		os.Unsetenv("FOO")
+	}()
+
+	os.Setenv("FOO", "echo")
+
+	output, err := sh.Output()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "hey hello happy world\n", output)
 }

--- a/git/git.go
+++ b/git/git.go
@@ -139,7 +139,7 @@ func Editor() (string, error) {
 		return "", fmt.Errorf("Can't load git var: GIT_EDITOR")
 	}
 
-	return os.ExpandEnv(firstLine(output)), nil
+	return firstLine(output), nil
 }
 
 func Head() (string, error) {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -29,17 +29,12 @@ func TestGitEditor(t *testing.T) {
 		if err := os.Setenv("GIT_EDITOR", editor); err != nil {
 			t.Fatal(err)
 		}
-		os.Unsetenv("FOO")
-		os.Unsetenv("BAR")
 	}()
 
-	os.Setenv("FOO", "hello")
-	os.Setenv("BAR", "happy world")
-
-	SetGlobalConfig("core.editor", `$FOO "${BAR}"`)
+	SetGlobalConfig("core.editor", "foo")
 	gitEditor, err := Editor()
 	assert.Equal(t, nil, err)
-	assert.Equal(t, `hello "happy world"`, gitEditor)
+	assert.Equal(t, "foo", gitEditor)
 }
 
 func TestGitLog(t *testing.T) {

--- a/github/editor.go
+++ b/github/editor.go
@@ -142,9 +142,9 @@ func openTextEditor(program, file string) error {
 	if err != nil {
 		return err
 	}
-	editCmd := cmd.NewWithArray(programArgs)
+	editCmd := cmd.NewWithShell([]string{program})
 	r := regexp.MustCompile(`\b(?:[gm]?vim)(?:\.exe)?$`)
-	if r.MatchString(editCmd.Name) {
+	if r.MatchString(programArgs[0]) {
 		editCmd.WithArg("--cmd")
 		editCmd.WithArg("set ft=gitcommit tw=0 wrap lbr")
 	}


### PR DESCRIPTION
Several attempts have been made to provide better handling of the EDITOR and VISUAL environment variables. However, because these commands can contain arbitrary shell code, it isn't possible to provide correct behavior without actually invoking the shell.

Create a new function that invokes the shell with the proper arguments. For all editor invocations, invoke the shell in the way that Git does, even though this is incompatible with the way that other software behaves. For example, Git allows the use of "$@" directly in the command, while most other programs, including Debian's `sensible-editor` and Git LFS, require the user to wrap such commands in a shell function. It isn't possible to make it work in both cases, but we're trying to be like Git, so do what Git does.

Rewrite the command line in verbose output so we don't show the user the doubled argument we need to pass for things to work correctly. Also, stop expanding environment variables in the editor code path, since the shell will do that for us.

I'm not 100% certain that this will catch all Windows Git installations; it's possible that there are other custom ones that won't install things the same way. However, since Git doesn't tell us what the path is for its `sh`, we can't do anything but guess. This does work fine on macOS and Linux, and should be fine on all other Unix systems as well.

Fixes #1482.