### PR TITLE
Remove redundant whitespace trim from editor

### DIFF
--- a/github/editor.go
+++ b/github/editor.go
@@ -78,7 +78,6 @@ func (e *Editor) EditContent() (content string, err error) {
 		return
 	}
 
-	b = bytes.TrimSpace(b)
 	reader := bytes.NewReader(b)
 	scanner := bufio.NewScanner(reader)
 	unquotedLines := []string{}


### PR DESCRIPTION
Preserves empty lines from to allow for empty title checks in pull_request.

Fixes: https://github.com/github/hub/issues/2305