### PR TITLE
Support compressed man-pages

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -19,6 +19,10 @@ Feature: hub help
     When I successfully run `hub help -a`
     Then the output should contain "pull-request"
 
+  Scenario: Shows help for the hub command
+    When I successfully run `hub help hub`
+    Then the output should contain "hub(1) -- make git easier with GitHub"
+
   Scenario: Shows help for a subcommand
     When I successfully run `hub help hub-help`
-    Then the output should contain "`hub help` hub-<COMMAND>"
+    Then the output should contain "`hub help` hub-<COMMAND> [--plain-text]"

--- a/features/support/fakebin/man
+++ b/features/support/fakebin/man
@@ -1,2 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 echo man "$@" >> "$HOME"/.history
+
+# Requires man-pages to be built
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+MAN_DIR="$DIR/../../../share/man/man1/"
+
+if [ "$1" = "" ]; then
+  echo "What manual page do you want?"
+elif [ -f "$MAN_DIR/$1.1.md" ]; then
+  cat "$MAN_DIR/$1.1.md"
+else
+  echo "No manual entry for $1"
+  exit 1
+fi

--- a/script/test
+++ b/script/test
@@ -54,6 +54,7 @@ install_test() {
 
 [ -z "$HUB_COVERAGE" ] || script/coverage prepare
 script/build
+make man-pages
 go test ./... || STATUS="$?"
 script/ruby-test "$@" || STATUS="$?"
 [ -z "$HUB_COVERAGE" ] || script/coverage summarize "$min_coverage" || STATUS="$?"


### PR DESCRIPTION
Fixes #2228

This PR lets `man` handle the search for man-pages, so it doesn't matter if they're uncompressed, .gz, .bz2, etc. Instead of passing the full path to `man`, it will only pass the man-page name (e.g. `hub-sync`). Searching for local man-page files remains unchanged if `man` is not installed.

It took me some time to understand how everything works together with my changes, e.g. `cmd.Exec` replacing the current process (at least on mac), `man` not exiting with code `16` on every platform if the page couldn't be found, and the whole `fakebin` stuff, so I might've missed something that would've made things easier for me :P

## Open questions
1. Before continuing, is this the right direction?
2. `fakebin/man` and the test scenarios:

When initially running the test suite (after my changes), the scenario for getting help for a command didn't work anymore since `man` is replaced by the minimal `fakebin/man` script which didn't do anything special. Even if the original `man` was the one being used, it wouldn't find any installed man-pages, and since `cmd.Exec` replaces the current process, the `cmd.HelpText()` code won't ever be reached (as far as my tests showed). Previously this code was invoked in the error case when the local man-page file couldn't be found (which happened before running the `man` cmd).

So for now I added generating man-pages to the test script (the only ready-to-use "man-page" that is shipped with the repo is the `hub.1.md` file) and did some changes to imitate the original `man` binary to get the tests working again for all commands/subcommands.

I'm not sure this is the best solution (always building man-pages in that case), so I'm open for other ideas if this PR is heading in the right direction.

I hope what I wrote here makes sense or is at least somewhat understandable :P

Thanks!

PS: I also thought about running sth. like
```go
if _, err := man.CombinedOutput(); err != nil {
    return err
}
```
before running the actual command just to see if it exits with an error so I could return that error and fall back to `cmd.HelpText()`, but didn't really like running the command basically twice. Maybe you have a different opinion :)