### PR TITLE
[docs] Add link to apt package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Windows | [Chocolatey](https://chocolatey.org/) | `choco install hub`
 Fedora Linux | [DNF](https://fedoraproject.org/wiki/DNF) | `sudo dnf install hub`
 Arch Linux | [pacman](https://wiki.archlinux.org/index.php/pacman) | `sudo pacman -S hub`
 FreeBSD | [pkg(8)](http://man.freebsd.org/pkg/8) | `pkg install hub`
-Debian | apt | `sudo apt install hub`
+Debian | [apt(8)](https://manpages.debian.org/buster/apt/apt.8.en.html) | `sudo apt install hub`
 Ubuntu | [Snap](https://snapcraft.io) | `snap install hub --classic`
 
 #### Standalone


### PR DESCRIPTION
I just added a link to the apt package manager from Debian man pages. 