### PR TITLE
Implement PR merge command

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -223,7 +223,7 @@ These GitHub commands are provided by hub:
    fork           Make a fork of a remote repository on GitHub and add as remote
    gist           Make a gist
    issue          List or create GitHub issues
-   pr             List or checkout GitHub pull requests
+   pr             Manage GitHub pull requests
    pull-request   Open a pull request on GitHub
    release        List or create GitHub releases
    sync           Fetch git objects from upstream and update branches

--- a/github/client.go
+++ b/github/client.go
@@ -145,6 +145,21 @@ func (client *Client) CreatePullRequest(project *Project, params map[string]inte
 	return
 }
 
+func (client *Client) MergePullRequest(project *Project, prNumber int, params map[string]interface{}) (err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	res, err := api.PutJSON(fmt.Sprintf("repos/%s/%s/pulls/%d/merge", project.Owner, project.Name, prNumber), params)
+	if err = checkStatus(200, "merging pull request", res, err); err != nil {
+		return
+	}
+
+	res.Body.Close()
+	return
+}
+
 func (client *Client) RequestReview(project *Project, prNumber int, params map[string]interface{}) (err error) {
 	api, err := client.simpleApi()
 	if err != nil {

--- a/github/http.go
+++ b/github/http.go
@@ -445,6 +445,10 @@ func (c *simpleClient) PostJSONPreview(path string, payload interface{}, mimeTyp
 	})
 }
 
+func (c *simpleClient) PutJSON(path string, payload interface{}) (*simpleResponse, error) {
+	return c.jsonRequest("PUT", path, payload, nil)
+}
+
 func (c *simpleClient) PatchJSON(path string, payload interface{}) (*simpleResponse, error) {
 	return c.jsonRequest("PATCH", path, payload, nil)
 }


### PR DESCRIPTION
## Background

Initially this was just a small hack in my local `hub` repo. After having used it without any issues almost every day for the past two years, I thought I would open this PR for discussion to see if others are also interested.

Personally, I find it super convenient not having to open a browser/website to **merge a PR** (which I usually create from command line as well using `hub pull-request`).

## Details

The GitHub API has offered a "merge" functionality for a long time:

```
PUT /repos/:owner/:repo/pulls/:pull_number/merge
```

See https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button

So far, this was not supported by `hub`.

I added a new `hub pr merge <PR-NUMBER>` command that takes the PR number and merges the PR (if the user has write access to the repo).

Note: This is the first `PUT` route - I had to add a `PutJSON` function to `github/http.go`.

## Examples

```sh
$ hub pr list
      #1  Create README.md
```

```sh
# (Success case - PR 1 is merged, no output, exit code `0`)
$ hub pr merge 1
```

```sh
# (Error case, for example user has no write access)
$ hub pr merge 1
Error merging pull request: Not Found (HTTP 404)
Not Found
```

I also slightly updated the `hub pr` documentation to better reflect what it can do now.

```sh
$ hub
...
These GitHub commands are provided by hub:

...
   pr             Manage GitHub Pull Requests
...
```

```sh
$ hub merge
Usage: hub pr list [-s <STATE>] [-h <HEAD>] [-b <BASE>] [-o <SORT_KEY> [-^]] [-f <FORMAT>] [-L <LIMIT>]
       hub pr checkout <PR-NUMBER> [<BRANCH>]
       hub pr show [-uc] [-h <HEAD>]
       hub pr show [-uc] <PR-NUMBER>
       hub pr merge <PR-NUMBER>
```

## Future ideas

Some ideas for the future (either as part of this PR or a follow up PR):

- Improve error messages
- Support different merge methods
- Before the merge, see if all checks are configured and have passed - if not, abort merge
- Allow "force" merging (if checks have not passed, see previous point)
- Allow customizing the merge commit message
- Add an option to automatically delete the PR head branch after successful merge