### PR TITLE
`script/version`: make sure to look at the correct `.git/` directory

### DIFF
--- a/script/version
+++ b/script/version
@@ -2,6 +2,7 @@
 # Displays hub's release version
 set -e
 
+export GIT_CEILING_DIRECTORIES=${PWD%/*}
 version="$(git describe --tags HEAD 2>/dev/null || true)"
 
 if [ -z "$version" ]; then


### PR DESCRIPTION
I noticed while trying to build `hub` from an unpacked archive inside an unrelated repository (https://github.com/git-for-windows/MINGW-packages) that `script/version` was happy to pick up incorrect tags.

This PR fixes that.