### PR TITLE
Strip co-author from PR descriptions

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -286,7 +286,7 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 			message, err = git.Show(commits[0])
 			utils.Check(err)
 
-			re := regexp.MustCompile(`\nSigned-off-by:\s.*$`)
+			re := regexp.MustCompile(`\n\(Co-authored\|Signed-off\)-by:\s.*$`)
 			message = re.ReplaceAllString(message, "")
 		} else if len(commits) > 1 {
 			commitLogs, err := git.Log(baseTracking, headForMessage)

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -286,7 +286,7 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 			message, err = git.Show(commits[0])
 			utils.Check(err)
 
-			re := regexp.MustCompile(`\n(Co-authored|Signed-off)-by:\s[^\n]*`)
+			re := regexp.MustCompile(`\n(Co-authored-by|Signed-off-by):[^\n]+`)
 			message = re.ReplaceAllString(message, "")
 		} else if len(commits) > 1 {
 			commitLogs, err := git.Log(baseTracking, headForMessage)

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -286,7 +286,7 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 			message, err = git.Show(commits[0])
 			utils.Check(err)
 
-			re := regexp.MustCompile(`\n(Co-authored|Signed-off)-by:\s.*$`)
+			re := regexp.MustCompile(`\n(Co-authored|Signed-off)-by:\s[^\n]*$`)
 			message = re.ReplaceAllString(message, "")
 		} else if len(commits) > 1 {
 			commitLogs, err := git.Log(baseTracking, headForMessage)

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -286,7 +286,7 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 			message, err = git.Show(commits[0])
 			utils.Check(err)
 
-			re := regexp.MustCompile(`\n\(Co-authored\|Signed-off\)-by:\s.*$`)
+			re := regexp.MustCompile(`\n(Co-authored|Signed-off)-by:\s.*$`)
 			message = re.ReplaceAllString(message, "")
 		} else if len(commits) > 1 {
 			commitLogs, err := git.Log(baseTracking, headForMessage)

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -286,7 +286,7 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 			message, err = git.Show(commits[0])
 			utils.Check(err)
 
-			re := regexp.MustCompile(`\n(Co-authored|Signed-off)-by:\s[^\n]*$`)
+			re := regexp.MustCompile(`\n(Co-authored|Signed-off)-by:\s[^\n]*`)
 			message = re.ReplaceAllString(message, "")
 		} else if len(commits) > 1 {
 			commitLogs, err := git.Log(baseTracking, headForMessage)

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -135,6 +135,7 @@ Feature: hub pull-request
 
       Hello
       Signed-off-by: NAME <email@example.com>
+      Co-authored-by: NAME <email@example.com>
       """
     And the "topic" branch is pushed to "origin/topic"
     When I successfully run `hub pull-request`


### PR DESCRIPTION
The Signed-off-by string already gets stripped, so I extended the regular expression to also match Co-authored-by.

Resolves #2311