### PR TITLE
Add type assertion test to YAML config decoder

### DIFF
--- a/fixtures/test_configs.go
+++ b/fixtures/test_configs.go
@@ -71,3 +71,44 @@ github.com:
 
 	return &TestConfigs{file.Name()}
 }
+
+func SetupTestConfigsInvalidHostName() *TestConfigs {
+	file, _ := ioutil.TempFile("", "test-gh-config-")
+
+	content := `---
+123:
+- user: jingweno
+  oauth_token: "123"
+  protocol: http
+  unix_socket: /tmp/go.sock`
+	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
+	os.Setenv("HUB_CONFIG", file.Name())
+
+	return &TestConfigs{file.Name()}
+}
+
+func SetupTestConfigsInvalidHostEntry() *TestConfigs {
+	file, _ := ioutil.TempFile("", "test-gh-config-")
+
+	content := `---
+github.com: hello`
+	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
+	os.Setenv("HUB_CONFIG", file.Name())
+
+	return &TestConfigs{file.Name()}
+}
+
+func SetupTestConfigsInvalidPropertyValue() *TestConfigs {
+	file, _ := ioutil.TempFile("", "test-gh-config-")
+
+	content := `---
+github.com:
+- user:
+  oauth_token: "123"
+  protocol: http
+  unix_socket: /tmp/go.sock`
+	ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm)
+	os.Setenv("HUB_CONFIG", file.Name())
+
+	return &TestConfigs{file.Name()}
+}

--- a/github/config_service_test.go
+++ b/github/config_service_test.go
@@ -94,6 +94,51 @@ func TestConfigService_YamlLoad_Unix_Socket(t *testing.T) {
 	assert.Equal(t, "/tmp/go.sock", host.UnixSocket)
 }
 
+func TestConfigService_YamlLoad_Invalid_HostName(t *testing.T) {
+	testConfigInvalidHostName := fixtures.SetupTestConfigsInvalidHostName()
+	defer testConfigInvalidHostName.TearDown()
+
+	cc := &Config{}
+	cs := &configService{
+		Encoder: &yamlConfigEncoder{},
+		Decoder: &yamlConfigDecoder{},
+	}
+
+	err := cs.Load(testConfigInvalidHostName.Path, cc)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "host name is must be string but got 123", err.Error())
+}
+
+func TestConfigService_YamlLoad_Invalid_HostEntry(t *testing.T) {
+	testConfigInvalidHostEntry := fixtures.SetupTestConfigsInvalidHostEntry()
+	defer testConfigInvalidHostEntry.TearDown()
+
+	cc := &Config{}
+	cs := &configService{
+		Encoder: &yamlConfigEncoder{},
+		Decoder: &yamlConfigDecoder{},
+	}
+
+	err := cs.Load(testConfigInvalidHostEntry.Path, cc)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "value of host entry is must be array but got \"hello\"", err.Error())
+}
+
+func TestConfigService_YamlLoad_Invalid_PropertyValue(t *testing.T) {
+	testConfigInvalidPropertyValue := fixtures.SetupTestConfigsInvalidPropertyValue()
+	defer testConfigInvalidPropertyValue.TearDown()
+
+	cc := &Config{}
+	cs := &configService{
+		Encoder: &yamlConfigEncoder{},
+		Decoder: &yamlConfigDecoder{},
+	}
+
+	err := cs.Load(testConfigInvalidPropertyValue.Path, cc)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "user is must be string but got <nil>", err.Error())
+}
+
 func TestConfigService_TomlSave(t *testing.T) {
 	file, _ := ioutil.TempFile("", "test-gh-config-")
 	defer os.RemoveAll(file.Name())


### PR DESCRIPTION
In my first time to use `hub`, my configuration file was incorrect.
And `hub` was crushed because of failed to type conversion. Please see #2379.

I added type check into the YAML configuration decoder.
Now, `hub` won't crush even if given an incorrect configuration file. It will just ignored it.

I think probably it more friendly if reporting about incorrect configuration.
But I didn't edit except a configuration decoder at the moment.