### PR TITLE
add git log entries to pr edit mode with template

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -257,6 +257,18 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 	} else if args.Flag.HasReceived("--file") {
 		messageBuilder.Message, err = msgFromFile(args.Flag.Value("--file"))
 		utils.Check(err)
+		headForMessage := headTracking
+
+		commits, _ := git.RefList(baseTracking, headForMessage)
+
+		if len(commits) >= 1 {
+			commitLogs, err := git.Log(baseTracking, headForMessage)
+			utils.Check(err)
+
+			if commitLogs != "" {
+				messageBuilder.AddCommentedSection("\nChanges:\n\n" + strings.TrimSpace(commitLogs))
+			}
+		}
 		messageBuilder.Edit = flagPullRequestEdit
 	} else if args.Flag.Bool("--no-edit") {
 		commits, _ := git.RefList(baseTracking, head)


### PR DESCRIPTION
currently, when I use --file and --edit to open a pull request, I don't
see the commits contained in the PR like I would without --file/--edit.
I'd really like to have those as a reference for filling out my
template, so this change adds the git log entires into the messageBuilder even when --file has been received