### PR TITLE
hub api url generation fixes

### DIFF
--- a/commands/api.go
+++ b/commands/api.go
@@ -193,8 +193,8 @@ func apiCommand(cmd *Command, args *Args) {
 	isGraphQL := path == "graphql"
 	if isGraphQL && params["query"] != nil {
 		query := params["query"].(string)
-		query = strings.Replace(query, quote("{owner}"), quote(owner), 1)
-		query = strings.Replace(query, quote("{repo}"), quote(repo), 1)
+		query = strings.Replace(query, "{owner}", owner, -1)
+		query = strings.Replace(query, "{repo}", repo, -1)
 
 		variables := make(map[string]interface{})
 		for key, value := range params {
@@ -209,8 +209,8 @@ func apiCommand(cmd *Command, args *Args) {
 
 		params["query"] = query
 	} else {
-		path = strings.Replace(path, "{owner}", owner, 1)
-		path = strings.Replace(path, "{repo}", repo, 1)
+		path = strings.Replace(path, "{owner}", owner, -1)
+		path = strings.Replace(path, "{repo}", repo, -1)
 	}
 
 	var body interface{}
@@ -329,8 +329,4 @@ func readFile(file string) (content []byte) {
 	}
 	utils.Check(err)
 	return
-}
-
-func quote(s string) string {
-	return fmt.Sprintf("%q", s)
 }

--- a/features/api.feature
+++ b/features/api.feature
@@ -294,6 +294,20 @@ Feature: hub api
       {"commits":12}
       """
 
+  Scenario: Multiple string interpolation
+    Given I am in "git://github.com/octocat/Hello-World.git" git repo
+    Given the GitHub API server:
+      """
+      get('/repos/octocat/Hello-World/pulls') {
+        json(params)
+      }
+      """
+    When I successfully run `hub api repos/{owner}/{repo}/pulls?head={owner}:{repo}`
+    Then the output should contain exactly:
+      """
+      {"head":"octocat:Hello-World"}
+      """
+
   Scenario: Repo context in graphql
     Given I am in "git://github.com/octocat/Hello-World.git" git repo
     Given the GitHub API server:
@@ -305,11 +319,11 @@ Feature: hub api
     When I run `hub api -t -F query=@- graphql` interactively
     And I pass in:
       """
-      repository(owner: "{owner}", name: "{repo}")
+      repository(owner: "{owner}", name: "{repo}", nameWithOwner: "{owner}/{repo}")
       """
     Then the output should contain exactly:
       """
-      .query	repository(owner: "octocat", name: "Hello-World")\n
+      .query	repository(owner: "octocat", name: "Hello-World", nameWithOwner: "octocat/Hello-World")\n
       """
 
   Scenario: Cache response


### PR DESCRIPTION
Fixes https://github.com/github/hub/issues/2234

- [x] Replace all occurrences of `{owner}` and `{repo}` in api paths and GraphQL queries
- [x] Add verbose mode to `hub api` to see generated URL