### PR TITLE
Fix error message on hub --paginate

### DIFF
--- a/commands/runner.go
+++ b/commands/runner.go
@@ -122,6 +122,9 @@ func executeCommands(cmds []*cmd.Cmd, execFinal bool) error {
 
 func expandAlias(args *Args) {
 	cmd := args.Command
+	if cmd == "" {
+		return
+	}
 	expandedCmd, err := git.Alias(cmd)
 
 	if err == nil && expandedCmd != "" && !git.IsBuiltInGitCommand(cmd) {


### PR DESCRIPTION
Calling hub with one or more options but no subcommand resulted in the
following error message trying to expand an empty string as an alias:

	error: key does not contain variable name: alias.

This fixes the root cause: attempting to retrieve an invalid config key.