### PR TITLE
Honor the rate limit headers in "hub api"

### DIFF
--- a/commands/api.go
+++ b/commands/api.go
@@ -321,7 +321,7 @@ func pauseUntil(timestamp int) {
 	rollover := time.Unix(int64(timestamp)+1, 0)
 	duration := time.Until(rollover)
 	if duration > 0 {
-		ui.Errorf("API rate limit reached; pausing until %v ...\n", rollover)
+		ui.Errorf("API rate limit exceeded; pausing until %v ...\n", rollover)
 		time.Sleep(duration)
 	}
 }

--- a/features/api.feature
+++ b/features/api.feature
@@ -436,7 +436,7 @@ Feature: hub api
       }
       """
     When I successfully run `hub api --rate-limit --paginate hello`
-    Then the stderr should contain "API rate limit reached; pausing until "
+    Then the stderr should contain "API rate limit exceeded; pausing until "
 
   Scenario: Honor rate limit for 403s
     Given the GitHub API server:
@@ -453,4 +453,4 @@ Feature: hub api
       }
       """
     When I successfully run `hub api --rate-limit hello`
-    Then the stderr should contain "API rate limit reached; pausing until "
+    Then the stderr should contain "API rate limit exceeded; pausing until "

--- a/features/api.feature
+++ b/features/api.feature
@@ -421,3 +421,76 @@ Feature: hub api
     Given I am "octocat" on github.com with OAuth token "TOKEN2"
     When I run `hub api -t count --cache 5`
     Then it should pass with ".count	2"
+
+  Scenario: Honor rate limit by sleeping
+    Given the GitHub API server:
+      """
+      get('/hello') {
+        page = (params[:page] || 1).to_i
+        response.headers['X-Ratelimit-Remaining'] = '0'
+        # it doesn't matter, cucumber blanks the .sleep anyway
+        response.headers['X-Ratelimit-Reset'] = '1'
+        response.headers['Link'] = %(</hello?page=2>; rel="next") if page < 2
+        json [{}]
+      }
+      """
+    When I run `hub api --rate-limit --paginate hello`
+    Then the stderr should contain "Pausing until "
+
+    Given the GitHub API server:
+      """
+      get('/hello') {
+        page = (params[:page] || 1).to_i
+        response.headers['X-Ratelimit-Remaining'] = '0'
+        # it doesn't matter, cucumber blanks the .sleep anyway
+        response.headers['X-Ratelimit-Reset'] = '9999999999'
+        response.headers['Link'] = %(</hello2>; rel="next")
+        json [{}]
+      }
+      get('/hello2') {
+        status 403
+      }
+      """
+    When I run `hub api --paginate hello`
+    Then the exit status should be 22
+    And the stderr should contain exactly ""
+
+    Given the GitHub API server:
+      """
+      get('/hello') {
+        page = (params[:page] || 1).to_i
+        response.headers['X-Ratelimit-Remaining'] = 'hello world'
+        response.headers['X-Ratelimit-Reset'] = 'yankee doodle'
+        response.headers['Link'] = %(</hello2>; rel="next")
+        json [{:page => 1}]
+      }
+      get('/hello2') {
+        json [{:page => 2}]
+      }
+      """
+    When I run `hub api --rate-limit --paginate hello`
+    Then the stdout should contain exactly:
+      """
+      [{"page":1}]
+      [{"page":2}]
+      """
+    And the stderr should contain "Unable to parse"
+
+    Given the GitHub API server:
+      """
+      get('/hello') {
+        response.headers['Link'] = %(</hello2>; rel="next")
+        json [{:page => 1}]
+      }
+      get('/hello2') {
+        json [{:page => 2}]
+      }
+      """
+    # rate-limit should behave rationally even when missing the headers
+    When I run `hub api --rate-limit --paginate hello`
+    Then the stdout should contain exactly:
+      """
+      [{"page":1}]
+      [{"page":2}]
+      """
+    And the stderr should contain exactly ""

--- a/features/api.feature
+++ b/features/api.feature
@@ -437,3 +437,20 @@ Feature: hub api
       """
     When I successfully run `hub api --rate-limit --paginate hello`
     Then the stderr should contain "API rate limit reached; pausing until "
+
+  Scenario: Honor rate limit for 403s
+    Given the GitHub API server:
+      """
+      count = 0
+      get('/hello') {
+        count += 1
+        if count == 1
+          response.headers['X-Ratelimit-Remaining'] = '0'
+          response.headers['X-Ratelimit-Reset'] = Time.now.utc.to_i.to_s
+          halt 403
+        end
+        json [{}]
+      }
+      """
+    When I successfully run `hub api --rate-limit hello`
+    Then the stderr should contain "API rate limit reached; pausing until "

--- a/features/api.feature
+++ b/features/api.feature
@@ -454,3 +454,15 @@ Feature: hub api
       """
     When I successfully run `hub api --rate-limit hello`
     Then the stderr should contain "API rate limit exceeded; pausing until "
+
+  Scenario: 403 unrelated to rate limit
+    Given the GitHub API server:
+      """
+      get('/hello') {
+        response.headers['X-Ratelimit-Remaining'] = '1'
+        status 403
+      }
+      """
+    When I run `hub api --rate-limit hello`
+    Then the exit status should be 22
+    Then the stderr should not contain "API rate limit exceeded"

--- a/features/api.feature
+++ b/features/api.feature
@@ -435,8 +435,33 @@ Feature: hub api
         json [{}]
       }
       """
-    When I successfully run `hub api --rate-limit --paginate hello`
+    When I successfully run `hub api --obey-ratelimit --paginate hello`
     Then the stderr should contain "API rate limit exceeded; pausing until "
+
+  Scenario: Succumb to rate limit with pagination
+    Given the GitHub API server:
+      """
+      get('/hello') {
+        page = (params[:page] || 1).to_i
+        response.headers['X-Ratelimit-Remaining'] = '0'
+        response.headers['X-Ratelimit-Reset'] = Time.now.utc.to_i.to_s
+        if page == 2
+          status 403
+          json :message => "API rate limit exceeded"
+        else
+          response.headers['Link'] = %(</hello?page=#{page+1}>; rel="next")
+          json [{page:page}]
+        end
+      }
+      """
+    When I run `hub api --paginate -t hello`
+    Then the exit status should be 22
+    And the stderr should not contain "API rate limit exceeded"
+    And the stdout should contain exactly:
+      """
+      .[0].page	1
+      .message	API rate limit exceeded\n
+      """
 
   Scenario: Honor rate limit for 403s
     Given the GitHub API server:
@@ -452,7 +477,7 @@ Feature: hub api
         json [{}]
       }
       """
-    When I successfully run `hub api --rate-limit hello`
+    When I successfully run `hub api --obey-ratelimit hello`
     Then the stderr should contain "API rate limit exceeded; pausing until "
 
   Scenario: 403 unrelated to rate limit
@@ -463,6 +488,6 @@ Feature: hub api
         status 403
       }
       """
-    When I run `hub api --rate-limit hello`
+    When I run `hub api --obey-ratelimit hello`
     Then the exit status should be 22
     Then the stderr should not contain "API rate limit exceeded"

--- a/github/http.go
+++ b/github/http.go
@@ -32,6 +32,11 @@ const checksType = "application/vnd.github.antiope-preview+json;charset=utf-8"
 const draftsType = "application/vnd.github.shadow-cat-preview+json;charset=utf-8"
 const cacheVersion = 2
 
+const (
+	rateLimitRemainingHeader = "X-Ratelimit-Remaining"
+	rateLimitResetHeader     = "X-Ratelimit-Reset"
+)
+
 var inspectHeaders = []string{
 	"Authorization",
 	"X-GitHub-OTP",
@@ -516,4 +521,22 @@ func (res *simpleResponse) Link(name string) string {
 		}
 	}
 	return ""
+}
+
+func (res *simpleResponse) RateLimitRemaining() int {
+	if v := res.Header.Get(rateLimitRemainingHeader); len(v) > 0 {
+		if num, err := strconv.Atoi(v); err == nil {
+			return num
+		}
+	}
+	return -1
+}
+
+func (res *simpleResponse) RateLimitReset() int {
+	if v := res.Header.Get(rateLimitResetHeader); len(v) > 0 {
+		if ts, err := strconv.Atoi(v); err == nil {
+			return ts
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
Previously, calling `hub api --paginate` with any substantial list of results would exhaust the Ratelimit allocation, since `hub api` did not pause before requesting the next page. With this change, `hub api` will check the rate limit headers and sleep until "Reset" if calling for the next page would exceed the limit.