### PR TITLE
Add completions for git fork

### DIFF
--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -224,12 +224,18 @@ EOF
     while [ $c -lt $cword ]; do
       i="${words[c]}"
       case "$i" in
-        --remote-name|--org)
+        --org)
           ((c++))
           flags=${flags/$i/}
           ;;
+        --remote-name)
+          ((c++))
+          flags=${flags/$i/}
+          flags=${flags/--no-remote/}
+          ;;
         --no-remote)
           flags=${flags/$i/}
+          flags=${flags/--remote-name/}
           ;;
       esac
       ((c++))

--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -218,13 +218,13 @@ EOF
     esac
   }
 
-  # hub fork [--no-remote] [--remote-name]
+  # hub fork [--no-remote] [--remote-name] [--org]
   _git_fork() {
-    local i c=2 flags="--no-remote --remote-name"
+    local i c=2 flags="--no-remote --remote-name --org"
     while [ $c -lt $cword ]; do
       i="${words[c]}"
       case "$i" in
-        --no-remote|--remote-name)
+        --no-remote|--remote-name|--org)
           flags=${flags/$i/}
           ;;
       esac

--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -218,19 +218,30 @@ EOF
     esac
   }
 
-  # hub fork [--no-remote] [--remote-name] [--org]
+  # hub fork [--no-remote] [--remote-name REMOTE] [--org ORGANIZATION]
   _git_fork() {
     local i c=2 flags="--no-remote --remote-name --org"
     while [ $c -lt $cword ]; do
       i="${words[c]}"
       case "$i" in
-        --no-remote|--remote-name|--org)
+        --remote-name|--org)
+          ((c++))
+          flags=${flags/$i/}
+          ;;
+        --no-remote)
           flags=${flags/$i/}
           ;;
       esac
       ((c++))
     done
-    __gitcomp "$flags"
+    case "$prev" in
+      --remote-name|--org)
+        COMPREPLY=()
+        ;;
+      *)
+        __gitcomp "$flags"
+        ;;
+    esac
   }
 
   # hub pull-request [-f] [-m <MESSAGE>|-F <FILE>|-i <ISSUE>|<ISSUE-URL>] [-b <BASE>] [-h <HEAD>] [-a <USER>] [-M <MILESTONE>] [-l <LABELS>]

--- a/etc/hub.bash_completion.sh
+++ b/etc/hub.bash_completion.sh
@@ -218,21 +218,19 @@ EOF
     esac
   }
 
-  # hub fork [--no-remote]
+  # hub fork [--no-remote] [--remote-name]
   _git_fork() {
-    local i c=2 remote=yes
+    local i c=2 flags="--no-remote --remote-name"
     while [ $c -lt $cword ]; do
       i="${words[c]}"
       case "$i" in
-        --no-remote)
-          unset remote
+        --no-remote|--remote-name)
+          flags=${flags/$i/}
           ;;
       esac
       ((c++))
     done
-    if [ -n "$remote" ]; then
-      __gitcomp "--no-remote"
-    fi
+    __gitcomp "$flags"
   }
 
   # hub pull-request [-f] [-m <MESSAGE>|-F <FILE>|-i <ISSUE>|<ISSUE-URL>] [-b <BASE>] [-h <HEAD>] [-a <USER>] [-M <MILESTONE>] [-l <LABELS>]

--- a/features/bash_completion.feature
+++ b/features/bash_completion.feature
@@ -35,7 +35,8 @@ Feature: bash tab-completion
 
   Scenario: Completion of fork argument
     When I type "git fork -" and press <Tab>
-    Then the command should expand to "git fork --no-remote"
+    When I press <Tab> again
+    Then the completion menu should offer "--no-remote --remote-name --org" unsorted
 
   Scenario: Completion of user/repo in "browse"
   Scenario: Completion of branch names in "compare"


### PR DESCRIPTION
Based on the manual page for git fork, this pull request adds `--remote-name` and `--org` completions, waiting for user-provided free-text as arguments to both. It also considers the `--remote-name` and `--no-remote` flags to be mutually exclusive. See commit messages for details.

Fixes #2108.