### PR TITLE
implement format for `pr show` for #2288

### DIFF
--- a/commands/pr.go
+++ b/commands/pr.go
@@ -31,7 +31,10 @@ pr show [-uc] [-f <FORMAT>] <PR-NUMBER>
 		Check out the head of a pull request in a new branch.
 
 	* _show_:
-		Open a pull request page in a web browser.
+		Open a pull request page in a web browser. When no <PR-NUMBER> is
+		specified, <HEAD> is used to look up open pull requests and defaults to
+		the current branch name. With '--format', print information about the
+		pull request instead of opening it.
 
 ## Options:
 

--- a/features/pr-show.feature
+++ b/features/pr-show.feature
@@ -44,17 +44,8 @@ Feature: hub pr show
       get('/repos/ashemesh/hub/pulls'){
         assert :state => "open",
                :head => "ashemesh:topic"
-        json [
-          { 
-            :html_url => "https://github.com/ashemesh/hub/pull/102",
-            :number => 102
-          },
-        ]
-      }
-
-      get('/repos/ashemesh/hub/pulls/102') {
-        json :number => 999,
-          :title => "First",
+        json [{
+          :number => 102,
           :state => "open",
           :base => {
             :ref => "master",
@@ -69,14 +60,16 @@ Feature: hub pr show
           :requested_teams => [
             { :slug => "troopers" },
             { :slug => "cantina-band" },
-          ]
+          ],
+          :html_url => "https://github.com/ashemesh/hub/pull/102",
+        }]
       }
       """
     When I successfully run `hub pr show -f "%sC%>(8)%i %rs%n"`
     Then "open https://github.com/ashemesh/hub/pull/102" should not be run
     And the output should contain exactly:
       """
-          #999 rey, github/troopers, github/cantina-band\n
+          #102 rey, github/troopers, github/cantina-band\n
       """
 
   Scenario: Current branch in fork
@@ -192,7 +185,7 @@ Feature: hub pr show
     Given the GitHub API server:
       """
       get('/repos/ashemesh/hub/pulls/102') {
-        json :number => 999,
+        json :number => 102,
           :title => "First",
           :state => "open",
           :base => {
@@ -215,7 +208,7 @@ Feature: hub pr show
     Then "open https://github.com/ashemesh/hub/pull/102" should not be run
     And the output should contain exactly:
       """
-          #999 rey, github/troopers, github/cantina-band\n
+          #102 rey, github/troopers, github/cantina-band\n
       """
 
   Scenario: Show pull request by invalid number

--- a/features/pr-show.feature
+++ b/features/pr-show.feature
@@ -35,6 +35,48 @@ Feature: hub pr show
     And the output should contain exactly:
       """
       https://github.com/ashemesh/hub/pull/102\n
+      """ 
+
+  Scenario: Format Current branch output URL
+    Given I am on the "topic" branch
+    Given the GitHub API server:
+      """
+      get('/repos/ashemesh/hub/pulls'){
+        assert :state => "open",
+               :head => "ashemesh:topic"
+        json [
+          { 
+            :html_url => "https://github.com/ashemesh/hub/pull/102",
+            :number => 102
+          },
+        ]
+      }
+
+      get('/repos/ashemesh/hub/pulls/102') {
+        json :number => 999,
+          :title => "First",
+          :state => "open",
+          :base => {
+            :ref => "master",
+            :label => "github:master",
+            :repo => { :owner => { :login => "github" } }
+          },
+          :head => { :ref => "patch-1", :label => "octocat:patch-1" },
+          :user => { :login => "octocat" },
+          :requested_reviewers => [
+            { :login => "rey" },
+          ],
+          :requested_teams => [
+            { :slug => "troopers" },
+            { :slug => "cantina-band" },
+          ]
+      }
+      """
+    When I successfully run `hub pr show -f "%sC%>(8)%i %rs%n"`
+    Then "open https://github.com/ashemesh/hub/pull/102" should not be run
+    And the output should contain exactly:
+      """
+          #999 rey, github/troopers, github/cantina-band\n
       """
 
   Scenario: Current branch in fork
@@ -145,6 +187,36 @@ Feature: hub pr show
   Scenario: Show pull request by number
     When I successfully run `hub pr show 102`
     Then "open https://github.com/ashemesh/hub/pull/102" should be run
+
+  Scenario: Format pull request by number
+    Given the GitHub API server:
+      """
+      get('/repos/ashemesh/hub/pulls/102') {
+        json :number => 999,
+          :title => "First",
+          :state => "open",
+          :base => {
+            :ref => "master",
+            :label => "github:master",
+            :repo => { :owner => { :login => "github" } }
+          },
+          :head => { :ref => "patch-1", :label => "octocat:patch-1" },
+          :user => { :login => "octocat" },
+          :requested_reviewers => [
+            { :login => "rey" },
+          ],
+          :requested_teams => [
+            { :slug => "troopers" },
+            { :slug => "cantina-band" },
+          ]
+      }
+      """
+    When I successfully run `hub pr show 102 -f "%sC%>(8)%i %rs%n"`
+    Then "open https://github.com/ashemesh/hub/pull/102" should not be run
+    And the output should contain exactly:
+      """
+          #999 rey, github/troopers, github/cantina-band\n
+      """
 
   Scenario: Show pull request by invalid number
     When I run `hub pr show XYZ`


### PR DESCRIPTION
Adds the same formatting for `pr show` that are used in `pr list`. The format option supercedes the copy `-c, --copy` or url `-u, --url` flags and instead prints out the information from the git api. I choose not to remove `--url` for now to not break any existing scripts that use that flag.