### PR TITLE
Have `release` fail fast when attempting to attach unavailable files

### DIFF
--- a/features/release.feature
+++ b/features/release.feature
@@ -453,7 +453,52 @@ MARKDOWN
     Then the output should contain exactly:
       """
       https://github.com/mislav/will_paginate/releases/v1.2.0
-      Attaching release asset `./hello-1.2.0.tar.gz'...\n
+      Attaching 1 asset...\n
+      """
+
+  Scenario: Create a release with some assets failing
+    Given the GitHub API server:
+      """
+      post('/repos/mislav/will_paginate/releases') {
+        status 201
+        json :tag_name => "v1.2.0",
+             :html_url => "https://github.com/mislav/will_paginate/releases/v1.2.0",
+             :upload_url => "https://uploads.github.com/uploads/assets{?name,label}"
+      }
+      post('/uploads/assets', :host_name => 'uploads.github.com') {
+        halt 422 if params[:name] == "two"
+        status 201
+      }
+      """
+    And a file named "one" with:
+      """
+      ONE
+      """
+    And a file named "two" with:
+      """
+      TWO
+      """
+    And a file named "three" with:
+      """
+      THREE
+      """
+    When I run `hub release create -m "m" v1.2.0 -a one -a two -a three`
+    Then the exit status should be 1
+    Then the stderr should contain exactly:
+      """
+      Attaching 3 assets...
+      The release was created, but attaching 2 assets failed. You can retry with:
+      hub release edit v1.2.0 -m '' -a two -a three
+      
+      Error uploading release asset: Unprocessable Entity (HTTP 422)\n
+      """
+
+  Scenario: Create a release with nonexistent asset
+    When I run `hub release create -m "hello" v1.2.0 -a "idontexis.tgz"`
+    Then the exit status should be 1
+    Then the stderr should contain exactly:
+      """
+      open idontexis.tgz: no such file or directory\n
       """
 
   Scenario: Open new release in web browser
@@ -586,7 +631,7 @@ MARKDOWN
     When I successfully run `hub release edit -m "" v1.2.0 -a hello-1.2.0.tar.gz`
     Then the output should contain exactly:
       """
-      Attaching release asset `hello-1.2.0.tar.gz'...\n
+      Attaching 1 asset...\n
       """
 
   Scenario: Edit release no tag

--- a/github/http.go
+++ b/github/http.go
@@ -434,20 +434,11 @@ func (c *simpleClient) PatchJSON(path string, payload interface{}) (*simpleRespo
 	return c.jsonRequest("PATCH", path, payload, nil)
 }
 
-func (c *simpleClient) PostFile(path, filename string) (*simpleResponse, error) {
-	stat, err := os.Stat(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	return c.performRequest("POST", path, file, func(req *http.Request) {
-		req.ContentLength = stat.Size()
+func (c *simpleClient) PostFile(path string, contents io.Reader, fileSize int64) (*simpleResponse, error) {
+	return c.performRequest("POST", path, contents, func(req *http.Request) {
+		if fileSize > 0 {
+			req.ContentLength = fileSize
+		}
 		req.Header.Set("Content-Type", "application/octet-stream")
 	})
 }


### PR DESCRIPTION
The files to attach are first opened for reading and only then is the release created/edited. This ensures that missing or unreadable asset files will fail the operation immediately instead of the release being created and assets failing to upload in the next step.

If some assets failed to upload due to server problems, have the error message indicate that the release was still created, but that the listed assets failed.For now, I want to avoid trying to make the `create` operation atomic, i.e. deleting the release on asset upload failure, since that might lead to complications with notifications/Actions that were triggered post-release.

Fixes #2315, ref. https://github.com/github/hub/issues/2197