### PR TITLE
docs: remove `--classic` from Ubuntu install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Fedora Linux | [DNF](https://fedoraproject.org/wiki/DNF) | `sudo dnf install hub
 Arch Linux | [pacman](https://wiki.archlinux.org/index.php/pacman) | `sudo pacman -S hub`
 FreeBSD | [pkg(8)](http://man.freebsd.org/pkg/8) | `pkg install hub`
 Debian | [apt(8)](https://manpages.debian.org/buster/apt/apt.8.en.html) | `sudo apt install hub`
-Ubuntu | [Snap](https://snapcraft.io) | `snap install hub --classic`
+Ubuntu | [Snap](https://snapcraft.io) | `snap install hub`
 
 #### Standalone
 


### PR DESCRIPTION
I fee it's better to let snap explain to the user than to bypass that message:

```
$ snap install hub
error: This revision of snap "hub" was published using classic confinement and thus may perform
       arbitrary system changes outside of the security sandbox that snaps are usually confined to,
       which may put your system at risk.

       If you understand and want to proceed repeat the command including --classic.
```