### PR TITLE
Restructure manpage-based help format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /bin
 .bundle
 bundle/
+share/doc/*
 share/man/*
 !share/man/man1/hub.1.md
 tmp/

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,8 @@ share/man/.man-pages.stamp: $(HELP_ALL:=.md) ./man-template.html bin/md2roff
 		--date="$(BUILD_DATE)" --version="$(HUB_VERSION)" \
 		--template=./man-template.html \
 		share/man/man1/*.md
+	mkdir -p share/doc/hub-doc
+	mv share/man/*/*.html share/doc/hub-doc/
 	touch $@
 
 %.1.md: bin/hub

--- a/commands/help.go
+++ b/commands/help.go
@@ -3,11 +3,11 @@ package commands
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 
-	"github.com/github/hub/cmd"
 	"github.com/github/hub/ui"
 	"github.com/github/hub/utils"
 	"github.com/kballard/go-shellquote"
@@ -28,17 +28,7 @@ help hub-<COMMAND> [--plain-text]
 		Use this format to view help for hub extensions to an existing git command.
 
 	--plain-text
-		Skip man page lookup mechanism and display plain help text.
-
-## Lookup mechanism:
-
-On systems that have 'man', help pages are looked up in these directories
-relative to the hub install prefix:
-
-* man/<command>.1
-* share/man/man1/<command>.1
-
-On systems without 'man', help pages are looked up using the ".txt" extension.
+		Skip man page lookup mechanism and display raw help text.
 
 ## See also:
 
@@ -79,27 +69,29 @@ func runHelp(helpCmd *Command, args *Args) {
 		return
 	}
 
-	command := args.FirstParam()
+	cmdName := args.FirstParam()
 
-	if command == "hub" {
-		err := displayManPage("hub.1", args)
-		if err != nil {
-			utils.Check(err)
-		}
-	}
-
-	if c := lookupCmd(command); c != nil {
-		if !p.Bool("--plain-text") {
-			manPage := fmt.Sprintf("hub-%s.1", c.Name())
-			err := displayManPage(manPage, args)
-			if err == nil {
-				return
-			}
-		}
-
-		ui.Println(c.HelpText())
+	if cmdName == "hub" {
+		err := displayManPage("hub", args)
+		utils.Check(err)
 		args.NoForward()
+		return
 	}
+
+	foundCmd := lookupCmd(cmdName)
+	if foundCmd == nil {
+		return
+	}
+	args.NoForward()
+
+	if p.Bool("--plain-text") {
+		ui.Println(foundCmd.HelpText())
+		return
+	}
+
+	manPage := fmt.Sprintf("hub-%s", foundCmd.Name())
+	err := displayManPage(manPage, args)
+	utils.Check(err)
 }
 
 func runListCmds(cmd *Command, args *Args) {
@@ -120,15 +112,19 @@ func runListCmds(cmd *Command, args *Args) {
 	}
 }
 
+// On systems where `man` was found, invoke:
+//   MANPATH={PREFIX}/share/man:$MANPATH man <page>
+//
+// otherwise:
+//   less -R {PREFIX}/share/man/man1/<page>.1.txt
 func displayManPage(manPage string, args *Args) error {
 	var manArgs []string
 	manProgram, _ := utils.CommandPath("man")
 	if manProgram != "" {
 		manArgs = []string{manProgram}
 	} else {
-		manPage += ".txt"
-		manProgram = os.Getenv("PAGER")
-		if manProgram != "" {
+		manPage += ".1.txt"
+		if manProgram = os.Getenv("PAGER"); manProgram != "" {
 			var err error
 			manArgs, err = shellquote.Split(manProgram)
 			if err != nil {
@@ -144,36 +140,21 @@ func displayManPage(manPage string, args *Args) error {
 		return err
 	}
 
-	installPrefix := filepath.Join(filepath.Dir(programPath), "..")
-	manFile, err := localManPage(manPage, installPrefix)
-	if err != nil {
-		return err
-	}
-
-	manArgs = append(manArgs, manFile)
-	man := cmd.NewWithArray(manArgs)
-	if err = man.Run(); err == nil {
-		os.Exit(0)
+	env := os.Environ()
+	if strings.HasSuffix(manPage, ".txt") {
+		manFile := filepath.Join(programPath, "..", "..", "share", "man", "man1", manPage)
+		manArgs = append(manArgs, manFile)
 	} else {
-		os.Exit(1)
-	}
-	return nil
-}
-
-func localManPage(name, installPrefix string) (string, error) {
-	manPath := filepath.Join(installPrefix, "man", name)
-	_, err := os.Stat(manPath)
-	if err == nil {
-		return manPath, nil
+		manArgs = append(manArgs, manPage)
+		manPath := filepath.Join(programPath, "..", "..", "share", "man")
+		env = append(env, fmt.Sprintf("MANPATH=%s:%s", manPath, os.Getenv("MANPATH")))
 	}
 
-	manPath = filepath.Join(installPrefix, "share", "man", "man1", name)
-	_, err = os.Stat(manPath)
-	if err == nil {
-		return manPath, nil
-	} else {
-		return "", err
-	}
+	c := exec.Command(manArgs[0], manArgs[1:]...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Env = env
+	return c.Run()
 }
 
 func lookupCmd(name string) *Command {

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -56,6 +56,15 @@ func (r *Runner) Execute(cliArgs []string) error {
 		cmdName = args.Command
 	}
 
+	// make `<cmd> --help` equivalent to `help <cmd>`
+	if args.ParamsSize() == 1 && args.GetParam(0) == helpFlag {
+		if c := r.Lookup(cmdName); c != nil && !c.GitExtension {
+			args.ReplaceParam(0, cmdName)
+			args.Command = "help"
+			cmdName = args.Command
+		}
+	}
+
 	cmd := r.Lookup(cmdName)
 	if cmd != nil && cmd.Runnable() {
 		err := callRunnableCommand(cmd, args)

--- a/features/help.feature
+++ b/features/help.feature
@@ -26,3 +26,18 @@ Feature: hub help
   Scenario: Shows help for a hub command
     When I successfully run `hub help fork`
     Then "man hub-fork" should be run
+
+  Scenario: Show help in HTML format
+    When I successfully run `hub help -w fork`
+    Then "man hub-fork" should not be run
+    And "git web--browse PATH/hub-fork.1.html" should be run
+
+  Scenario: Show help in HTML format by default
+    Given I successfully run `git config --global help.format html`
+    When I successfully run `hub help fork`
+    Then "git web--browse PATH/hub-fork.1.html" should be run
+
+  Scenario: Override HTML format back to man
+    Given I successfully run `git config --global help.format html`
+    When I successfully run `hub help -m fork`
+    Then "man hub-fork" should be run

--- a/features/help.feature
+++ b/features/help.feature
@@ -19,6 +19,10 @@ Feature: hub help
     When I successfully run `hub help -a`
     Then the output should contain "pull-request"
 
-  Scenario: Shows help for a subcommand
+  Scenario: Shows help for a hub extension
     When I successfully run `hub help hub-help`
-    Then the output should contain "`hub help` hub-<COMMAND>"
+    Then "man hub-help" should be run
+
+  Scenario: Shows help for a hub command
+    When I successfully run `hub help fork`
+    Then "man hub-fork" should be run

--- a/features/help.feature
+++ b/features/help.feature
@@ -41,3 +41,12 @@ Feature: hub help
     Given I successfully run `git config --global help.format html`
     When I successfully run `hub help -m fork`
     Then "man hub-fork" should be run
+
+  Scenario: The --help flag opens man page
+    When I successfully run `hub fork --help`
+    Then "man hub-fork" should be run
+
+  Scenario: The --help flag expands alias first
+    Given I successfully run `git config --global alias.ci ci-status`
+    When I successfully run `hub ci --help`
+    Then "man hub-ci-status" should be run

--- a/features/support/fakebin/git
+++ b/features/support/fakebin/git
@@ -5,7 +5,15 @@
 set -e
 
 command="$1"
-[ "$command" = "config" ] || echo git "$@" >> "$HOME"/.history
+case "$command" in
+  "config" ) ;;
+  "web--browse" )
+    echo git web--browse PATH/$(basename "$2") >> "$HOME"/.history
+    ;;
+  * )
+    echo git "$@" >> "$HOME"/.history
+    ;;
+esac
 
 case "$command" in
   "--list-cmds="* )

--- a/script/install.sh
+++ b/script/install.sh
@@ -16,7 +16,7 @@ fi
 prefix="${PREFIX:-$prefix}"
 prefix="${prefix:-/usr/local}"
 
-for src in bin/hub share/man/*/*.1 share/vim/vimfiles/*/*.vim; do
+for src in bin/hub share/man/*/*.1 share/doc/*/*.html share/vim/vimfiles/*/*.vim; do
   dest="${DESTDIR}${prefix}/${src}"
   mkdir -p "${dest%/*}"
   [[ $src == share/* ]] && mode="644" || mode=755

--- a/script/package
+++ b/script/package
@@ -39,11 +39,10 @@ if [ "$os" = "windows" ]; then
   crlf README.md "${tmpdir}/README.txt"
   crlf LICENSE "${tmpdir}/LICENSE.txt"
   mkdir "${tmpdir}/help"
-  for man in share/man/*/*.html; do crlf "$man" "${tmpdir}/help/${man##*/}"; done
+  for man in share/doc/*/*.html; do crlf "$man" "${tmpdir}/help/${man##*/}"; done
   crlf script/install.bat "${tmpdir}/install.bat"
 else
   cp -R README.md LICENSE etc share "$tmpdir"
-  rm -rf "${tmpdir}/share/man/"*/*.html
   rm -rf "${tmpdir}/share/man/"*/*.md
   cp script/install.sh "${tmpdir}/install"
   chmod +x "${tmpdir}/install"

--- a/script/publish-release
+++ b/script/publish-release
@@ -20,7 +20,7 @@ publish_documentation() {
   pushd "$doc_dir"
 
   git rm hub*.html >/dev/null
-  cp ../share/man/*/*.html .
+  cp ../share/doc/*/*.html .
   git add hub*.html
   GIT_COMMITTER_NAME='Travis CI' GIT_COMMITTER_EMAIL='travis@travis-ci.org' \
     GIT_AUTHOR_NAME='Mislav Marohnić' GIT_AUTHOR_EMAIL='mislav@github.com' \

--- a/script/test
+++ b/script/test
@@ -44,6 +44,7 @@ check_formatting() {
 }
 
 install_test() {
+  mkdir -p share/doc/hub-doc
   touch share/man/man1/hub.1 share/doc/hub-doc/hub.1.html
   DESTDIR="$PWD/tmp/destdir" prefix=/my/prefix bash < script/install.sh
   test -x tmp/destdir/my/prefix/bin/hub

--- a/script/test
+++ b/script/test
@@ -44,12 +44,14 @@ check_formatting() {
 }
 
 install_test() {
-  touch share/man/man1/hub.1
+  touch share/man/man1/hub.1 share/doc/hub-doc/hub.1.html
   DESTDIR="$PWD/tmp/destdir" prefix=/my/prefix bash < script/install.sh
   test -x tmp/destdir/my/prefix/bin/hub
   test -e tmp/destdir/my/prefix/share/man/man1/hub.1
   test ! -x tmp/destdir/my/prefix/share/man/man1/hub.1
-  rm share/man/man1/hub.1
+  test -e tmp/destdir/my/prefix/share/doc/hub-doc/hub.1.html
+  test ! -x tmp/destdir/my/prefix/share/doc/hub-doc/hub.1.html
+  rm share/man/man1/hub.1 share/doc/hub-doc/hub.1.html
 }
 
 [ -z "$HUB_COVERAGE" ] || script/coverage prepare


### PR DESCRIPTION
- Support compressed man pages by delegating to `man <arg>`
- Enable `hub help --web <command>`
- Respect `git config help.format`

Fixes #2228, closes #2298