### PR TITLE
commands: consult global color.ui setting when --color=auto

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -634,6 +634,9 @@ func listLabels(cmd *Command, args *Args) {
 
 func colorizeOutput(colorSet bool, when string) bool {
 	if !colorSet || when == "auto" {
+		if value, _ := git.GlobalConfig("color.ui"); value == "false" {
+			return false
+		}
 		return ui.IsTerminal(os.Stdout)
 	} else if when == "never" {
 		return false

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -634,8 +634,12 @@ func listLabels(cmd *Command, args *Args) {
 
 func colorizeOutput(colorSet bool, when string) bool {
 	if !colorSet || when == "auto" {
-		if value, _ := git.GlobalConfig("color.ui"); value == "false" {
+		colorConfig, _ := git.Config("color.ui")
+		switch colorConfig {
+		case "false", "never":
 			return false
+		case "always":
+			return true
 		}
 		return ui.IsTerminal(os.Stdout)
 	} else if when == "never" {

--- a/features/pr-list.feature
+++ b/features/pr-list.feature
@@ -155,12 +155,28 @@ Feature: hub pr list
     }
     """
     When I successfully run `hub pr list --format "%I %pC %pS %Creset%n" --color`
-    Then the output should contain exactly:
+    Then its output should contain exactly:
       """
       999 \e[37m draft \e[m
       102 \e[32m open \e[m
       42 \e[35m merged \e[m
       8 \e[31m closed \e[m\n
+      """
+    When I successfully run `hub -c color.ui=always pr list --format "%I %pC %pS %Creset%n"`
+    Then its output should contain exactly:
+      """
+      999 \e[37m draft \e[m
+      102 \e[32m open \e[m
+      42 \e[35m merged \e[m
+      8 \e[31m closed \e[m\n
+      """
+    When I successfully run `hub -c color.ui=false pr list --format "%I %pC%pS%Creset%n" --color=auto`
+    Then its output should contain exactly:
+      """
+      999 draft
+      102 open
+      42 merged
+      8 closed\n
       """
 
   Scenario: Sort by number of comments ascending

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -290,3 +290,28 @@ Given(/^the SHAs and timestamps are normalized in "([^"]+)"$/) do |file|
   contents.gsub!(/[0-9a-f]{7} \(Hub, \d seconds? ago\)/, "SHA1SHA (Hub, 0 seconds ago)")
   File.open(file, "w") { |f| f.write(contents) }
 end
+
+Then(/^its (output|stderr|stdout) should( not)? contain( exactly)?:$/) do |channel, negated, exactly, expected|
+  matcher = case channel.to_sym
+            when :output
+              :have_output
+            when :stderr
+              :have_output_on_stderr
+            when :stdout
+              :have_output_on_stdout
+            end
+
+  commands = [last_command_started]
+
+  output_string_matcher = if exactly
+                            :an_output_string_being_eq
+                          else
+                            :an_output_string_including
+                          end
+
+  if negated
+    expect(commands).not_to include_an_object send(matcher, send(output_string_matcher, expected))
+  else
+    expect(commands).to include_an_object send(matcher, send(output_string_matcher, expected))
+  end
+end


### PR DESCRIPTION
This makes the behavior consistent with other git commands.
Also fix up a bug in the documentation of `--color`.