### PR TITLE
Add install script to use hub more easily in github actions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+
+PROJECT_NAME="hub"
+
+: ${USE_SUDO:="true"}
+: ${HUB_INSTALL_DIR:="/usr/local/bin"}
+
+# initArch discovers the architecture for this system.
+initArch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+    armv5*) ARCH="armv5";;
+    armv6*) ARCH="armv6";;
+    armv7*) ARCH="arm";;
+    aarch64) ARCH="arm64";;
+    x86) ARCH="386";;
+    x86_64) ARCH="amd64";;
+    i686) ARCH="386";;
+    i386) ARCH="386";;
+  esac
+}
+
+# initOS discovers the operating system for this system.
+initOS() {
+  OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+
+  case "$OS" in
+    # Minimalist GNU for Windows
+    mingw*) OS='windows';;
+  esac
+}
+
+# runs the given command as root (detects if we are root already)
+runAsRoot() {
+  local CMD="$*"
+
+  if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
+    CMD="sudo $CMD"
+  fi
+
+  $CMD
+}
+
+# verifySupported checks that the os/arch combination is supported for
+# binary builds.
+verifySupported() {
+  local supported="darwin-386\ndarwin-amd64\nfreebsd-386\nfreebas-amd64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nwindows-386\nwindows-amd64"
+  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+    echo "No prebuilt binary for ${OS}-${ARCH}."
+    echo "To build from source, go to https://github.com/helm/helm"
+    exit 1
+  fi
+
+  if ! type "curl" > /dev/null && ! type "wget" > /dev/null; then
+    echo "Either curl or wget is required"
+    exit 1
+  fi
+}
+
+# checkDesiredVersion checks if the desired version is available.
+checkDesiredVersion() {
+  if [ "x$DESIRED_VERSION" == "x" ]; then
+    # Get tag from release URL
+    local latest_release_url="https://github.com/github/hub/releases"
+    if type "curl" > /dev/null; then
+      TAG=$(curl -Ls -o /dev/null -w %{url_effective} $latest_release_url | grep -oE "[^/]+$" )
+    elif type "wget" > /dev/null; then
+      TAG=$(wget $latest_release_url --server-response -O /dev/null 2>&1 | awk '/^  Location: /{DEST=$2} END{ print DEST}' | grep -oE "[^/]+$")
+    fi
+  else
+    TAG=$DESIRED_VERSION
+  fi
+}
+
+# checkHubInstalledVersion checks which version of helm is installed and
+# if it needs to be changed.
+checkHubInstalledVersion() {
+  if [[ -f "${HUB_INSTALL_DIR}/${PROJECT_NAME}" ]]; then
+    local version="v"$("${HUB_INSTALL_DIR}/${PROJECT_NAME}" --version | grep 'hub version' | cut -d' ' -f3)
+    if [[ "$version" == "$TAG" ]]; then
+      echo "HUB ${version} is already ${DESIRED_VERSION:-latest}"
+      return 0
+    else
+      echo "HUB ${TAG} is available. Changing from version ${version}."
+      return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+# downloadFile downloads the latest binary package and also the checksum
+# for that binary.
+downloadFile() {
+  HUB_DIST="hub-$OS-$ARCH-$TAG.tgz"
+	DOWNLOAD_URL=$(
+    curl -s https://api.github.com/repos/github/hub/releases/tags/$TAG | \
+    jq -r '.assets[] | select(.name | test("'$OS'-'$ARCH'$")) | .browser_download_url'
+  )
+  
+  HUB_TMP_ROOT="$(mktemp -dt helm-installer-XXXXXX)"
+  HUB_TMP_FILE="$HUB_TMP_ROOT/$HUB_DIST"
+  
+  echo "Downloading $DOWNLOAD_URL"
+  if type "curl" > /dev/null; then
+    curl -SsL "$DOWNLOAD_URL" -o "$HUB_TMP_FILE"
+  elif type "wget" > /dev/null; then
+    wget -q -O "$HUB_TMP_FILE" "$DOWNLOAD_URL"
+  fi
+}
+
+# installFile verifies the SHA256 for the file, then unpacks and
+# installs it.
+installFile() {
+  HUB_TMP="$HUB_TMP_ROOT/$PROJECT_NAME"
+
+  mkdir -p "$HUB_TMP"
+  tar xf "$HUB_TMP_FILE" -C "$HUB_TMP"
+	HUB_DIST="hub-$OS-$ARCH-$TAG"
+  HUB_INSTALL_FILE="$HUB_TMP/$HUB_DIST/$PROJECT_NAME/install"
+
+  echo "Preparing to install $PROJECT_NAME into ${HUB_INSTALL_DIR}"
+	runAsRoot prefix=$HUB_INSTALL_DIR $HUB_INSTALL_FILE
+}
+
+# fail_trap is executed if an error occurs.
+fail_trap() {
+  result=$?
+  if [ "$result" != "0" ]; then
+    if [[ -n "$INPUT_ARGUMENTS" ]]; then
+      echo "Failed to install $PROJECT_NAME with the arguments provided: $INPUT_ARGUMENTS"
+      help
+    else
+      echo "Failed to install $PROJECT_NAME"
+    fi
+  fi
+  cleanup
+  exit $result
+}
+
+# testVersion tests the installed client to make sure it is working.
+testVersion() {
+  set +e
+  HUB="$(which $PROJECT_NAME)"
+  if [ "$?" = "1" ]; then
+    echo "$PROJECT_NAME not found. Is $HUB_INSTALL_DIR on your "'$PATH?'
+    exit 1
+  fi
+  set -e
+  echo "Run '$PROJECT_NAME init' to configure $PROJECT_NAME."
+}
+
+# help provides possible cli installation arguments
+help () {
+  echo "Accepted cli arguments are:"
+  echo -e "\t[--help|-h ] ->> prints this help"
+  echo -e "\t[--version|-v <desired_version>] . When not defined it defaults to latest"
+  echo -e "\te.g. --version v2.4.0  or -v latest"
+  echo -e "\t[--no-sudo]  ->> install without sudo"
+}
+
+# cleanup temporary files to avoid https://github.com/helm/helm/issues/2977
+cleanup() {
+  if [[ -d "${HUB_TMP_ROOT:-}" ]]; then
+    rm -rf "$HUB_TMP_ROOT"
+  fi
+}
+
+# Execution
+
+#Stop execution on any error
+trap "fail_trap" EXIT
+set -e
+
+# Parsing input arguments (if any)
+export INPUT_ARGUMENTS="${@}"
+set -u
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    '--version'|-v)
+       shift
+       if [[ $# -ne 0 ]]; then
+           export DESIRED_VERSION="${1}"
+       else
+           echo -e "Please provide the desired version. e.g. --version v2.4.0 or -v latest"
+           exit 0
+       fi
+       ;;
+    '--no-sudo')
+       USE_SUDO="false"
+       ;;
+    '--help'|-h)
+       help
+       exit 0
+       ;;
+    *) exit 1
+       ;;
+  esac
+  shift
+done
+set +u
+
+initArch
+initOS
+verifySupported
+checkDesiredVersion
+if ! checkHubInstalledVersion; then
+  downloadFile
+  installFile
+fi
+testVersion
+cleanup

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,7 @@ installFile() {
   HUB_INSTALL_FILE="$HUB_TMP/$HUB_DIST/install"
 
   echo "Preparing to install $PROJECT_NAME into ${HUB_INSTALL_DIR}"
-	runAsRoot prefix=$HUB_INSTALL_DIR $HUB_INSTALL_FILE
+	runAsRoot $HUB_INSTALL_FILE
 }
 
 # fail_trap is executed if an error occurs.

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 PROJECT_NAME="hub"
 
 : ${USE_SUDO:="true"}
-: ${HUB_INSTALL_DIR:="/usr/local/bin"}
+: ${HUB_INSTALL_DIR:="/usr/local"}
 
 # initArch discovers the architecture for this system.
 initArch() {

--- a/install.sh
+++ b/install.sh
@@ -87,6 +87,17 @@ downloadFile() {
   fi
 }
 
+# runs the given command as root (detects if we are root already)
+runAsRoot() {
+  local CMD="$*"
+
+  if { [ $EUID -ne 0 ] && [ $USE_SUDO = "true" ];}; then
+    CMD="sudo $CMD"
+  fi
+
+  $CMD
+}
+
 # installFile verifies the SHA256 for the file, then unpacks and
 # installs it.
 installFile() {
@@ -98,7 +109,7 @@ installFile() {
   HUB_INSTALL_FILE="$HUB_TMP/$HUB_DIST/install"
 
   echo "Preparing to install $PROJECT_NAME into ${HUB_INSTALL_DIR}"
-	prefix=$HUB_INSTALL_DIR $HUB_INSTALL_FILE
+	runAsRoot prefix=$HUB_INSTALL_DIR $HUB_INSTALL_FILE
 }
 
 # fail_trap is executed if an error occurs.

--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ checkHubInstalledVersion() {
 # for that binary.
 downloadFile() {
   HUB_DIST="hub-$OS-$ARCH-$TAG.tgz"
-	DOWNLOAD_URL=$(curl -s https://api.github.com/repos/github/hub/releases/tags/$TAG | grep -E 'browser_download_url": ".+linux-amd64.+\.tgz"' | sed 's/.+(https://[^"]+).+/\1/' | sed -E 's|.+(https://[^"]+).+|\1|')
+	DOWNLOAD_URL=$(curl -s https://api.github.com/repos/github/hub/releases/tags/$TAG | grep -E 'browser_download_url": ".+linux-amd64.+\.tgz"' | sed -E 's|.+(https://[^"]+).+|\1|')
 
   HUB_TMP_ROOT="$(mktemp -dt helm-installer-XXXXXX)"
   HUB_TMP_FILE="$HUB_TMP_ROOT/$HUB_DIST"

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ installFile() {
   mkdir -p "$HUB_TMP"
   tar xf "$HUB_TMP_FILE" -C "$HUB_TMP"
 	HUB_DIST="hub-$OS-$ARCH-$VERSION"
-  HUB_INSTALL_FILE="$HUB_TMP/$HUB_DIST/$PROJECT_NAME/install"
+  HUB_INSTALL_FILE="$HUB_TMP/$HUB_DIST/install"
 
   echo "Preparing to install $PROJECT_NAME into ${HUB_INSTALL_DIR}"
 	runAsRoot prefix=$HUB_INSTALL_DIR $HUB_INSTALL_FILE

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ verifySupported() {
   local supported="darwin-386\ndarwin-amd64\nfreebsd-386\nfreebas-amd64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-ppc64le\nwindows-386\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuilt binary for ${OS}-${ARCH}."
-    echo "To build from source, go to https://github.com/helm/helm"
+    echo "To build from source, go to https://github.com/github/hub"
     exit 1
   fi
 
@@ -60,9 +60,10 @@ verifySupported() {
 # checkDesiredVersion checks if the desired version is available.
 latest_release() {
 	TAG=$(curl --silent "https://api.github.com/repos/github/hub/releases/latest" | grep "tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
+	VERSION=$(echo $TAG | sed 's/v//')
 }
 
-# checkHubInstalledVersion checks which version of helm is installed and
+# checkHubInstalledVersion checks which version of hub is installed and
 # if it needs to be changed.
 checkHubInstalledVersion() {
   if [[ -f "${HUB_INSTALL_DIR}/${PROJECT_NAME}" ]]; then
@@ -85,7 +86,7 @@ downloadFile() {
   HUB_DIST="hub-$OS-$ARCH-$TAG.tgz"
 	DOWNLOAD_URL=$(curl -s https://api.github.com/repos/github/hub/releases/tags/$TAG | grep -E "browser_download_url\": \".+$OS-$ARCH.+\.tgz\"" | sed -E 's|.+(https://[^"]+).+|\1|')
 
-  HUB_TMP_ROOT="$(mktemp -dt helm-installer-XXXXXX)"
+  HUB_TMP_ROOT="$(mktemp -dt hub-installer-XXXXXX)"
   HUB_TMP_FILE="$HUB_TMP_ROOT/$HUB_DIST"
   
   echo "Downloading $DOWNLOAD_URL"
@@ -103,7 +104,7 @@ installFile() {
 
   mkdir -p "$HUB_TMP"
   tar xf "$HUB_TMP_FILE" -C "$HUB_TMP"
-	HUB_DIST="hub-$OS-$ARCH-$TAG"
+	HUB_DIST="hub-$OS-$ARCH-$VERSION"
   HUB_INSTALL_FILE="$HUB_TMP/$HUB_DIST/$PROJECT_NAME/install"
 
   echo "Preparing to install $PROJECT_NAME into ${HUB_INSTALL_DIR}"
@@ -146,7 +147,6 @@ help () {
   echo -e "\t[--no-sudo]  ->> install without sudo"
 }
 
-# cleanup temporary files to avoid https://github.com/helm/helm/issues/2977
 cleanup() {
   if [[ -d "${HUB_TMP_ROOT:-}" ]]; then
     rm -rf "$HUB_TMP_ROOT"

--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ checkHubInstalledVersion() {
 # for that binary.
 downloadFile() {
   HUB_DIST="hub-$OS-$ARCH-$TAG.tgz"
-	DOWNLOAD_URL=$(curl -s https://api.github.com/repos/github/hub/releases/tags/$TAG | grep -E 'browser_download_url": ".+linux-amd64.+\.tgz"' | sed -E 's|.+(https://[^"]+).+|\1|')
+	DOWNLOAD_URL=$(curl -s https://api.github.com/repos/github/hub/releases/tags/$TAG | grep -E "browser_download_url\": \".+$OS-$ARCH.+\.tgz\"" | sed -E 's|.+(https://[^"]+).+|\1|')
 
   HUB_TMP_ROOT="$(mktemp -dt helm-installer-XXXXXX)"
   HUB_TMP_FILE="$HUB_TMP_ROOT/$HUB_DIST"

--- a/install.sh
+++ b/install.sh
@@ -125,7 +125,7 @@ testVersion() {
     exit 1
   fi
   set -e
-  echo "Run '$PROJECT_NAME init' to configure $PROJECT_NAME."
+  echo "Ready to run $PROJECT_NAME"
 }
 
 # help provides possible cli installation arguments

--- a/install.sh
+++ b/install.sh
@@ -48,10 +48,22 @@ verifySupported() {
 }
 
 # checkDesiredVersion checks if the desired version is available.
-latest_release() {
-	TAG=$(curl --silent "https://api.github.com/repos/github/hub/releases/latest" | grep "tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
-	VERSION=$(echo $TAG | sed 's/v//')
-	echo "Latest version $VERSION"
+checkDesiredVersion() {
+	if [ "x$DESIRED_VERSION" == "x" ]; then
+		local latest_release_url="https://api.github.com/repos/github/hub/releases/latest"
+		if type "curl" > /dev/null; then
+      TAG=$(curl --silent $latest_release_url | grep "tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
+    elif type "wget" > /dev/null; then
+      TAG=$(wget -O - $latest_release_url | grep "tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
+    fi
+		
+		VERSION=$(echo $TAG | sed 's/v//')
+		echo "Latest version $VERSION"
+	else 
+		TAG="v$DESIRED_VERSION"
+		VERSION="$DESIRED_VERSION"
+
+	fi
 }
 
 # checkHubInstalledVersion checks which version of hub is installed and
@@ -145,7 +157,7 @@ help () {
   echo "Accepted cli arguments are:"
   echo -e "\t[--help|-h ] ->> prints this help"
   echo -e "\t[--version|-v <desired_version>] . When not defined it defaults to latest"
-  echo -e "\te.g. --version v2.4.0  or -v latest"
+  echo -e "\te.g. --version 2.4.0  or -v latest"
   echo -e "\t[--no-sudo]  ->> install without sudo"
 }
 
@@ -192,7 +204,7 @@ set +u
 initArch
 initOS
 verifySupported
-latest_release
+checkDesiredVersion
 if ! checkHubInstalledVersion; then
   downloadFile
   installFile

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,7 @@ verifySupported() {
 latest_release() {
 	TAG=$(curl --silent "https://api.github.com/repos/github/hub/releases/latest" | grep "tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
 	VERSION=$(echo $TAG | sed 's/v//')
+	echo "Latest version $VERSION"
 }
 
 # checkHubInstalledVersion checks which version of hub is installed and

--- a/install.sh
+++ b/install.sh
@@ -30,16 +30,6 @@ initOS() {
   esac
 }
 
-# runs the given command as root (detects if we are root already)
-runAsRoot() {
-  local CMD="$*"
-
-  if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
-    CMD="sudo $CMD"
-  fi
-
-  $CMD
-}
 
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
@@ -108,7 +98,7 @@ installFile() {
   HUB_INSTALL_FILE="$HUB_TMP/$HUB_DIST/install"
 
   echo "Preparing to install $PROJECT_NAME into ${HUB_INSTALL_DIR}"
-	runAsRoot prefix=$HUB_INSTALL_DIR $HUB_INSTALL_FILE
+	prefix=$HUB_INSTALL_DIR $HUB_INSTALL_FILE
 }
 
 # fail_trap is executed if an error occurs.


### PR DESCRIPTION
This script is directly inspired by https://github.com/helm/helm/blob/master/scripts/get

You can use it to install hub in command line easily using the following command:

`curl -qs https://raw.githubusercontent.com/vibou/hub/master/install.sh | env DESIRED_VERSION=2.12.3 bash -`

 If no version is specified the latest is used

`curl -qs https://raw.githubusercontent.com/vibou/hub/master/install.sh | bash -`

The script automatically detects the OS and the ARCH to download the correct release asset.
