### PR TITLE
Move regex compilation to package variables

### DIFF
--- a/commands/alias.go
+++ b/commands/alias.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/github/hub/ui"
@@ -115,8 +114,7 @@ end`
 			eval = `eval "$(hub alias -s)"`
 		}
 
-		indent := regexp.MustCompile(`(?m)^\t+`)
-		eval = indent.ReplaceAllStringFunc(eval, func(match string) string {
+		eval = indentRe.ReplaceAllStringFunc(eval, func(match string) string {
 			return strings.Repeat(" ", len(match)*4)
 		})
 

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -55,6 +55,12 @@ hub-apply(1), hub-cherry-pick(1), hub(1), git-am(1)
 `,
 }
 
+var (
+	gistRegexp   = regexp.MustCompile("^https?://gist\\.github\\.com/([\\w.-]+/)?([a-f0-9]+)")
+	commitRegexp = regexp.MustCompile("^(commit|pull/[0-9]+/commits)/([0-9a-f]+)")
+	pullRegexp   = regexp.MustCompile("^pull/([0-9]+)")
+)
+
 func init() {
 	CmdRunner.Use(cmdApply)
 	CmdRunner.Use(cmdAm)
@@ -67,9 +73,6 @@ func apply(command *Command, args *Args) {
 }
 
 func transformApplyArgs(args *Args) {
-	gistRegexp := regexp.MustCompile("^https?://gist\\.github\\.com/([\\w.-]+/)?([a-f0-9]+)")
-	commitRegexp := regexp.MustCompile("^(commit|pull/[0-9]+/commits)/([0-9a-f]+)")
-	pullRegexp := regexp.MustCompile("^pull/([0-9]+)")
 	for idx, arg := range args.Params {
 		var (
 			patch    io.ReadCloser

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -56,9 +56,9 @@ hub-apply(1), hub-cherry-pick(1), hub(1), git-am(1)
 }
 
 var (
-	gistRegexp   = regexp.MustCompile("^https?://gist\\.github\\.com/([\\w.-]+/)?([a-f0-9]+)")
-	commitRegexp = regexp.MustCompile("^(commit|pull/[0-9]+/commits)/([0-9a-f]+)")
-	pullRegexp   = regexp.MustCompile("^pull/([0-9]+)")
+	gistRe   = regexp.MustCompile("^https?://gist\\.github\\.com/([\\w.-]+/)?([a-f0-9]+)")
+	commitRe = regexp.MustCompile("^(commit|pull/[0-9]+/commits)/([0-9a-f]+)")
+	pullRe   = regexp.MustCompile("^pull/([0-9]+)")
 )
 
 func init() {
@@ -81,13 +81,13 @@ func transformApplyArgs(args *Args) {
 		projectURL, err := github.ParseURL(arg)
 		if err == nil {
 			gh := github.NewClient(projectURL.Project.Host)
-			if match := commitRegexp.FindStringSubmatch(projectURL.ProjectPath()); match != nil {
+			if match := commitRe.FindStringSubmatch(projectURL.ProjectPath()); match != nil {
 				patch, apiError = gh.CommitPatch(projectURL.Project, match[2])
-			} else if match := pullRegexp.FindStringSubmatch(projectURL.ProjectPath()); match != nil {
+			} else if match := pullRe.FindStringSubmatch(projectURL.ProjectPath()); match != nil {
 				patch, apiError = gh.PullRequestPatch(projectURL.Project, match[1])
 			}
 		} else {
-			match := gistRegexp.FindStringSubmatch(arg)
+			match := gistRe.FindStringSubmatch(arg)
 			if match != nil {
 				// TODO: support Enterprise gist
 				gh := github.NewClient(github.GitHubHost)

--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -49,7 +49,7 @@ func checkout(command *Command, args *Args) {
 	}
 
 	projectPath := url.ProjectPath()
-	if !pullURLRegex.MatchString(projectPath) {
+	if !pullURLRe.MatchString(projectPath) {
 		// not a valid PR URL
 		return
 	}
@@ -57,7 +57,7 @@ func checkout(command *Command, args *Args) {
 	err = sanitizeCheckoutFlags(args)
 	utils.Check(err)
 
-	id := pullURLRegex.FindStringSubmatch(projectPath)[1]
+	id := pullURLRe.FindStringSubmatch(projectPath)[1]
 	gh := github.NewClient(url.Project.Host)
 	pullRequest, err := gh.PullRequest(url.Project, id)
 	utils.Check(err)

--- a/commands/checkout.go
+++ b/commands/checkout.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/github/hub/git"
 	"github.com/github/hub/github"
@@ -49,7 +48,6 @@ func checkout(command *Command, args *Args) {
 		return
 	}
 
-	pullURLRegex := regexp.MustCompile("^pull/(\\d+)")
 	projectPath := url.ProjectPath()
 	if !pullURLRegex.MatchString(projectPath) {
 		// not a valid PR URL

--- a/commands/cherry_pick.go
+++ b/commands/cherry_pick.go
@@ -24,10 +24,10 @@ hub-am(1), hub(1), git-cherry-pick(1)
 }
 
 var (
-	shaRe              = "[a-f0-9]{7,40}"
-	commitRegex        = regexp.MustCompile(fmt.Sprintf("^commit/(%s)", shaRe))
-	pullRegex          = regexp.MustCompile(fmt.Sprintf(`^pull/(\d+)/commits/(%s)`, shaRe))
-	ownerWithShaRegexp = regexp.MustCompile(fmt.Sprintf("^(%s)@(%s)$", OwnerRe, shaRe))
+	shaReStr       = "[a-f0-9]{7,40}"
+	commitRegex    = regexp.MustCompile(fmt.Sprintf("^commit/(%s)", shaReStr))
+	pullRegex      = regexp.MustCompile(fmt.Sprintf(`^pull/(\d+)/commits/(%s)`, shaReStr))
+	ownerWithShaRe = regexp.MustCompile(fmt.Sprintf("^(%s)@(%s)$", OwnerReStr, shaReStr))
 )
 
 func init() {
@@ -68,7 +68,7 @@ func transformCherryPickArgs(args *Args) {
 			refspec = fmt.Sprintf("refs/pull/%s/head", pullId)
 		}
 	} else {
-		if matches := ownerWithShaRegexp.FindStringSubmatch(ref); len(matches) > 0 {
+		if matches := ownerWithShaRe.FindStringSubmatch(ref); len(matches) > 0 {
 			utils.Check(mainProjectErr)
 			project = mainProject
 			project.Owner = matches[1]

--- a/commands/clone.go
+++ b/commands/clone.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/github/hub/github"
@@ -75,10 +74,9 @@ func transformCloneArgs(args *Args) {
 	}
 	p.Parse(args.Params)
 
-	nameWithOwnerRegexp := regexp.MustCompile(NameWithOwnerRe)
 	for _, i := range p.PositionalIndices {
 		a := args.Params[i]
-		if nameWithOwnerRegexp.MatchString(a) && !isCloneable(a) {
+		if NameWithOwnerRe.MatchString(a) && !isCloneable(a) {
 			url := getCloneUrl(a, isSSH, args.Command != "submodule")
 			args.ReplaceParam(i, url)
 		}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -9,12 +9,12 @@ import (
 )
 
 var (
-	NameRe              = `[\w.-]+`
-	OwnerRe             = "[a-zA-Z0-9][a-zA-Z0-9-]*"
-	NameWithOwnerString = fmt.Sprintf(`^(%s/)?%s$`, OwnerRe, NameRe)
-	NameWithOwnerRe     = regexp.MustCompile(NameWithOwnerString)
+	NameReStr          = `[\w.-]+`
+	OwnerReStr         = "[a-zA-Z0-9][a-zA-Z0-9-]*"
+	NameWithOwnerReStr = fmt.Sprintf(`^(%s/)?%s$`, OwnerReStr, NameReStr)
+	NameWithOwnerRe    = regexp.MustCompile(NameWithOwnerReStr)
 
-	pullURLRegex = regexp.MustCompile("^pull/(\\d+)")
+	pullURLRe = regexp.MustCompile("^pull/(\\d+)")
 
 	usageRe          = regexp.MustCompile(`(?m)^([a-z-]+)(.*)$`)
 	headingRe        = regexp.MustCompile(`(?m)^(## .+):$`)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -11,7 +11,8 @@ import (
 var (
 	NameRe          = `[\w.-]+`
 	OwnerRe         = "[a-zA-Z0-9][a-zA-Z0-9-]*"
-	NameWithOwnerRe = fmt.Sprintf(`^(%s/)?%s$`, OwnerRe, NameRe)
+	NameWithOwnerString = fmt.Sprintf(`^(%s/)?%s$`, OwnerRe, NameRe)
+	NameWithOwnerRe = regexp.MustCompile(NameWithOwnerString)
 
 	CmdRunner = NewRunner()
 )

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -9,10 +9,17 @@ import (
 )
 
 var (
-	NameRe          = `[\w.-]+`
-	OwnerRe         = "[a-zA-Z0-9][a-zA-Z0-9-]*"
+	NameRe              = `[\w.-]+`
+	OwnerRe             = "[a-zA-Z0-9][a-zA-Z0-9-]*"
 	NameWithOwnerString = fmt.Sprintf(`^(%s/)?%s$`, OwnerRe, NameRe)
-	NameWithOwnerRe = regexp.MustCompile(NameWithOwnerString)
+	NameWithOwnerRe     = regexp.MustCompile(NameWithOwnerString)
+
+	pullURLRegex = regexp.MustCompile("^pull/(\\d+)")
+
+	usageRe          = regexp.MustCompile(`(?m)^([a-z-]+)(.*)$`)
+	headingRe        = regexp.MustCompile(`(?m)^(## .+):$`)
+	indentRe         = regexp.MustCompile(`(?m)^\t`)
+	definitionListRe = regexp.MustCompile(`(?m)^(\* )?([^#\s][^\n]*?):?\n\t`)
 
 	CmdRunner = NewRunner()
 )
@@ -111,7 +118,6 @@ func (c *Command) Synopsis() string {
 
 func (c *Command) HelpText() string {
 	usage := strings.Replace(c.Usage, "-^", "`-^`", 1)
-	usageRe := regexp.MustCompile(`(?m)^([a-z-]+)(.*)$`)
 	usage = usageRe.ReplaceAllString(usage, "`hub $1`$2  ")
 	usage = strings.TrimSpace(usage)
 
@@ -124,12 +130,9 @@ func (c *Command) HelpText() string {
 
 	long = strings.Replace(long, "'", "`", -1)
 	long = strings.Replace(long, "``", "'", -1)
-	headingRe := regexp.MustCompile(`(?m)^(## .+):$`)
 	long = headingRe.ReplaceAllString(long, "$1")
 
-	indentRe := regexp.MustCompile(`(?m)^\t`)
 	long = indentRe.ReplaceAllLiteralString(long, "")
-	definitionListRe := regexp.MustCompile(`(?m)^(\* )?([^#\s][^\n]*?):?\n\t`)
 	long = definitionListRe.ReplaceAllString(long, "$2\n:\t")
 
 	return fmt.Sprintf("hub-%s(1) -- %s\n===\n\n## Synopsis\n\n%s\n%s", c.Name(), desc, usage, long)

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"io/ioutil"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/bmizerany/assert"
@@ -126,21 +125,19 @@ func TestSubCommandCall(t *testing.T) {
 }
 
 func Test_NameWithOwnerRe(t *testing.T) {
-	re := regexp.MustCompile(NameWithOwnerRe)
+	assert.Equal(t, true, NameWithOwnerRe.MatchString("o/n"))
+	assert.Equal(t, true, NameWithOwnerRe.MatchString("own-er/my-project.git"))
+	assert.Equal(t, true, NameWithOwnerRe.MatchString("my-project.git"))
+	assert.Equal(t, true, NameWithOwnerRe.MatchString("my_project"))
+	assert.Equal(t, true, NameWithOwnerRe.MatchString("-dash"))
+	assert.Equal(t, true, NameWithOwnerRe.MatchString(".dotfiles"))
 
-	assert.Equal(t, true, re.MatchString("o/n"))
-	assert.Equal(t, true, re.MatchString("own-er/my-project.git"))
-	assert.Equal(t, true, re.MatchString("my-project.git"))
-	assert.Equal(t, true, re.MatchString("my_project"))
-	assert.Equal(t, true, re.MatchString("-dash"))
-	assert.Equal(t, true, re.MatchString(".dotfiles"))
-
-	assert.Equal(t, false, re.MatchString(""))
-	assert.Equal(t, false, re.MatchString("/"))
-	assert.Equal(t, false, re.MatchString(" "))
-	assert.Equal(t, false, re.MatchString("owner/na me"))
-	assert.Equal(t, false, re.MatchString("owner/na/me"))
-	assert.Equal(t, false, re.MatchString("own.er/name"))
-	assert.Equal(t, false, re.MatchString("own_er/name"))
-	assert.Equal(t, false, re.MatchString("-owner/name"))
+	assert.Equal(t, false, NameWithOwnerRe.MatchString(""))
+	assert.Equal(t, false, NameWithOwnerRe.MatchString("/"))
+	assert.Equal(t, false, NameWithOwnerRe.MatchString(" "))
+	assert.Equal(t, false, NameWithOwnerRe.MatchString("owner/na me"))
+	assert.Equal(t, false, NameWithOwnerRe.MatchString("owner/na/me"))
+	assert.Equal(t, false, NameWithOwnerRe.MatchString("own.er/name"))
+	assert.Equal(t, false, NameWithOwnerRe.MatchString("own_er/name"))
+	assert.Equal(t, false, NameWithOwnerRe.MatchString("-owner/name"))
 }

--- a/commands/compare.go
+++ b/commands/compare.go
@@ -61,9 +61,9 @@ hub-browse(1), hub(1)
 }
 
 var (
-	shaOrTag            = fmt.Sprintf("((?:%s:)?\\w(?:[\\w/.-]*\\w)?)", OwnerRe)
-	shaOrTagRange       = fmt.Sprintf("^%s\\.\\.%s$", shaOrTag, shaOrTag)
-	shaOrTagRangeRegexp = regexp.MustCompile(shaOrTagRange)
+	shaOrTagReStr      = fmt.Sprintf("((?:%s:)?\\w(?:[\\w/.-]*\\w)?)", OwnerReStr)
+	shaOrTagRangeReStr = fmt.Sprintf("^%s\\.\\.%s$", shaOrTagReStr, shaOrTagReStr)
+	shaOrTagRangeRe    = regexp.MustCompile(shaOrTagRangeReStr)
 )
 
 func init() {
@@ -136,7 +136,7 @@ func compare(command *Command, args *Args) {
 }
 
 func parseCompareRange(r string) string {
-	return shaOrTagRangeRegexp.ReplaceAllString(r, "$1...$2")
+	return shaOrTagRangeRe.ReplaceAllString(r, "$1...$2")
 }
 
 // characters we want to allow unencoded in compare views

--- a/commands/compare.go
+++ b/commands/compare.go
@@ -60,6 +60,12 @@ hub-browse(1), hub(1)
 `,
 }
 
+var (
+	shaOrTag            = fmt.Sprintf("((?:%s:)?\\w(?:[\\w/.-]*\\w)?)", OwnerRe)
+	shaOrTagRange       = fmt.Sprintf("^%s\\.\\.%s$", shaOrTag, shaOrTag)
+	shaOrTagRangeRegexp = regexp.MustCompile(shaOrTagRange)
+)
+
 func init() {
 	CmdRunner.Use(cmdCompare)
 }
@@ -130,9 +136,6 @@ func compare(command *Command, args *Args) {
 }
 
 func parseCompareRange(r string) string {
-	shaOrTag := fmt.Sprintf("((?:%s:)?\\w(?:[\\w/.-]*\\w)?)", OwnerRe)
-	shaOrTagRange := fmt.Sprintf("^%s\\.\\.%s$", shaOrTag, shaOrTag)
-	shaOrTagRangeRegexp := regexp.MustCompile(shaOrTagRange)
 	return shaOrTagRangeRegexp.ReplaceAllString(r, "$1...$2")
 }
 

--- a/commands/delete.go
+++ b/commands/delete.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/github/hub/github"
@@ -48,8 +47,7 @@ func deleteRepo(command *Command, args *Args) {
 		repoName = args.FirstParam()
 	}
 
-	re := regexp.MustCompile(NameWithOwnerRe)
-	if !re.MatchString(repoName) {
+	if !NameWithOwnerRe.MatchString(repoName) {
 		utils.Check(command.UsageError(""))
 	}
 

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -28,6 +28,12 @@ hub-remote(1), hub(1), git-fetch(1)
 `,
 }
 
+var (
+	ownerRegexp      = regexp.MustCompile(fmt.Sprintf("^%s$", OwnerRe))
+	commaPattern     = fmt.Sprintf("^%s(,%s)+$", OwnerRe, OwnerRe)
+	remoteNameRegexp = regexp.MustCompile(commaPattern)
+)
+
 func init() {
 	CmdRunner.Use(cmdFetch)
 }
@@ -48,7 +54,6 @@ func transformFetchArgs(args *Args) error {
 	currentProject, currentProjectErr := localRepo.CurrentProject()
 
 	projects := make(map[*github.Project]bool)
-	ownerRegexp := regexp.MustCompile(fmt.Sprintf("^%s$", OwnerRe))
 	for _, name := range names {
 		if ownerRegexp.MatchString(name) && !isCloneable(name) {
 			_, err := localRepo.RemoteByName(name)
@@ -81,8 +86,6 @@ func parseRemoteNames(args *Args) (names []string) {
 		}
 	} else if len(words) > 0 {
 		remoteName := words[0]
-		commaPattern := fmt.Sprintf("^%s(,%s)+$", OwnerRe, OwnerRe)
-		remoteNameRegexp := regexp.MustCompile(commaPattern)
 		if remoteNameRegexp.MatchString(remoteName) {
 			i := args.IndexOfParam(remoteName)
 			args.RemoveParam(i)

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -29,9 +29,9 @@ hub-remote(1), hub(1), git-fetch(1)
 }
 
 var (
-	ownerRegexp      = regexp.MustCompile(fmt.Sprintf("^%s$", OwnerRe))
-	commaPattern     = fmt.Sprintf("^%s(,%s)+$", OwnerRe, OwnerRe)
-	remoteNameRegexp = regexp.MustCompile(commaPattern)
+	ownerRe           = regexp.MustCompile(fmt.Sprintf("^%s$", OwnerReStr))
+	commaPatternReStr = fmt.Sprintf("^%s(,%s)+$", OwnerReStr, OwnerReStr)
+	remoteNameRe      = regexp.MustCompile(commaPatternReStr)
 )
 
 func init() {
@@ -55,7 +55,7 @@ func transformFetchArgs(args *Args) error {
 
 	projects := make(map[*github.Project]bool)
 	for _, name := range names {
-		if ownerRegexp.MatchString(name) && !isCloneable(name) {
+		if ownerRe.MatchString(name) && !isCloneable(name) {
 			_, err := localRepo.RemoteByName(name)
 			if err != nil {
 				utils.Check(currentProjectErr)
@@ -86,7 +86,7 @@ func parseRemoteNames(args *Args) (names []string) {
 		}
 	} else if len(words) > 0 {
 		remoteName := words[0]
-		if remoteNameRegexp.MatchString(remoteName) {
+		if remoteNameRe.MatchString(remoteName) {
 			i := args.IndexOfParam(remoteName)
 			args.RemoveParam(i)
 			names = strings.Split(remoteName, ",")

--- a/commands/init.go
+++ b/commands/init.go
@@ -34,7 +34,7 @@ hub-create(1), hub(1), git-init(1)
 `,
 }
 
-var hasValueRegexp = regexp.MustCompile("^--(template|separate-git-dir|shared)$")
+var hasValueRe = regexp.MustCompile("^--(template|separate-git-dir|shared)$")
 
 func init() {
 	CmdRunner.Use(cmdInit)
@@ -57,7 +57,7 @@ func transformInitArgs(args *Args) error {
 	// We assume this is the optional `directory` argument to git init.
 	for i := 0; i < args.ParamsSize(); i++ {
 		arg := args.Params[i]
-		if hasValueRegexp.MatchString(arg) {
+		if hasValueRe.MatchString(arg) {
 			i++
 		} else if !strings.HasPrefix(arg, "-") {
 			dirToInit = arg

--- a/commands/init.go
+++ b/commands/init.go
@@ -34,6 +34,8 @@ hub-create(1), hub(1), git-init(1)
 `,
 }
 
+var hasValueRegexp = regexp.MustCompile("^--(template|separate-git-dir|shared)$")
+
 func init() {
 	CmdRunner.Use(cmdInit)
 }
@@ -50,7 +52,6 @@ func transformInitArgs(args *Args) error {
 
 	var err error
 	dirToInit := "."
-	hasValueRegexp := regexp.MustCompile("^--(template|separate-git-dir|shared)$")
 
 	// Find the first argument that isn't related to any of the init flags.
 	// We assume this is the optional `directory` argument to git init.

--- a/commands/merge.go
+++ b/commands/merge.go
@@ -53,11 +53,11 @@ func transformMergeArgs(args *Args) error {
 	}
 
 	projectPath := url.ProjectPath()
-	if !pullURLRegex.MatchString(projectPath) {
+	if !pullURLRe.MatchString(projectPath) {
 		return nil
 	}
 
-	id := pullURLRegex.FindStringSubmatch(projectPath)[1]
+	id := pullURLRe.FindStringSubmatch(projectPath)[1]
 	gh := github.NewClient(url.Project.Host)
 	pullRequest, err := gh.PullRequest(url.Project, id)
 	if err != nil {

--- a/commands/merge.go
+++ b/commands/merge.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/github/hub/github"
 	"github.com/github/hub/utils"
@@ -53,7 +52,6 @@ func transformMergeArgs(args *Args) error {
 		return nil
 	}
 
-	pullURLRegex := regexp.MustCompile("^pull/(\\d+)")
 	projectPath := url.ProjectPath()
 	if !pullURLRegex.MatchString(projectPath) {
 		return nil

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -127,6 +127,9 @@ hub(1), hub-merge(1), hub-checkout(1)
 `,
 }
 
+var AuthorOrSignedRe = regexp.MustCompile(`\n(Co-authored-by|Signed-off-by):[^\n]+`)
+var issuesRe = regexp.MustCompile(`^issues\/(\d+)`)
+
 func init() {
 	CmdRunner.Use(cmdPullRequest)
 }
@@ -286,8 +289,7 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 			message, err = git.Show(commits[0])
 			utils.Check(err)
 
-			re := regexp.MustCompile(`\n(Co-authored-by|Signed-off-by):[^\n]+`)
-			message = re.ReplaceAllString(message, "")
+			message = AuthorOrSignedRe.ReplaceAllString(message, "")
 		} else if len(commits) > 1 {
 			commitLogs, err := git.Log(baseTracking, headForMessage)
 			utils.Check(err)
@@ -463,10 +465,9 @@ func parsePullRequestIssueNumber(url string) string {
 		return ""
 	}
 
-	r := regexp.MustCompile(`^issues\/(\d+)`)
 	p := u.ProjectPath()
-	if r.MatchString(p) {
-		return r.FindStringSubmatch(p)[1]
+	if issuesRe.MatchString(p) {
+		return issuesRe.FindStringSubmatch(p)[1]
 	}
 
 	return ""

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -42,6 +42,8 @@ hub-fork(1), hub(1), git-remote(1)
 `,
 }
 
+var OwnerAndNameRe = regexp.MustCompile(fmt.Sprintf(`^%s(/%s)?$`, OwnerRe, NameRe))
+
 func init() {
 	CmdRunner.Use(cmdRemote)
 }
@@ -57,8 +59,7 @@ func remote(command *Command, args *Args) {
 func transformRemoteArgs(args *Args) {
 	ownerWithName := args.LastParam()
 
-	re := regexp.MustCompile(fmt.Sprintf(`^%s(/%s)?$`, OwnerRe, NameRe))
-	if !re.MatchString(ownerWithName) {
+	if !OwnerAndNameRe.MatchString(ownerWithName) {
 		return
 	}
 	owner := ownerWithName

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/github/hub/git"
@@ -42,8 +41,6 @@ hub-fork(1), hub(1), git-remote(1)
 `,
 }
 
-var OwnerAndNameRe = regexp.MustCompile(fmt.Sprintf(`^%s(/%s)?$`, OwnerRe, NameRe))
-
 func init() {
 	CmdRunner.Use(cmdRemote)
 }
@@ -59,7 +56,7 @@ func remote(command *Command, args *Args) {
 func transformRemoteArgs(args *Args) {
 	ownerWithName := args.LastParam()
 
-	if !OwnerAndNameRe.MatchString(ownerWithName) {
+	if !NameWithOwnerRe.MatchString(ownerWithName) {
 		return
 	}
 	owner := ownerWithName

--- a/commands/remote_test.go
+++ b/commands/remote_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/github/hub/github"
 )
 
+var JingwenoGitRe = regexp.MustCompile("^git@github\\.com:jingweno/.+\\.git$")
+var MislavGitRe = regexp.MustCompile("^git@github\\.com:mislav/.+\\.git$")
+
 func TestTransformRemoteArgs(t *testing.T) {
 	repo := fixtures.SetupTestRepo()
 	defer repo.TearDown()
@@ -23,8 +26,7 @@ func TestTransformRemoteArgs(t *testing.T) {
 	assert.Equal(t, 3, args.ParamsSize())
 	assert.Equal(t, "add", args.FirstParam())
 	assert.Equal(t, "jingweno", args.GetParam(1))
-	reg := regexp.MustCompile("^git@github\\.com:jingweno/.+\\.git$")
-	assert.T(t, reg.MatchString(args.GetParam(2)))
+	assert.T(t, JingwenoGitRe.MatchString(args.GetParam(2)))
 
 	args = NewArgs([]string{"remote", "add", "-p", "mislav"})
 	transformRemoteArgs(args)
@@ -32,8 +34,7 @@ func TestTransformRemoteArgs(t *testing.T) {
 	assert.Equal(t, 3, args.ParamsSize())
 	assert.Equal(t, "add", args.FirstParam())
 	assert.Equal(t, "mislav", args.GetParam(1))
-	reg = regexp.MustCompile("^git@github\\.com:mislav/.+\\.git$")
-	assert.T(t, reg.MatchString(args.GetParam(2)))
+	assert.T(t, MislavGitRe.MatchString(args.GetParam(2)))
 
 	args = NewArgs([]string{"remote", "add", "origin"})
 	transformRemoteArgs(args)
@@ -41,8 +42,7 @@ func TestTransformRemoteArgs(t *testing.T) {
 	assert.Equal(t, 3, args.ParamsSize())
 	assert.Equal(t, "add", args.FirstParam())
 	assert.Equal(t, "origin", args.GetParam(1))
-	reg = regexp.MustCompile("^git@github\\.com:jingweno/.+\\.git$")
-	assert.T(t, reg.MatchString(args.GetParam(2)))
+	assert.T(t, JingwenoGitRe.MatchString(args.GetParam(2)))
 
 	args = NewArgs([]string{"remote", "add", "jingweno", "git@github.com:jingweno/gh.git"})
 	transformRemoteArgs(args)

--- a/commands/remote_test.go
+++ b/commands/remote_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/github/hub/github"
 )
 
-var JingwenoGitRe = regexp.MustCompile("^git@github\\.com:jingweno/.+\\.git$")
-var MislavGitRe = regexp.MustCompile("^git@github\\.com:mislav/.+\\.git$")
+var jingwenoGitRe = regexp.MustCompile("^git@github\\.com:jingweno/.+\\.git$")
+var mislavGitRe = regexp.MustCompile("^git@github\\.com:mislav/.+\\.git$")
 
 func TestTransformRemoteArgs(t *testing.T) {
 	repo := fixtures.SetupTestRepo()
@@ -26,7 +26,7 @@ func TestTransformRemoteArgs(t *testing.T) {
 	assert.Equal(t, 3, args.ParamsSize())
 	assert.Equal(t, "add", args.FirstParam())
 	assert.Equal(t, "jingweno", args.GetParam(1))
-	assert.T(t, JingwenoGitRe.MatchString(args.GetParam(2)))
+	assert.T(t, jingwenoGitRe.MatchString(args.GetParam(2)))
 
 	args = NewArgs([]string{"remote", "add", "-p", "mislav"})
 	transformRemoteArgs(args)
@@ -34,7 +34,7 @@ func TestTransformRemoteArgs(t *testing.T) {
 	assert.Equal(t, 3, args.ParamsSize())
 	assert.Equal(t, "add", args.FirstParam())
 	assert.Equal(t, "mislav", args.GetParam(1))
-	assert.T(t, MislavGitRe.MatchString(args.GetParam(2)))
+	assert.T(t, mislavGitRe.MatchString(args.GetParam(2)))
 
 	args = NewArgs([]string{"remote", "add", "origin"})
 	transformRemoteArgs(args)
@@ -42,7 +42,7 @@ func TestTransformRemoteArgs(t *testing.T) {
 	assert.Equal(t, 3, args.ParamsSize())
 	assert.Equal(t, "add", args.FirstParam())
 	assert.Equal(t, "origin", args.GetParam(1))
-	assert.T(t, JingwenoGitRe.MatchString(args.GetParam(2)))
+	assert.T(t, jingwenoGitRe.MatchString(args.GetParam(2)))
 
 	args = NewArgs([]string{"remote", "add", "jingweno", "git@github.com:jingweno/gh.git"})
 	transformRemoteArgs(args)

--- a/commands/sync.go
+++ b/commands/sync.go
@@ -34,6 +34,8 @@ hub(1), git-fetch(1)
 `,
 }
 
+var configRe = regexp.MustCompile(`^branch\.(.+?)\.remote (.+)`)
+
 func init() {
 	CmdRunner.Use(cmdSync)
 }
@@ -57,7 +59,6 @@ func sync(cmd *Command, args *Args) {
 
 	branchToRemote := map[string]string{}
 	if lines, err := git.ConfigAll("branch.*.remote"); err == nil {
-		configRe := regexp.MustCompile(`^branch\.(.+?)\.remote (.+)`)
 
 		for _, line := range lines {
 			if matches := configRe.FindStringSubmatch(line); len(matches) > 0 {

--- a/git/ssh_config.go
+++ b/git/ssh_config.go
@@ -16,6 +16,9 @@ const (
 
 type SSHConfig map[string]string
 
+var hostRe = regexp.MustCompile(hostReStr)
+var expandTokensRe = regexp.MustCompile(`%[%h]`)
+
 func newSSHConfigReader() *SSHConfigReader {
 	configFiles := []string{
 		"/etc/ssh_config",
@@ -36,7 +39,6 @@ type SSHConfigReader struct {
 
 func (r *SSHConfigReader) Read() SSHConfig {
 	config := make(SSHConfig)
-	hostRe := regexp.MustCompile(hostReStr)
 
 	for _, filename := range r.Files {
 		r.readFile(config, hostRe, filename)
@@ -77,8 +79,7 @@ func (r *SSHConfigReader) readFile(c SSHConfig, re *regexp.Regexp, f string) err
 }
 
 func expandTokens(text, host string) string {
-	re := regexp.MustCompile(`%[%h]`)
-	return re.ReplaceAllStringFunc(text, func(match string) string {
+	return expandTokensRe.ReplaceAllStringFunc(text, func(match string) string {
 		switch match {
 		case "%h":
 			return host

--- a/github/branch.go
+++ b/github/branch.go
@@ -13,20 +13,23 @@ type Branch struct {
 	Name string
 }
 
+var (
+	shortRemoteRe = regexp.MustCompile("^refs/(remotes/)?.+?/")
+	longRemoteRe  = regexp.MustCompile("^refs/(remotes/)?")
+	remoteRe      = regexp.MustCompile("^refs/remotes/([^/]+)")
+)
+
 func (b *Branch) ShortName() string {
-	reg := regexp.MustCompile("^refs/(remotes/)?.+?/")
-	return reg.ReplaceAllString(b.Name, "")
+	return shortRemoteRe.ReplaceAllString(b.Name, "")
 }
 
 func (b *Branch) LongName() string {
-	reg := regexp.MustCompile("^refs/(remotes/)?")
-	return reg.ReplaceAllString(b.Name, "")
+	return longRemoteRe.ReplaceAllString(b.Name, "")
 }
 
 func (b *Branch) RemoteName() string {
-	reg := regexp.MustCompile("^refs/remotes/([^/]+)")
-	if reg.MatchString(b.Name) {
-		return reg.FindStringSubmatch(b.Name)[1]
+	if remoteRe.MatchString(b.Name) {
+		return remoteRe.FindStringSubmatch(b.Name)[1]
 	}
 
 	return ""

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/bmizerany/assert"
 )
 
+var Hub1Re = regexp.MustCompile("hub for (.+)@(.+)")
+
+var Hub2Re = regexp.MustCompile("hub for (.+)@(.+) 2")
+
 func TestClient_FormatError(t *testing.T) {
 	e := &errorInfo{
 		Response: &http.Response{
@@ -35,13 +39,11 @@ func TestAuthTokenNote(t *testing.T) {
 	note, err := authTokenNote(1)
 	assert.Equal(t, nil, err)
 
-	reg := regexp.MustCompile("hub for (.+)@(.+)")
-	assert.T(t, reg.MatchString(note))
+	assert.T(t, Hub1Re.MatchString(note))
 
 	note, err = authTokenNote(2)
 	assert.Equal(t, nil, err)
 
-	reg = regexp.MustCompile("hub for (.+)@(.+) 2")
-	assert.T(t, reg.MatchString(note))
+	assert.T(t, Hub2Re.MatchString(note))
 
 }

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/bmizerany/assert"
 )
 
-var Hub1Re = regexp.MustCompile("hub for (.+)@(.+)")
+var hub1Re = regexp.MustCompile("hub for (.+)@(.+)")
 
-var Hub2Re = regexp.MustCompile("hub for (.+)@(.+) 2")
+var hub2Re = regexp.MustCompile("hub for (.+)@(.+) 2")
 
 func TestClient_FormatError(t *testing.T) {
 	e := &errorInfo{
@@ -39,11 +39,11 @@ func TestAuthTokenNote(t *testing.T) {
 	note, err := authTokenNote(1)
 	assert.Equal(t, nil, err)
 
-	assert.T(t, Hub1Re.MatchString(note))
+	assert.T(t, hub1Re.MatchString(note))
 
 	note, err = authTokenNote(2)
 	assert.Equal(t, nil, err)
 
-	assert.T(t, Hub2Re.MatchString(note))
+	assert.T(t, hub2Re.MatchString(note))
 
 }

--- a/github/editor.go
+++ b/github/editor.go
@@ -17,6 +17,8 @@ import (
 
 const Scissors = "------------------------ >8 ------------------------"
 
+var textEditorRe = regexp.MustCompile(`\b(?:[gm]?vim)(?:\.exe)?$`)
+
 func NewEditor(filename, topic, message string) (editor *Editor, err error) {
 	gitDir, err := git.Dir()
 	if err != nil {
@@ -143,8 +145,7 @@ func openTextEditor(program, file string) error {
 		return err
 	}
 	editCmd := cmd.NewWithArray(programArgs)
-	r := regexp.MustCompile(`\b(?:[gm]?vim)(?:\.exe)?$`)
-	if r.MatchString(editCmd.Name) {
+	if textEditorRe.MatchString(editCmd.Name) {
 		editCmd.WithArg("--cmd")
 		editCmd.WithArg("set ft=gitcommit tw=0 wrap lbr")
 	}

--- a/github/http.go
+++ b/github/http.go
@@ -45,8 +45,8 @@ var inspectHeaders = []string{
 	"Accept",
 }
 
-var BasicOrTokenRe = regexp.MustCompile("(?i)^(basic|token) (.+)")
-var RelRe = regexp.MustCompile(`<([^>]+)>; rel="([^"]+)"`)
+var basicOrTokenRe = regexp.MustCompile("(?i)^(basic|token) (.+)")
+var relRe = regexp.MustCompile(`<([^>]+)>; rel="([^"]+)"`)
 
 type verboseTransport struct {
 	Transport   *http.Transport
@@ -115,8 +115,8 @@ func (t *verboseTransport) dumpHeaders(header http.Header, indent string) {
 			for _, v := range vv {
 				if v != "" {
 
-					if BasicOrTokenRe.MatchString(v) {
-						v = BasicOrTokenRe.ReplaceAllString(v, "$1 [REDACTED]")
+					if basicOrTokenRe.MatchString(v) {
+						v = basicOrTokenRe.ReplaceAllString(v, "$1 [REDACTED]")
 					}
 
 					info := fmt.Sprintf("%s %s: %s", indent, name, v)
@@ -517,7 +517,7 @@ func (res *simpleResponse) ErrorInfo() (msg *errorInfo, err error) {
 
 func (res *simpleResponse) Link(name string) string {
 	linkVal := res.Header.Get("Link")
-	for _, match := range RelRe.FindAllStringSubmatch(linkVal, -1) {
+	for _, match := range relRe.FindAllStringSubmatch(linkVal, -1) {
 		if match[2] == name {
 			return match[1]
 		}

--- a/github/message_builder.go
+++ b/github/message_builder.go
@@ -14,6 +14,8 @@ type MessageBuilder struct {
 	editor            *Editor
 }
 
+var newLineRe = regexp.MustCompile(`\r?\n`)
+
 func (b *MessageBuilder) AddCommentedSection(section string) {
 	b.commentedSections = append(b.commentedSections, section)
 }
@@ -34,8 +36,7 @@ func (b *MessageBuilder) Extract() (title, body string, err error) {
 			return
 		}
 	} else {
-		nl := regexp.MustCompile(`\r?\n`)
-		content = nl.ReplaceAllString(content, "\n")
+		content = newLineRe.ReplaceAllString(content, "\n")
 	}
 
 	parts := strings.SplitN(content, "\n\n", 2)

--- a/utils/args_parser.go
+++ b/utils/args_parser.go
@@ -12,6 +12,9 @@ type argsFlag struct {
 	values       []string
 }
 
+var newArgsParserReStr = `(-[a-zA-Z0-9@^]|--[a-z][a-z0-9-]+)(?:\[?[ =]([a-zA-Z_<>:=-]+\]?))?`
+var newArgsParserRe = regexp.MustCompile(fmt.Sprintf(`(?m)^\s*%s(?:,\s*%s)?$`, newArgsParserReStr, newArgsParserReStr))
+
 func (f *argsFlag) addValue(v string) {
 	f.values = append(f.values, v)
 }
@@ -192,9 +195,7 @@ func NewArgsParser() *ArgsParser {
 
 func NewArgsParserWithUsage(usage string) *ArgsParser {
 	p := NewArgsParser()
-	f := `(-[a-zA-Z0-9@^]|--[a-z][a-z0-9-]+)(?:\[?[ =]([a-zA-Z_<>:=-]+\]?))?`
-	re := regexp.MustCompile(fmt.Sprintf(`(?m)^\s*%s(?:,\s*%s)?$`, f, f))
-	for _, match := range re.FindAllStringSubmatch(usage, -1) {
+	for _, match := range newArgsParserRe.FindAllStringSubmatch(usage, -1) {
 		n1 := match[1]
 		n2 := match[3]
 		hasValue := !(match[2] == "" || strings.HasSuffix(match[2], "]")) || match[4] != ""


### PR DESCRIPTION
The regexp.MustCompile function panics if the regex fails to compile and should only be used in globals or init functions, otherwise if the regex is invalid it may panic at run time.

I have moved all the occurrences of the function to be global variables so that they are checked during compile time.