### PR TITLE
Make hub easier to use from GitHub Actions

### DIFF
--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -289,6 +289,31 @@ Feature: OAuth authentication
     And the output should not contain "github.com username"
     And the file "../home/.config/hub" should not exist
 
+  Scenario: Credentials from GITHUB_TOKEN and GITHUB_REPOSITORY
+    Given I am in "git://github.com/monalisa/playground.git" git repo
+    Given the GitHub API server:
+      """
+      get('/user') {
+        status 403
+        json :message => "Resource not accessible by integration",
+             :documentation_url => "https://developer.github.com/v3/users/#get-the-authenticated-user"
+      }
+      get('/repos/monalisa/playground/releases') {
+        halt 401 unless request.env["HTTP_AUTHORIZATION"] == "token OTOKEN"
+        json [
+          { tag_name: 'v1.2.0',
+          }
+        ]
+      }
+      """
+    Given $GITHUB_TOKEN is "OTOKEN"
+    Given $GITHUB_REPOSITORY is "mona-lisa/play-ground"
+    Given $GITHUB_USER is ""
+    When I successfully run `hub release show v1.2.0`
+    Then the output should not contain "github.com password"
+    And the output should not contain "github.com username"
+    And the file "../home/.config/hub" should not exist
+
   Scenario: Credentials from GITHUB_TOKEN override those from config file
     Given I am "mislav" on github.com with OAuth token "OTOKEN"
     Given the GitHub API server:

--- a/github/config.go
+++ b/github/config.go
@@ -88,6 +88,13 @@ func (c *Config) PromptForHost(host string) (h *Host, err error) {
 	}
 
 	userFromEnv := os.Getenv("GITHUB_USER")
+	repoFromEnv := os.Getenv("GITHUB_REPOSITORY")
+	if userFromEnv == "" && repoFromEnv != "" {
+		repoParts := strings.SplitN(repoFromEnv, "/", 2)
+		if len(repoParts) > 0 {
+			userFromEnv = repoParts[0]
+		}
+	}
 	if tokenFromEnv && userFromEnv != "" {
 		h.User = userFromEnv
 	} else {

--- a/share/man/man1/hub.1.md
+++ b/share/man/man1/hub.1.md
@@ -178,6 +178,11 @@ this can be affected with the `GITHUB_HOST` environment variable:
 `GITHUB_TOKEN`
 :   OAuth token to use for GitHub API requests.
 
+`GITHUB_REPOSITORY`
+:   A value in "OWNER/REPO" format that specifies the repository that API
+    operations should be performed against. Currently only used to infer the
+    default value of `GITHUB_USER` for API requests.
+
 ## Bugs
 
 <https://github.com/github/hub/issues>

--- a/share/man/man1/hub.1.md
+++ b/share/man/man1/hub.1.md
@@ -173,10 +173,21 @@ this can be affected with the `GITHUB_HOST` environment variable:
     searched for in `XDG_CONFIG_DIRS` per XDG Base Directory Specification.
 
 `HUB_PROTOCOL`
-:   Use one of "https|ssh|git" as preferred protocol for git clone/push.
+:   One of "https", "ssh", or "git" as preferred protocol for git clone/push.
+
+`GITHUB_HOST`
+:   The GitHub hostname to default to instead of "github.com".
 
 `GITHUB_TOKEN`
 :   OAuth token to use for GitHub API requests.
+
+`GITHUB_USER`
+:   The GitHub username of the actor of GitHub API operations.
+
+`GITHUB_PASSWORD`
+:   The GitHub password used to exchange user credentials for an OAuth token
+    that gets stored in hub configuration. If not set, it may be interactively
+    prompted for on first run.
 
 `GITHUB_REPOSITORY`
 :   A value in "OWNER/REPO" format that specifies the repository that API


### PR DESCRIPTION
Previously, hub enabled usage within Actions if GITHUB_USER was explicitly specified https://github.com/github/hub/releases/tag/v2.12.3

To make this step optional for the user, hub now infers GITHUB_USER from the first part of GITHUB_REPOSITORY which should be a value [set by default within Action runs](https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables).

Ref. https://github.com/github/hub/issues/2249