### PR TITLE
Make a gist command

### DIFF
--- a/commands/gist.go
+++ b/commands/gist.go
@@ -19,14 +19,6 @@ cat <file> | gist create [--public]
 `,
 		Long: `Create a GitHub Gist
 
-Can both create and retrieve gists. With no arguements, it takes a file on
-stdin and creates a gist. With multiple '--file' arguments, will create a
-mult-file gist.
-
-If gistid is passed in, if there is only one file in the gist, it will be
-printed, otherwise will error if a specific file is not requested. However, if
-'--json' is used, then multiple files can be retreived.
-
 ## Commands:
 
     * _show_:

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -13,7 +13,7 @@ var (
 	cmdGist = &Command{
 		Run: printGistHelp,
 		Usage: `
-gist create [--public] [<FILES>...]
+gist create [-oc] [--public] [<FILES>...]
 gist show <ID> [<FILENAME>]
 `,
 		Long: `Create and print GitHub Gists

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"fmt"
-	"github.com/github/hub/github"
-	"github.com/github/hub/utils"
 	"os"
+
+	"github.com/github/hub/github"
+	"github.com/github/hub/ui"
+	"github.com/github/hub/utils"
 )
 
 var cmdGist = &Command{
@@ -107,14 +109,6 @@ func getGist(gh *github.Client, id string, filename string, no_headers bool) {
 	}
 }
 
-func putGist(gh *github.Client, file string, public bool) {
-	response, err := gh.Gist(file, public)
-	if err != nil {
-		fmt.Printf("ERROR: Unable to create gist. The most likely problem is your token doesn't have the 'gist' scope. Go to `github.com/settings/token`, edit the scopes and add 'gist'.\nFull error:\n\t%s", err)
-	}
-	fmt.Printf("%s\n", response.HtmlUrl)
-}
-
 func gist(cmd *Command, args *Args) {
 	args.NoForward()
 
@@ -132,12 +126,14 @@ func gist(cmd *Command, args *Args) {
 		if args.ParamsSize() > 1 {
 			filename = args.GetParam(1)
 		}
-		getGist(gh, id, filename, args.Flag.HasReceived("--no-headers"))
+		getGist(gh, id, filename, args.Flag.Bool("--no-headers"))
 	} else {
 		file := "-"
 		if args.Flag.HasReceived("--file") {
 			file = args.Flag.Value("--file")
 		}
-		putGist(gh, file, args.Flag.HasReceived("--public"))
+		g, err := gh.CreateGist(file, args.Flag.Bool("--public"))
+		utils.Check(err)
+		ui.Println(g.HtmlUrl)
 	}
 }

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -147,6 +147,10 @@ func createGist(cmd *Command, args *Args) {
 func showGist(cmd *Command, args *Args) {
 	args.NoForward()
 
+	if args.ParamsSize() < 1 {
+		utils.Check(cmd.UsageError("you must specify a gist ID"))
+	}
+
 	host, err := github.CurrentConfig().DefaultHostNoPrompt()
 	utils.Check(err)
 	gh := github.NewClient(host.Host)

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -13,62 +13,38 @@ var (
 	cmdGist = &Command{
 		Run: printGistHelp,
 		Usage: `
-gist show <GistID> [--json] [<filename>]
-gist create [--public] <file1> [<file2> ..]
-cat <file> | gist create [--public]
+gist create [--public] [<FILES>...]
+gist show [--json] <ID> [<FILENAME>]
 `,
-		Long: `Create a GitHub Gist
+		Long: `Create and print GitHub Gists
 
 ## Commands:
 
-    * _show_:
-        Show the gist <GistID>. If the gist has more than one file in it,
-        either a file must be specified, or --json must be used. When --json
-        is specified, filenames are ignored.
+	* _create_:
+		Create a new gist. If no <FILES> are specified, the content is read from
+		standard input.
 
-    * _create_:
-        Create a gist. If no files are specified, the file is content
-        is read from stdin. You may specify as many files as you want.
+    * _show_:
+		Print the contents of a gist. If the gist contains multiple files, the
+		operation will error out unless either <FILENAME> is specified or the
+		'--json' flag is used.
 
 ## Options:
 
     --public
-        The gist should be marked as public.
+        Make the new gist public (default: false).
 
     --json
         Print all files in the gist and emit them in JSON.
 
 ## Examples:
 
-    # Retrieve the contents of a gist with a single file
-    $ hub gist show 87560fa4ebcc8683f68ec04d9100ab1c
-    this is test content in testfile.txt in test gist
+	$ echo hello | hub gist create --public
 
-    # Retrieve same gist, but specify a single file
-    $ hub gist show 6188fb16b1a7df0f51a51e03b3a2b4e8 testfile1.txt
-    test content in testfile1.txt inside of test gist 2
+	$ hub gist create <file1> <file2>
 
-    # Retrieve same gist, with all files, using JSON
-    $ hub gist show --json 6188fb16b1a7df0f51a51e03b3a2b4e8
-    test content in testfile1.txt inside of test gist 2
-    more test content in testfile2.txt inside of test gist 2
-
-    # Create a gist:
-    $ cat /tmp/testfile | hub gist create
-    https://gist.github.com/bdf551042f77bb8431b99f13c1105168
-
-    # Or a public one:
-    $ cat /tmp/testfile | hub gist create --public
-    https://gist.github.com/6c925133a295f0c5ad61eafcf05fee30
-
-    # You can also specify a file directly
-    $ hub gist create /tmp/testfile
-    https://gist.github.com/bdf551042f77bb8431b99f13c1105168
-
-    # Or with multiple files
-    $ hub gist create /tmp/testfile /tmp/testfile2
-    https://gist.github.com/bdf551042f77bb8431b99f13c1105168
-
+    # print a specific file within a gist:
+    $ hub gist show <ID> testfile1.txt
 
 ## See also:
 

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -114,7 +114,7 @@ func printGistHelp(command *Command, args *Args) {
 func createGist(cmd *Command, args *Args) {
 	args.NoForward()
 
-	host, err := github.CurrentConfig().DefaultHost()
+	host, err := github.CurrentConfig().DefaultHostNoPrompt()
 	utils.Check(err)
 	gh := github.NewClient(host.Host)
 
@@ -132,7 +132,7 @@ func createGist(cmd *Command, args *Args) {
 func showGist(cmd *Command, args *Args) {
 	args.NoForward()
 
-	host, err := github.CurrentConfig().DefaultHost()
+	host, err := github.CurrentConfig().DefaultHostNoPrompt()
 	utils.Check(err)
 	gh := github.NewClient(host.Host)
 

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -1,0 +1,201 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/github/hub/github"
+	"github.com/github/hub/utils"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+var cmdGist = &Command{
+	Run: gist,
+	Usage: `
+gist <GistID> [--no-headers] [<filename>]
+gist [--public] --file <file>
+cat <file> | gist [--public]
+`,
+	Long: `Create a GitHub Gist
+
+Doesn't take any options. With no arguments, it assumes a file on stdin. With an arguement, it tries to display that gist ID. If there is a second arguement it'll print that filename (if it exists) from the gist.
+
+## Options:
+    --public
+        The gist should be marked as public.
+
+    --file <file>
+        The file to use. If not specified, or if the filename is "-", then
+        contents will be read from STDIN.
+
+    --no-headers
+        If there is more than one file in a gist, don't separate them by
+        headers, simply print them all out one after another.
+
+## Examples:
+
+    # Retrieve the contents of a gist with a single file
+    $ hub gist 87560fa4ebcc8683f68ec04d9100ab1c
+    this is test content in testfile.txt in test gist
+
+    # Retrieve the contents of a gist with multiple files
+    $ hub gist 6188fb16b1a7df0f51a51e03b3a2b4e8
+    GIST: test gist 2 (6188fb16b1a7df0f51a51e03b3a2b4e8)
+
+    ==== BEGIN testfile1.txt ====>
+    test content in testfile1.txt inside of test gist 2
+    <=== END testfile1.txt =======
+    ==== BEGIN testfile2.txt ====>
+    more test content in testfile2.txt inside of test gist 2
+    <=== END testfile2.txt =======
+
+    # Retrieve same gist, but specify a single file
+    $ hub gist 6188fb16b1a7df0f51a51e03b3a2b4e8 testfile1.txt
+    test content in testfile1.txt inside of test gist 2
+
+    # Retrieve same gist, with all files, but no headers
+    $ hub gist --no-headers 6188fb16b1a7df0f51a51e03b3a2b4e8
+    test content in testfile1.txt inside of test gist 2
+    more test content in testfile2.txt inside of test gist 2
+
+    # Create a gist:
+    $ cat /tmp/testfile | hub gist
+    https://gist.github.com/bdf551042f77bb8431b99f13c1105168
+
+    # Or a public one:
+    $ cat /tmp/testfile | hub gist --public
+    https://gist.github.com/6c925133a295f0c5ad61eafcf05fee30
+
+    # You can also specify a file directly
+    $ hub gist --file /tmp/testfile
+    https://gist.github.com/bdf551042f77bb8431b99f13c1105168
+
+## See also:
+
+hub(1), hub-api(1)
+`,
+}
+
+func init() {
+	CmdRunner.Use(cmdGist)
+}
+
+type Gist struct {
+	Files       map[string]GistFile `json:"files"`
+	Description string              `json:"description,omitempty"`
+	Id          string              `json:"id,omitempty"`
+	Public      bool                `json:"public"`
+}
+type GistFile struct {
+	Type     string `json:"type,omitempty"`
+	Language string `json:"language,omitempty"`
+	Content  string `json:"content"`
+}
+type GistResponse struct {
+	HtmlUrl string `json:"html_url"`
+}
+
+func getGist(gh *github.Client, id string, filename string, no_headers bool) {
+	path := "gists/" + id
+	var headers map[string]string
+	cacheTTL := 0
+
+	response, err := gh.GenericAPIRequest("GET", path, "", headers, cacheTTL)
+	utils.Check(err)
+
+	gist := Gist{}
+	response.Unmarshal(&gist)
+	response.Body.Close()
+	if filename != "" {
+		if val, err := gist.Files[filename]; err {
+			fmt.Printf("%s\n", val.Content)
+		} else {
+			fmt.Printf("No such file in that Gist\n")
+			os.Exit(1)
+		}
+	} else {
+		print_hdrs := len(gist.Files) != 1 && !no_headers
+		if print_hdrs {
+			fmt.Printf("GIST: %s (%s)\n\n", gist.Description, gist.Id)
+		}
+		for name, file := range gist.Files {
+			if print_hdrs {
+				fmt.Printf("==== BEGIN " + name + " ====>\n")
+			}
+			// yes, the printf is necessary to prevent it interpolating
+			// '%'s in the string as part of a format string.
+			fmt.Printf("%s\n", file.Content)
+			if print_hdrs {
+				fmt.Printf("<=== END " + name + " =======\n")
+			}
+		}
+	}
+}
+
+func putGist(gh *github.Client, file string, public bool) {
+	var content, name []byte
+	var err error
+	if file == "-" {
+		content, err = ioutil.ReadAll(os.Stdin)
+		name = []byte("hub_gist.txt")
+	} else {
+		content, err = ioutil.ReadFile(file)
+		name = []byte(path.Base(file))
+	}
+	utils.Check(err)
+	strcont := string(content)
+	gf := GistFile{Content: strcont}
+	gp := make(map[string]GistFile)
+	gp[string(name)] = gf
+	g := Gist{Files: gp, Public: public}
+	mybytes, _ := json.Marshal(g)
+	body := string(mybytes)
+	reader := strings.NewReader(body)
+
+	var headers map[string]string
+	cacheTTL := 0
+
+	response, err := gh.GenericAPIRequest("POST", "gists", reader, headers, cacheTTL)
+	utils.Check(err)
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(response.Body)
+	response.Body.Close()
+	if response.StatusCode > 299 {
+		fmt.Printf("ERROR: Unable to create gist: %s\n", buf.String())
+		return
+	}
+
+	gist_resp := GistResponse{}
+	json.Unmarshal(buf.Bytes(), &gist_resp)
+	fmt.Printf("%s\n", gist_resp.HtmlUrl)
+}
+
+func gist(cmd *Command, args *Args) {
+	args.NoForward()
+
+	localRepo, err := github.LocalRepo()
+	utils.Check(err)
+
+	project, err := localRepo.MainProject()
+	utils.Check(err)
+
+	gh := github.NewClient(project.Host)
+
+	if !args.IsParamsEmpty() {
+		id := args.GetParam(0)
+		filename := ""
+		if args.ParamsSize() > 1 {
+			filename = args.GetParam(1)
+		}
+		getGist(gh, id, filename, args.Flag.HasReceived("--no-headers"))
+	} else {
+		file := "-"
+		if args.Flag.HasReceived("--file") {
+			file = args.Flag.Value("--file")
+		}
+		putGist(gh, file, args.Flag.HasReceived("--public"))
+	}
+}

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -80,7 +80,7 @@ func init() {
 	CmdRunner.Use(cmdGist)
 }
 
-func getGist(gh *github.Client, id string, filename string, no_headers bool) error {
+func getGist(gh *github.Client, id string, filename string, includeHeaders bool) error {
 	gist, err := gh.FetchGist(id)
 	if err != nil {
 		return err
@@ -93,8 +93,8 @@ func getGist(gh *github.Client, id string, filename string, no_headers bool) err
 			return fmt.Errorf("no such file in gist")
 		}
 	} else {
-		print_hdrs := len(gist.Files) != 1 && !no_headers
-		if print_hdrs {
+		includeHeaders := includeHeaders && len(gist.Files) > 1
+		if includeHeaders {
 			ui.Printf("GIST: %s (%s)\n\n", gist.Description, gist.Id)
 		}
 
@@ -106,11 +106,11 @@ func getGist(gh *github.Client, id string, filename string, no_headers bool) err
 
 		for _, name := range filenames {
 			file := gist.Files[name]
-			if print_hdrs {
+			if includeHeaders {
 				ui.Printf("==== BEGIN %s ====>\n", name)
 			}
 			ui.Println(file.Content)
-			if print_hdrs {
+			if includeHeaders {
 				ui.Printf("<=== END %s =======\n", name)
 			}
 		}
@@ -131,7 +131,7 @@ func gist(cmd *Command, args *Args) {
 		if args.ParamsSize() > 1 {
 			filename = args.GetParam(1)
 		}
-		getGist(gh, id, filename, args.Flag.Bool("--no-headers"))
+		getGist(gh, id, filename, !args.Flag.Bool("--no-headers"))
 	} else {
 		file := "-"
 		if args.Flag.HasReceived("--file") {

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -1,144 +1,179 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
-	"sort"
 
 	"github.com/github/hub/github"
 	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 )
 
-var cmdGist = &Command{
-	Run: gist,
-	Usage: `
-gist <GistID> [--no-headers] [<filename>]
-gist [--public] --file <file>
-cat <file> | gist [--public]
+var (
+	cmdGist = &Command{
+		Run: printGistHelp,
+		Usage: `
+gist show <GistID> [--json] [<filename>]
+gist create [--public] <file1> [<file2> ..]
+cat <file> | gist create [--public]
 `,
-	Long: `Create a GitHub Gist
+		Long: `Create a GitHub Gist
 
-Doesn't take any options. With no arguments, it assumes a file on stdin. With an arguement, it tries to display that gist ID. If there is a second arguement it'll print that filename (if it exists) from the gist.
+Can both create and retrieve gists. With no arguements, it takes a file on
+stdin and creates a gist. With multiple '--file' arguments, will create a
+mult-file gist.
+
+If gistid is passed in, if there is only one file in the gist, it will be
+printed, otherwise will error if a specific file is not requested. However, if
+'--json' is used, then multiple files can be retreived.
+
+## Commands:
+
+    * _show_:
+        Show the gist <GistID>. If the gist has more than one file in it,
+        either a file must be specified, or --json must be used. When --json
+        is specified, filenames are ignored.
+
+    * _create_:
+        Create a gist. If no files are specified, the file is content
+        is read from stdin. You may specify as many files as you want.
 
 ## Options:
+
     --public
         The gist should be marked as public.
 
-    --file <file>
-        The file to use. If not specified, or if the filename is "-", then
-        contents will be read from STDIN.
-
-    --no-headers
-        If there is more than one file in a gist, don't separate them by
-        headers, simply print them all out one after another.
+    --json
+        Print all files in the gist and emit them in JSON.
 
 ## Examples:
 
     # Retrieve the contents of a gist with a single file
-    $ hub gist 87560fa4ebcc8683f68ec04d9100ab1c
+    $ hub gist show 87560fa4ebcc8683f68ec04d9100ab1c
     this is test content in testfile.txt in test gist
 
-    # Retrieve the contents of a gist with multiple files
-    $ hub gist 6188fb16b1a7df0f51a51e03b3a2b4e8
-    GIST: test gist 2 (6188fb16b1a7df0f51a51e03b3a2b4e8)
-
-    ==== BEGIN testfile1.txt ====>
-    test content in testfile1.txt inside of test gist 2
-    <=== END testfile1.txt =======
-    ==== BEGIN testfile2.txt ====>
-    more test content in testfile2.txt inside of test gist 2
-    <=== END testfile2.txt =======
-
     # Retrieve same gist, but specify a single file
-    $ hub gist 6188fb16b1a7df0f51a51e03b3a2b4e8 testfile1.txt
+    $ hub gist show 6188fb16b1a7df0f51a51e03b3a2b4e8 testfile1.txt
     test content in testfile1.txt inside of test gist 2
 
-    # Retrieve same gist, with all files, but no headers
-    $ hub gist --no-headers 6188fb16b1a7df0f51a51e03b3a2b4e8
+    # Retrieve same gist, with all files, using JSON
+    $ hub gist show --json 6188fb16b1a7df0f51a51e03b3a2b4e8
     test content in testfile1.txt inside of test gist 2
     more test content in testfile2.txt inside of test gist 2
 
     # Create a gist:
-    $ cat /tmp/testfile | hub gist
+    $ cat /tmp/testfile | hub gist create
     https://gist.github.com/bdf551042f77bb8431b99f13c1105168
 
     # Or a public one:
-    $ cat /tmp/testfile | hub gist --public
+    $ cat /tmp/testfile | hub gist create --public
     https://gist.github.com/6c925133a295f0c5ad61eafcf05fee30
 
     # You can also specify a file directly
-    $ hub gist --file /tmp/testfile
+    $ hub gist create /tmp/testfile
     https://gist.github.com/bdf551042f77bb8431b99f13c1105168
+
+    # Or with multiple files
+    $ hub gist create /tmp/testfile /tmp/testfile2
+    https://gist.github.com/bdf551042f77bb8431b99f13c1105168
+
 
 ## See also:
 
 hub(1), hub-api(1)
 `,
-}
+		KnownFlags: "\n",
+	}
+
+	cmdShowGist = &Command{
+		Key:        "show",
+		Run:        showGist,
+		KnownFlags: "--json",
+	}
+
+	cmdCreateGist = &Command{
+		Key:        "create",
+		Run:        createGist,
+		KnownFlags: "--public",
+	}
+)
 
 func init() {
+	cmdGist.Use(cmdShowGist)
+	cmdGist.Use(cmdCreateGist)
 	CmdRunner.Use(cmdGist)
 }
 
-func getGist(gh *github.Client, id string, filename string, includeHeaders bool) error {
+func getGist(gh *github.Client, id string, filename string, emitJson bool) error {
 	gist, err := gh.FetchGist(id)
 	if err != nil {
 		return err
 	}
 
-	if filename != "" {
+	if len(gist.Files) > 1 && !emitJson && filename == "" {
+		return fmt.Errorf("There are multiple files, you must specify one, or use --json")
+	}
+
+	if emitJson {
+		data, err := json.Marshal(gist.Files)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", data)
+	} else if filename != "" {
 		if val, ok := gist.Files[filename]; ok {
 			ui.Println(val.Content)
 		} else {
 			return fmt.Errorf("no such file in gist")
 		}
 	} else {
-		includeHeaders := includeHeaders && len(gist.Files) > 1
-		if includeHeaders {
-			ui.Printf("GIST: %s (%s)\n\n", gist.Description, gist.Id)
-		}
-
-		filenames := []string{}
+		/*
+		 * There's only one, but we don't know the name so a
+		 * loop us fine.
+		 */
 		for name := range gist.Files {
-			filenames = append(filenames, name)
-		}
-		sort.Strings(filenames)
-
-		for _, name := range filenames {
 			file := gist.Files[name]
-			if includeHeaders {
-				ui.Printf("==== BEGIN %s ====>\n", name)
-			}
 			ui.Println(file.Content)
-			if includeHeaders {
-				ui.Printf("<=== END %s =======\n", name)
-			}
 		}
 	}
 	return nil
 }
 
-func gist(cmd *Command, args *Args) {
+func printGistHelp(command *Command, args *Args) {
+	utils.Check(command.UsageError(""))
+}
+
+func createGist(cmd *Command, args *Args) {
 	args.NoForward()
 
 	host, err := github.CurrentConfig().DefaultHost()
 	utils.Check(err)
 	gh := github.NewClient(host.Host)
 
-	if !args.IsParamsEmpty() {
-		id := args.GetParam(0)
-		filename := ""
-		if args.ParamsSize() > 1 {
-			filename = args.GetParam(1)
-		}
-		getGist(gh, id, filename, !args.Flag.Bool("--no-headers"))
+	filenames := []string{}
+	if args.IsParamsEmpty() {
+		filenames = append(filenames, "-")
 	} else {
-		file := "-"
-		if args.Flag.HasReceived("--file") {
-			file = args.Flag.Value("--file")
-		}
-		g, err := gh.CreateGist(file, args.Flag.Bool("--public"))
-		utils.Check(err)
-		ui.Println(g.HtmlUrl)
+		filenames = args.Params
 	}
+	g, err := gh.CreateGist(filenames, args.Flag.Bool("--public"))
+	utils.Check(err)
+	ui.Println(g.HtmlUrl)
+}
+
+func showGist(cmd *Command, args *Args) {
+	args.NoForward()
+
+	host, err := github.CurrentConfig().DefaultHost()
+	utils.Check(err)
+	gh := github.NewClient(host.Host)
+
+	id := args.GetParam(0)
+	ui.Println("id is %s", id)
+	filename := ""
+	if args.ParamsSize() > 1 {
+		filename = args.GetParam(1)
+	}
+	err = getGist(gh, id, filename, args.Flag.Bool("--json"))
+	utils.Check(err)
 }

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -169,7 +169,6 @@ func showGist(cmd *Command, args *Args) {
 	gh := github.NewClient(host.Host)
 
 	id := args.GetParam(0)
-	ui.Println("id is %s", id)
 	filename := ""
 	if args.ParamsSize() > 1 {
 		filename = args.GetParam(1)

--- a/commands/gist.go
+++ b/commands/gist.go
@@ -112,13 +112,9 @@ func getGist(gh *github.Client, id string, filename string, no_headers bool) {
 func gist(cmd *Command, args *Args) {
 	args.NoForward()
 
-	localRepo, err := github.LocalRepo()
+	host, err := github.CurrentConfig().DefaultHost()
 	utils.Check(err)
-
-	project, err := localRepo.MainProject()
-	utils.Check(err)
-
-	gh := github.NewClient(project.Host)
+	gh := github.NewClient(host.Host)
 
 	if !args.IsParamsEmpty() {
 		id := args.GetParam(0)

--- a/commands/help.go
+++ b/commands/help.go
@@ -212,6 +212,7 @@ These GitHub commands are provided by hub:
    create         Create this repository on GitHub and add GitHub as origin
    delete         Delete a repository on GitHub
    fork           Make a fork of a remote repository on GitHub and add as remote
+   gist           Make a gist
    issue          List or create GitHub issues
    pr             List or checkout GitHub pull requests
    pull-request   Open a pull request on GitHub

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -11,7 +11,7 @@ Feature: OAuth authentication
 
       post('/authorizations') {
         assert_basic_auth 'mislav', 'kitty'
-        assert :scopes => ['repo'],
+        assert :scopes => ['repo', 'gist'],
                :note => "hub for #{machine_id}",
                :note_url => 'https://hub.github.com/'
         status 201

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -1,6 +1,5 @@
 Feature: hub gist
   Background:
-    Given I am in "git://github.com/octocat/Hello-World.git" git repo
     Given I am "octokitten" on github.com with OAuth token "OTOKEN"
 
   Scenario: Fetch a gist with a single file

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -73,14 +73,12 @@ Feature: hub gist
       my content is here
       """
 
-  Scenario: Creates a gist
+  Scenario: Create a gist from file
     Given the GitHub API server:
       """
       post('/gists') {
         status 201
-        json({
-          :html_url => 'http://gists.github.com/somehash',
-        })
+        json :html_url => 'http://gists.github.com/somehash'
       }
       """
     Given a file named "testfile.txt" with:
@@ -109,7 +107,7 @@ Feature: hub gist
     Then the output should contain exactly ""
     And "open http://gists.github.com/somehash" should be run
 
-  Scenario: Creates a gist with multiple files
+  Scenario: Create a gist with multiple files
     Given the GitHub API server:
       """
       post('/gists') {
@@ -130,6 +128,25 @@ Feature: hub gist
       this is another test file
       """
     When I successfully run `hub gist create testfile.txt testfile2.txt`
+    Then the output should contain exactly:
+      """
+      http://gists.github.com/somehash
+      """
+
+  Scenario: Create a gist from stdin
+    Given the GitHub API server:
+      """
+      post('/gists') {
+        halt 400 unless params[:files]["gistfile1.txt"]["content"] == "hello\n"
+        status 201
+        json :html_url => 'http://gists.github.com/somehash'
+      }
+      """
+    When I run `hub gist create` interactively
+    And I pass in:
+      """
+      hello
+      """
     Then the output should contain exactly:
       """
       http://gists.github.com/somehash

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -1,0 +1,123 @@
+Feature: hub gist
+  Background:
+    Given I am in "git://github.com/octocat/Hello-World.git" git repo
+    Given I am "octokitten" on github.com with OAuth token "OTOKEN"
+
+  Scenario: Fetch a gist with a single file
+    Given the GitHub API server:
+      """
+      get('/gists/myhash') {
+        json({
+          :files => {
+            'hub_gist1.txt' => {
+              'content' => "my content is here",
+            }
+          },
+          :description => "my gist",
+        })
+      }
+      """
+    When I successfully run `hub gist myhash`
+    Then the output should contain exactly:
+      """
+      my content is here
+      """
+  
+  Scenario: Fetch a gist with many files
+    Given the GitHub API server:
+      """
+      get('/gists/myhash') {
+        json({
+          :files => {
+            'hub_gist1.txt' => {
+              'content' => "my content is here"
+            },
+            'hub_gist2.txt' => {
+              'content' => "more content is here"
+            }
+          },
+          :description => "my gist",
+          :id => "myhash",
+        })
+      }
+      """
+    When I successfully run `hub gist myhash`
+    Then the output should contain exactly:
+      """
+GIST: my gist (myhash)
+
+==== BEGIN hub_gist1.txt ====>
+my content is here
+<=== END hub_gist1.txt =======
+==== BEGIN hub_gist2.txt ====>
+more content is here
+<=== END hub_gist2.txt =======
+      """
+
+  Scenario: Fetch a gist with many files while specifying a single one
+    Given the GitHub API server:
+      """
+      get('/gists/myhash') {
+        json({
+          :files => {
+            'hub_gist1.txt' => {
+              'content' => "my content is here"
+            },
+            'hub_gist2.txt' => {
+              'content' => "more content is here"
+            }
+          },
+          :description => "my gist",
+          :id => "myhash",
+        })
+      }
+      """
+    When I successfully run `hub gist myhash hub_gist1.txt`
+    Then the output should contain exactly:
+      """
+      my content is here
+      """
+
+  Scenario: Fetch a gist with many files without heders
+    Given the GitHub API server:
+      """
+      get('/gists/myhash') {
+        json({
+          :files => {
+            'hub_gist1.txt' => {
+              'content' => "my content is here"
+            },
+            'hub_gist2.txt' => {
+              'content' => "more content is here"
+            }
+          },
+          :description => "my gist",
+          :id => "myhash",
+        })
+      }
+      """
+    When I successfully run `hub gist myhash --no-headers`
+    # can't do "exactly" since the ordering of JSON hashes
+    # is not gauranteed, so just check for both lines
+    Then the output should contain "my content is here"
+    And the stdout should contain "more content is here"
+
+  Scenario: Creates a gist
+    Given the GitHub API server:
+      """
+      post('/gists') {
+        json({
+          :html_url => 'http://gists.github.com/somehash',
+        })
+      }
+      """
+    Given a file named "testfile.txt" with:
+      """
+      this is a test file
+      """
+    When I successfully run `hub gist --file testfile.txt`
+    Then the output should contain exactly:
+      """
+      http://gists.github.com/somehash
+      """
+

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -16,7 +16,7 @@ Feature: hub gist
         })
       }
       """
-    When I successfully run `hub gist myhash`
+    When I successfully run `hub gist show myhash`
     Then the output should contain exactly:
       """
       my content is here
@@ -40,17 +40,10 @@ Feature: hub gist
         })
       }
       """
-    When I successfully run `hub gist myhash`
+    When I successfully run `hub gist show myhash --json`
     Then the output should contain exactly:
       """
-GIST: my gist (myhash)
-
-==== BEGIN hub_gist1.txt ====>
-my content is here
-<=== END hub_gist1.txt =======
-==== BEGIN hub_gist2.txt ====>
-more content is here
-<=== END hub_gist2.txt =======
+      {"hub_gist1.txt":{"content":"my content is here","raw_url":""},"hub_gist2.txt":{"content":"more content is here","raw_url":""}}
       """
 
   Scenario: Fetch a gist with many files while specifying a single one
@@ -71,35 +64,10 @@ more content is here
         })
       }
       """
-    When I successfully run `hub gist myhash hub_gist1.txt`
+    When I successfully run `hub gist show myhash hub_gist1.txt`
     Then the output should contain exactly:
       """
       my content is here
-      """
-
-  Scenario: Fetch a gist with many files without heders
-    Given the GitHub API server:
-      """
-      get('/gists/myhash') {
-        json({
-          :files => {
-            'hub_gist1.txt' => {
-              'content' => "my content is here"
-            },
-            'hub_gist2.txt' => {
-              'content' => "more content is here"
-            }
-          },
-          :description => "my gist",
-          :id => "myhash",
-        })
-      }
-      """
-    When I successfully run `hub gist myhash --no-headers`
-    Then the output should contain exactly:
-      """
-      my content is here
-      more content is here
       """
 
   Scenario: Creates a gist
@@ -116,7 +84,31 @@ more content is here
       """
       this is a test file
       """
-    When I successfully run `hub gist --file testfile.txt`
+    When I successfully run `hub gist create testfile.txt`
+    Then the output should contain exactly:
+      """
+      http://gists.github.com/somehash
+      """
+
+  Scenario: Creates a gist with multiple files
+    Given the GitHub API server:
+      """
+      post('/gists') {
+        status 201
+        json({
+          :html_url => 'http://gists.github.com/somehash',
+        })
+      }
+      """
+    Given a file named "testfile.txt" with:
+      """
+      this is a test file
+      """
+    Given a file named "testfile2.txt" with:
+      """
+      this is another test file
+      """
+    When I successfully run `hub gist create testfile.txt testfile2.txt`
     Then the output should contain exactly:
       """
       http://gists.github.com/somehash

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -96,10 +96,11 @@ more content is here
       }
       """
     When I successfully run `hub gist myhash --no-headers`
-    # can't do "exactly" since the ordering of JSON hashes
-    # is not gauranteed, so just check for both lines
-    Then the output should contain "my content is here"
-    And the stdout should contain "more content is here"
+    Then the output should contain exactly:
+      """
+      my content is here
+      more content is here
+      """
 
   Scenario: Creates a gist
     Given the GitHub API server:

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -106,6 +106,7 @@ more content is here
     Given the GitHub API server:
       """
       post('/gists') {
+        status 201
         json({
           :html_url => 'http://gists.github.com/somehash',
         })

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -114,3 +114,44 @@ Feature: hub gist
       http://gists.github.com/somehash
       """
 
+  Scenario: Insufficient OAuth scopes
+    Given the GitHub API server:
+      """
+      post('/gists') {
+        status 404
+        response.headers['x-oauth-scopes'] = 'repos'
+        json({})
+      }
+      """
+    Given a file named "testfile.txt" with:
+      """
+      this is a test file
+      """
+    When I run `hub gist create testfile.txt`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      Error creating gist: Not Found (HTTP 404)
+      Go to https://github.com/settings/tokens and enable the 'gist' scope for hub\n
+      """
+
+  Scenario: Create error
+    Given the GitHub API server:
+      """
+      post('/gists') {
+        status 404
+        response.headers['x-oauth-scopes'] = 'repos, gist'
+        json({})
+      }
+      """
+    Given a file named "testfile.txt" with:
+      """
+      this is a test file
+      """
+    When I run `hub gist create testfile.txt`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      Error creating gist: Not Found (HTTP 404)\n
+      """
+

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -40,13 +40,16 @@ Feature: hub gist
         })
       }
       """
-    When I successfully run `hub gist show myhash --json`
-    Then the output should contain exactly:
+    When I run `hub gist show myhash`
+    Then the exit status should be 1
+    Then the output should contain:
       """
-      {"hub_gist1.txt":{"content":"my content is here","raw_url":""},"hub_gist2.txt":{"content":"more content is here","raw_url":""}}
+      the gist contains multiple files, you must specify one:\n
       """
+    And the output should contain "hub_gist1.txt"
+    And the output should contain "hub_gist2.txt"
 
-  Scenario: Fetch a gist with many files while specifying a single one
+  Scenario: Fetch a single file from gist
     Given the GitHub API server:
       """
       get('/gists/myhash') {

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -44,10 +44,10 @@ Feature: hub gist
     Then the exit status should be 1
     Then the stderr should contain:
       """
-      the gist contains multiple files, you must specify one:\n
+      This gist contains multiple files, you must specify one:
+        hub_gist1.txt
+        hub_gist2.txt
       """
-    And the stderr should contain "hub_gist1.txt"
-    And the stderr should contain "hub_gist2.txt"
 
   Scenario: Fetch a single file from gist
     Given the GitHub API server:

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -97,6 +97,8 @@ Feature: hub gist
     Given the GitHub API server:
       """
       post('/gists') {
+        halt 400 unless params[:files]["testfile.txt"]["content"]
+        halt 400 unless params[:files]["testfile2.txt"]["content"]
         status 201
         json({
           :html_url => 'http://gists.github.com/somehash',

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -42,12 +42,12 @@ Feature: hub gist
       """
     When I run `hub gist show myhash`
     Then the exit status should be 1
-    Then the output should contain:
+    Then the stderr should contain:
       """
       the gist contains multiple files, you must specify one:\n
       """
-    And the output should contain "hub_gist1.txt"
-    And the output should contain "hub_gist2.txt"
+    And the stderr should contain "hub_gist1.txt"
+    And the stderr should contain "hub_gist2.txt"
 
   Scenario: Fetch a single file from gist
     Given the GitHub API server:

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -93,6 +93,22 @@ Feature: hub gist
       http://gists.github.com/somehash
       """
 
+  Scenario: Open the new gist in a browser
+    Given the GitHub API server:
+      """
+      post('/gists') {
+        status 201
+        json :html_url => 'http://gists.github.com/somehash'
+      }
+      """
+    Given a file named "testfile.txt" with:
+      """
+      this is a test file
+      """
+    When I successfully run `hub gist create -o testfile.txt`
+    Then the output should contain exactly ""
+    And "open http://gists.github.com/somehash" should be run
+
   Scenario: Creates a gist with multiple files
     Given the GitHub API server:
       """

--- a/features/git_compatibility.feature
+++ b/features/git_compatibility.feature
@@ -21,6 +21,7 @@ Feature: git-hub compatibility
       create
       delete
       fork
+      gist
       issue
       pr
       pull-request

--- a/github/client.go
+++ b/github/client.go
@@ -873,7 +873,7 @@ func (client *Client) FindOrCreateToken(user, password, twoFactorCode string) (t
 	}
 
 	params := map[string]interface{}{
-		"scopes":   []string{"repo"},
+		"scopes":   []string{"repo", "gist"},
 		"note_url": OAuthAppURL,
 	}
 

--- a/github/client.go
+++ b/github/client.go
@@ -1008,27 +1008,31 @@ func (client *Client) FetchGist(id string) (gist *Gist, err error) {
 	return
 }
 
-func (client *Client) CreateGist(file string, public bool) (gist *Gist, err error) {
+func (client *Client) CreateGist(filenames []string, public bool) (gist *Gist, err error) {
 	api, err := client.simpleApi()
 	if err != nil {
 		return
 	}
-
-	var content []byte
-	basename := "gistfile1.txt"
-	if file == "-" {
-		content, err = ioutil.ReadAll(os.Stdin)
-	} else {
-		content, err = ioutil.ReadFile(file)
-		basename = path.Base(file)
-	}
-	if err != nil {
-		return
-	}
-
-	gf := GistFile{Content: string(content)}
 	files := map[string]GistFile{}
-	files[basename] = gf
+	var basename string
+	var content []byte
+	var gf GistFile
+
+	for _, file := range filenames {
+		if file == "-" {
+			content, err = ioutil.ReadAll(os.Stdin)
+			basename = "gistfile1.txt"
+		} else {
+			content, err = ioutil.ReadFile(file)
+			basename = path.Base(file)
+		}
+		if err != nil {
+			return
+		}
+		gf = GistFile{Content: string(content)}
+		files[basename] = gf
+	}
+
 	g := Gist{
 		Files:  files,
 		Public: public,

--- a/github/client.go
+++ b/github/client.go
@@ -993,7 +993,7 @@ func (client *Client) absolute(host string) *url.URL {
 	return u
 }
 
-func (client *Client) FetchGist(id string, filename string) (gist *Gist, err error) {
+func (client *Client) FetchGist(id string) (gist *Gist, err error) {
 	api, err := client.simpleApi()
 	if err != nil {
 		return


### PR DESCRIPTION
This addresses #2226 and #2116 by creating a `gist` subcommand.

This allows you to both create and retrieve gists. When creating a gist it can be public or private.

In order to do this, the `gist` scope is added to the token we request.

Closes: #2226
Closes: #2116

Signed-off-by: Phil Dibowitz <phil@ipom.com>