### PR TITLE
Fix parsing `~/.ssh/config` on Windows

### DIFF
--- a/git/ssh_config.go
+++ b/git/ssh_config.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -15,12 +17,16 @@ const (
 type SSHConfig map[string]string
 
 func newSSHConfigReader() *SSHConfigReader {
+	configFiles := []string{
+		"/etc/ssh_config",
+		"/etc/ssh/ssh_config",
+	}
+	if homedir, err := homedir.Dir(); err == nil {
+		userConfig := filepath.Join(homedir, ".ssh", "config")
+		configFiles = append([]string{userConfig}, configFiles...)
+	}
 	return &SSHConfigReader{
-		Files: []string{
-			filepath.Join(os.Getenv("HOME"), ".ssh/config"),
-			"/etc/ssh_config",
-			"/etc/ssh/ssh_config",
-		},
+		Files: configFiles,
 	}
 }
 


### PR DESCRIPTION
Use `homedir.Dir()` instead of `Getenv("HOME")` on Windows to look up `~/.ssh/config` in the correct location.

Fixes #2270