### PR TITLE
Add the ability to edit issues

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -634,6 +634,10 @@ func updateIssue(cmd *Command, args *Args) {
 		utils.Check(cmd.UsageError(""))
 	}
 
+	if !args.Flag.HasReceivedOneOf([]string{"--message", "--edit", "--file", "--labels", "--milestone", "--assign"}) {
+		utils.Check(cmd.UsageError("please specify fields to update"))
+	}
+
 	localRepo, err := github.LocalRepo()
 	utils.Check(err)
 

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -731,23 +731,28 @@ func hasField(args *Args, names ...string) bool {
 }
 
 func setLabelsFromArgs(params map[string]interface{}, args *Args) {
-	flagIssueLabels := commaSeparated(args.Flag.AllValues("--labels"))
-	if len(flagIssueLabels) > 0 {
-		params["labels"] = flagIssueLabels
+	if !args.Flag.HasReceived("--labels") {
+		return
 	}
+	params["labels"] = commaSeparated(args.Flag.AllValues("--labels"))
 }
 
 func setAssigneesFromArgs(params map[string]interface{}, args *Args) {
-	flagIssueAssignees := commaSeparated(args.Flag.AllValues("--assign"))
-	if len(flagIssueAssignees) > 0 {
-		params["assignees"] = flagIssueAssignees
+	if !args.Flag.HasReceived("--assign") {
+		return
 	}
+	params["assignees"] = commaSeparated(args.Flag.AllValues("--assign"))
 }
 
 func setMilestoneFromArgs(params map[string]interface{}, args *Args, gh *github.Client, project *github.Project) {
+	if !args.Flag.HasReceived("--milestone") {
+		return
+	}
 	milestoneNumber, err := milestoneValueToNumber(args.Flag.Value("--milestone"), gh, project)
 	utils.Check(err)
-	if milestoneNumber > 0 {
+	if milestoneNumber == 0 {
+		params["milestone"] = nil
+	} else {
 		params["milestone"] = milestoneNumber
 	}
 }

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -20,7 +20,7 @@ var (
 issue [-a <ASSIGNEE>] [-c <CREATOR>] [-@ <USER>] [-s <STATE>] [-f <FORMAT>] [-M <MILESTONE>] [-l <LABELS>] [-d <DATE>] [-o <SORT_KEY> [-^]] [-L <LIMIT>]
 issue show [-f <FORMAT>] <NUMBER>
 issue create [-oc] [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
-issue update <NUMBER> [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
+issue update <NUMBER> [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>] [-s <STATE>]
 issue labels [--color]
 issue transfer <NUMBER> <REPO>
 `,
@@ -243,6 +243,7 @@ hub-pr(1), hub(1)
 		-l, --labels LIST
 		-a, --assign USER
 		-e, --edit
+		-s, --state STATE
 `,
 	}
 )
@@ -635,7 +636,7 @@ func updateIssue(cmd *Command, args *Args) {
 	if issueNumber == 0 {
 		utils.Check(cmd.UsageError(""))
 	}
-	if !hasField(args, "--message", "--file", "--labels", "--milestone", "--assign", "--edit") {
+	if !hasField(args, "--message", "--file", "--labels", "--milestone", "--assign", "--state", "--edit") {
 		utils.Check(cmd.UsageError("please specify fields to update"))
 	}
 
@@ -651,6 +652,10 @@ func updateIssue(cmd *Command, args *Args) {
 	setLabelsFromArgs(params, args)
 	setAssigneesFromArgs(params, args)
 	setMilestoneFromArgs(params, args, gh, project)
+
+	if args.Flag.HasReceived("--state") {
+		params["state"] = args.Flag.Value("--state")
+	}
 
 	if hasField(args, "--message", "--file", "--edit") {
 		messageBuilder := &github.MessageBuilder{

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -660,7 +660,7 @@ func updateIssue(cmd *Command, args *Args) {
 			Filename: "ISSUE_EDITMSG",
 			Title:    "issue",
 			Edit:     args.Flag.Bool("--edit"),
-			Message:  fmt.Sprintf("%s\n\n%s", issue.Title, issue.Body),
+			Message:  strings.Replace(fmt.Sprintf("%s\n\n%s", issue.Title, issue.Body), "\r\n", "\n", -1),
 		}
 
 		messageBuilder.AddCommentedSection(fmt.Sprintf(`Editing issue #%d for %s

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -21,7 +21,7 @@ issue [-a <ASSIGNEE>] [-c <CREATOR>] [-@ <USER>] [-s <STATE>] [-f <FORMAT>] [-M 
 issue show [-f <FORMAT>] <NUMBER>
 issue create [-oc] [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
 issue labels [--color]
-issue update <NUMBER> [-oc] [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
+issue update <NUMBER> [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
 issue transfer <NUMBER> <REPO>
 `,
 		Long: `Manage GitHub Issues for the current repository.
@@ -238,8 +238,6 @@ hub-pr(1), hub(1)
 		-M, --milestone NAME
 		-l, --labels LIST
 		-a, --assign USER
-		-o, --browse
-		-c, --copy
 		-e, --edit
 `,
 	}
@@ -706,10 +704,6 @@ text is the title and the rest is the description.`, issue.Number, project))
 	} else {
 		err := gh.UpdateIssue(project, issueNumber, params)
 		utils.Check(err)
-
-		flagIssueBrowse := args.Flag.Bool("--browse")
-		flagIssueCopy := args.Flag.Bool("--copy")
-		printBrowseOrCopy(args, issue.HtmlUrl, flagIssueBrowse, flagIssueCopy)
 	}
 
 	messageBuilder.Cleanup()

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -604,21 +604,11 @@ text is the title and the rest is the description.`, project))
 		"body":  body,
 	}
 
-	flagIssueLabels := commaSeparated(args.Flag.AllValues("--labels"))
-	if len(flagIssueLabels) > 0 {
-		params["labels"] = flagIssueLabels
-	}
+	setLabelsFromArgs(params, args)
 
-	flagIssueAssignees := commaSeparated(args.Flag.AllValues("--assign"))
-	if len(flagIssueAssignees) > 0 {
-		params["assignees"] = flagIssueAssignees
-	}
+	setAssigneesFromArgs(params, args)
 
-	milestoneNumber, err := milestoneValueToNumber(args.Flag.Value("--milestone"), gh, project)
-	utils.Check(err)
-	if milestoneNumber > 0 {
-		params["milestone"] = milestoneNumber
-	}
+	setMilestoneFromArgs(params, args, gh, project)
 
 	args.NoForward()
 	if args.Noop {
@@ -661,9 +651,7 @@ func editIssue(cmd *Command, args *Args) {
 		Title:    "issue",
 	}
 
-	messageBuilder.Message = fmt.Sprintf(`%s
-
-%s`, issue.Title, issue.Body)
+	messageBuilder.Message = fmt.Sprintf("%s\n\n%s", issue.Title, issue.Body)
 
 	messageBuilder.AddCommentedSection(fmt.Sprintf(`Editing issue %d for %s
 
@@ -695,21 +683,11 @@ text is the title and the rest is the description.`, issue.Number, project))
 		params["body"] = body
 	}
 
-	flagIssueLabels := commaSeparated(args.Flag.AllValues("--labels"))
-	if len(flagIssueLabels) > 0 {
-		params["labels"] = flagIssueLabels
-	}
+	setLabelsFromArgs(params, args)
 
-	flagIssueAssignees := commaSeparated(args.Flag.AllValues("--assign"))
-	if len(flagIssueAssignees) > 0 {
-		params["assignees"] = flagIssueAssignees
-	}
+	setAssigneesFromArgs(params, args)
 
-	milestoneNumber, err := milestoneValueToNumber(args.Flag.Value("--milestone"), gh, project)
-	utils.Check(err)
-	if milestoneNumber > 0 {
-		params["milestone"] = milestoneNumber
-	}
+	setMilestoneFromArgs(params, args, gh, project)
 
 	args.NoForward()
 	if args.Noop {
@@ -747,6 +725,28 @@ func listLabels(cmd *Command, args *Args) {
 	flagLabelsColorize := colorizeOutput(args.Flag.HasReceived("--color"), args.Flag.Value("--color"))
 	for _, label := range labels {
 		ui.Print(formatLabel(label, flagLabelsColorize))
+	}
+}
+
+func setLabelsFromArgs(params map[string]interface{}, args *Args) {
+	flagIssueLabels := commaSeparated(args.Flag.AllValues("--labels"))
+	if len(flagIssueLabels) > 0 {
+		params["labels"] = flagIssueLabels
+	}
+}
+
+func setAssigneesFromArgs(params map[string]interface{}, args *Args) {
+	flagIssueAssignees := commaSeparated(args.Flag.AllValues("--assign"))
+	if len(flagIssueAssignees) > 0 {
+		params["assignees"] = flagIssueAssignees
+	}
+}
+
+func setMilestoneFromArgs(params map[string]interface{}, args *Args, gh *github.Client, project *github.Project) {
+	milestoneNumber, err := milestoneValueToNumber(args.Flag.Value("--milestone"), gh, project)
+	utils.Check(err)
+	if milestoneNumber > 0 {
+		params["milestone"] = milestoneNumber
 	}
 }
 

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -634,7 +634,14 @@ func updateIssue(cmd *Command, args *Args) {
 		utils.Check(cmd.UsageError(""))
 	}
 
-	if !args.Flag.HasReceivedOneOf([]string{"--message", "--edit", "--file", "--labels", "--milestone", "--assign"}) {
+	flagsUpdatingFields := []string{"--message", "--edit", "--file", "--labels", "--milestone", "--assign"}
+	updatesFields := false
+	for _, name := range flagsUpdatingFields {
+		if args.Flag.HasReceived(name) {
+			updatesFields = true
+		}
+	}
+	if !updatesFields {
 		utils.Check(cmd.UsageError("please specify fields to update"))
 	}
 

--- a/commands/issue.go
+++ b/commands/issue.go
@@ -21,7 +21,7 @@ issue [-a <ASSIGNEE>] [-c <CREATOR>] [-@ <USER>] [-s <STATE>] [-f <FORMAT>] [-M 
 issue show [-f <FORMAT>] <NUMBER>
 issue create [-oc] [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
 issue labels [--color]
-issue edit <NUMBER> [-oc] [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
+issue update <NUMBER> [-oc] [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
 issue transfer <NUMBER> <REPO>
 `,
 		Long: `Manage GitHub Issues for the current repository.
@@ -229,9 +229,9 @@ hub-pr(1), hub(1)
 		Run: transferIssue,
 	}
 
-	cmdEdit = &Command{
-		Key: "edit",
-		Run: editIssue,
+	cmdUpdate = &Command{
+		Key: "update",
+		Run: updateIssue,
 		KnownFlags: `
 		-m, --message MSG
 		-F, --file FILE
@@ -250,7 +250,7 @@ func init() {
 	cmdIssue.Use(cmdCreateIssue)
 	cmdIssue.Use(cmdLabel)
 	cmdIssue.Use(cmdTransfer)
-	cmdIssue.Use(cmdEdit)
+	cmdIssue.Use(cmdUpdate)
 	CmdRunner.Use(cmdIssue)
 }
 
@@ -625,7 +625,7 @@ text is the title and the rest is the description.`, project))
 	messageBuilder.Cleanup()
 }
 
-func editIssue(cmd *Command, args *Args) {
+func updateIssue(cmd *Command, args *Args) {
 	issueNumber := 0
 	if args.ParamsSize() > 0 {
 		issueNumber, _ = strconv.Atoi(args.GetParam(0))

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -475,6 +475,9 @@ func parsePullRequestIssueNumber(url string) string {
 func commaSeparated(l []string) []string {
 	res := []string{}
 	for _, i := range l {
+		if i == "" {
+			continue
+		}
 		res = append(res, strings.Split(i, ",")...)
 	}
 	return res

--- a/commands/release.go
+++ b/commands/release.go
@@ -596,7 +596,7 @@ text is the title and the rest is the description.`, tagName, project))
 		messageBuilder.Edit = args.Flag.Bool("--edit")
 	} else {
 		messageBuilder.Edit = true
-		messageBuilder.Message = fmt.Sprintf("%s\n\n%s", release.Name, release.Body)
+		messageBuilder.Message = strings.Replace(fmt.Sprintf("%s\n\n%s", release.Name, release.Body), "\r\n", "\n", -1)
 	}
 
 	title, body, err := messageBuilder.Extract()

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -593,6 +593,270 @@ Feature: hub issue
       https://github.com/github/hub/issues/1337\n
       """
 
+
+  Scenario: Edit an issue's title
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/1337') {
+        json \
+          :number => 1337,
+          :state => "open",
+          :body => "I want this feature",
+          :title => "Not workie!",
+          :created_at => "2017-04-14T16:00:49Z",
+          :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => "Not workie, pls fix",
+               :body => "",
+               :milestone => :no,
+               :assignees => :no,
+               :labels => :no
+        json ""
+        status 200
+      }
+      """
+    When I successfully run `hub issue edit 1337 -m "Not workie, pls fix"`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+    
+  Scenario: Edit an issue's labels
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/1337') {
+        json \
+          :number => 1337,
+          :state => "open",
+          :body => "I want this feature",
+          :title => "Not workie!",
+          :created_at => "2017-04-14T16:00:49Z",
+          :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => :no,
+               :body => :no,
+               :milestone => :no,
+               :assignees => :no,
+               :labels => ["bug", "important"]
+        json ""
+        status 200
+      }
+      """
+    When I successfully run `hub issue edit 1337 -l bug,important`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+
+  Scenario: Edit an issue's milestone
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/1337') {
+        json \
+          :number => 1337,
+          :state => "open",
+          :body => "I want this feature",
+          :title => "Not workie!",
+          :created_at => "2017-04-14T16:00:49Z",
+          :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => :no,
+               :body => :no,
+               :milestone => 42,
+               :assignees => :no,
+               :labels => :no
+        json ""
+        status 200
+      }
+      """
+    When I successfully run `hub issue edit 1337 -M 42`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+
+  Scenario: Create an issue with milestone by name
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/milestones') {
+        status 200
+        json [
+          { :number => 237, :title => "prerelease" },
+          { :number => 42, :title => "Hello World!" }
+        ]
+      }
+      get('/repos/github/hub/issues/1337') {
+        json \
+          :number => 1337,
+          :state => "open",
+          :body => "I want this feature",
+          :title => "Not workie!",
+          :created_at => "2017-04-14T16:00:49Z",
+          :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => :no,
+               :body => :no,
+               :milestone => 42,
+               :assignees => :no,
+               :labels => :no
+        json ""
+        status 200
+      }
+      """
+    When I successfully run `hub issue edit 1337 -M "hello world!"`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+
+  Scenario: Edit an issue's assignees
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/1337') {
+        json \
+          :number => 1337,
+          :state => "open",
+          :body => "I want this feature",
+          :title => "Not workie!",
+          :created_at => "2017-04-14T16:00:49Z",
+          :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => :no,
+               :body => :no,
+               :milestone => :no,
+               :assignees => ["Cornwe19"],
+               :labels => :no
+        json ""
+        status 200
+      }
+      """
+    When I successfully run `hub issue edit 1337 -a Cornwe19`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+
+  Scenario: Edit an issue's title, labels, milestone, and assignees
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/1337') {
+        json \
+          :number => 1337,
+          :state => "open",
+          :body => "I want this feature",
+          :title => "Not workie!",
+          :created_at => "2017-04-14T16:00:49Z",
+          :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => "Not workie, pls fix",
+               :body => "",
+               :milestone => 42,
+               :assignees => ["Cornwe19"],
+               :labels => ["bug", "important"]
+        json ""
+        status 200
+      }
+      """
+    When I successfully run `hub issue edit 1337  -m "Not workie, pls fix" -M 42 -l bug,important -a Cornwe19`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+
+  Scenario: Edit an issue and open in browser
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/1337') {
+        json \
+          :number => 1337,
+          :state => "open",
+          :body => "",
+          :title => "Not workie!",
+          :created_at => "2017-04-14T16:00:49Z",
+          :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      patch('/repos/github/hub/issues/1337') {
+        json ""
+        status 200
+      }
+      """
+    When I successfully run `hub issue edit 1337 -m "Not workie, pls fix" -o`
+    Then the output should contain exactly ""
+    Then "open https://github.com/github/hub/issues/1337" should be run
+
+  Scenario: Edit an issue's title and body manually
+    Given the git commit editor is "vim"
+    And the text editor adds:
+      """
+      My new title
+      """
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/1337') {
+        json \
+          :number => 1337,
+          :state => "open",
+          :title => "My old title",
+          :body => "My old body",
+          :created_at => "2017-04-14T16:00:49Z",
+          :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => "My new title",
+               :body => "My old title\n\nMy old body",
+               :milestone => :no,
+               :assignees => :no,
+               :labels => :no
+        json ""
+        status 200
+      }
+      """
+    When I successfully run `hub issue edit 1337 --edit`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+
+  Scenario: Edit an issue's title and body via a file
+    Given a file named "my-issue.md" with:
+      """
+      My new title
+      
+      My new body
+      """
+    Given the GitHub API server:
+      """
+      get('/repos/github/hub/issues/1337') {
+        json \
+          :number => 1337,
+          :state => "open",
+          :title => "My old title",
+          :body => "My old body",
+          :created_at => "2017-04-14T16:00:49Z",
+          :html_url => "https://github.com/github/hub/issues/1337"
+      }
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => "My new title",
+               :body => "My new body",
+               :milestone => :no,
+               :assignees => :no,
+               :labels => :no
+        json ""
+        status 200
+      }
+      """
+    When I successfully run `hub issue edit 1337 -F my-issue.md`
+    Then the output should contain exactly:
+      """
+      https://github.com/github/hub/issues/1337\n
+      """
+
   Scenario: Fetch issue labels
     Given the GitHub API server:
     """

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -593,7 +593,6 @@ Feature: hub issue
       https://github.com/github/hub/issues/1337\n
       """
 
-
   Scenario: Update an issue's title
     Given the GitHub API server:
       """
@@ -602,10 +601,22 @@ Feature: hub issue
                :body => "",
                :milestone => :no,
                :assignees => :no,
-               :labels => :no
+               :labels => :no,
+               :state => :no
       }
       """
     Then I successfully run `hub issue update 1337 -m "Not workie, pls fix"`
+
+  Scenario: Update an issue's state
+    Given the GitHub API server:
+      """
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => :no,
+               :labels => :no,
+               :state => "closed"
+      }
+      """
+    Then I successfully run `hub issue update 1337 -s closed`
     
   Scenario: Update an issue's labels
     Given the GitHub API server:

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -679,6 +679,19 @@ Feature: hub issue
       """
     Then I successfully run `hub issue update 1337  -m "Not workie, pls fix" -M 42 -l bug,important -a Cornwe19`
 
+  Scenario: Clear existing issue labels, assignees, milestone
+    Given the GitHub API server:
+      """
+      patch('/repos/github/hub/issues/1337') {
+        assert :title => :no,
+               :body => :no,
+               :milestone => nil,
+               :assignees => [],
+               :labels => []
+      }
+      """
+    Then I successfully run `hub issue update 1337 --milestone= --assign= --labels=`
+
   Scenario: Update an issue's title and body manually
     Given the git commit editor is "vim"
     And the text editor adds:

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -594,7 +594,7 @@ Feature: hub issue
       """
 
 
-  Scenario: Edit an issue's title
+  Scenario: Update an issue's title
     Given the GitHub API server:
       """
       get('/repos/github/hub/issues/1337') {
@@ -614,13 +614,13 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue edit 1337 -m "Not workie, pls fix"`
+    When I successfully run `hub issue update 1337 -m "Not workie, pls fix"`
     Then the output should contain exactly:
       """
       https://github.com/github/hub/issues/1337\n
       """
     
-  Scenario: Edit an issue's labels
+  Scenario: Update an issue's labels
     Given the GitHub API server:
       """
       get('/repos/github/hub/issues/1337') {
@@ -640,13 +640,13 @@ Feature: hub issue
                :labels => ["bug", "important"]
       }
       """
-    When I successfully run `hub issue edit 1337 -l bug,important`
+    When I successfully run `hub issue update 1337 -l bug,important`
     Then the output should contain exactly:
       """
       https://github.com/github/hub/issues/1337\n
       """
 
-  Scenario: Edit an issue's milestone
+  Scenario: Update an issue's milestone
     Given the GitHub API server:
       """
       get('/repos/github/hub/issues/1337') {
@@ -666,13 +666,13 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue edit 1337 -M 42`
+    When I successfully run `hub issue update 1337 -M 42`
     Then the output should contain exactly:
       """
       https://github.com/github/hub/issues/1337\n
       """
 
-  Scenario: Edit an issue with milestone by name
+  Scenario: Upate an issue's milestone by name
     Given the GitHub API server:
       """
       get('/repos/github/hub/milestones') {
@@ -699,13 +699,13 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue edit 1337 -M "hello world!"`
+    When I successfully run `hub issue update 1337 -M "hello world!"`
     Then the output should contain exactly:
       """
       https://github.com/github/hub/issues/1337\n
       """
 
-  Scenario: Edit an issue's assignees
+  Scenario: Update an issue's assignees
     Given the GitHub API server:
       """
       get('/repos/github/hub/issues/1337') {
@@ -725,13 +725,13 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue edit 1337 -a Cornwe19`
+    When I successfully run `hub issue update 1337 -a Cornwe19`
     Then the output should contain exactly:
       """
       https://github.com/github/hub/issues/1337\n
       """
 
-  Scenario: Edit an issue's title, labels, milestone, and assignees
+  Scenario: Update an issue's title, labels, milestone, and assignees
     Given the GitHub API server:
       """
       get('/repos/github/hub/issues/1337') {
@@ -751,13 +751,13 @@ Feature: hub issue
                :labels => ["bug", "important"]
       }
       """
-    When I successfully run `hub issue edit 1337  -m "Not workie, pls fix" -M 42 -l bug,important -a Cornwe19`
+    When I successfully run `hub issue update 1337  -m "Not workie, pls fix" -M 42 -l bug,important -a Cornwe19`
     Then the output should contain exactly:
       """
       https://github.com/github/hub/issues/1337\n
       """
 
-  Scenario: Edit an issue and open in browser
+  Scenario: Update an issue and open in browser
     Given the GitHub API server:
       """
       get('/repos/github/hub/issues/1337') {
@@ -771,11 +771,11 @@ Feature: hub issue
       }
       patch('/repos/github/hub/issues/1337') {}
       """
-    When I successfully run `hub issue edit 1337 -m "Not workie, pls fix" -o`
+    When I successfully run `hub issue update 1337 -m "Not workie, pls fix" -o`
     Then the output should contain exactly ""
     Then "open https://github.com/github/hub/issues/1337" should be run
 
-  Scenario: Edit an issue's title and body manually
+  Scenario: Update an issue's title and body manually
     Given the git commit editor is "vim"
     And the text editor adds:
       """
@@ -800,13 +800,13 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue edit 1337 --edit`
+    When I successfully run `hub issue update 1337 --edit`
     Then the output should contain exactly:
       """
       https://github.com/github/hub/issues/1337\n
       """
 
-  Scenario: Edit an issue's title and body via a file
+  Scenario: Update an issue's title and body via a file
     Given a file named "my-issue.md" with:
       """
       My new title
@@ -832,7 +832,7 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue edit 1337 -F my-issue.md`
+    When I successfully run `hub issue update 1337 -F my-issue.md`
     Then the output should contain exactly:
       """
       https://github.com/github/hub/issues/1337\n

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -838,6 +838,12 @@ Feature: hub issue
       https://github.com/github/hub/issues/1337\n
       """
 
+  Scenario: Update an issue without specifying fields to update
+    When I run `hub issue update 1337`
+    Then the exit status should be 1
+    Then the stderr should contain "please specify fields to update"
+    Then the stderr should contain "Usage: hub issue"
+
   Scenario: Fetch issue labels
     Given the GitHub API server:
     """

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -614,11 +614,7 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue update 1337 -m "Not workie, pls fix"`
-    Then the output should contain exactly:
-      """
-      https://github.com/github/hub/issues/1337\n
-      """
+    Then I successfully run `hub issue update 1337 -m "Not workie, pls fix"`
     
   Scenario: Update an issue's labels
     Given the GitHub API server:
@@ -640,11 +636,7 @@ Feature: hub issue
                :labels => ["bug", "important"]
       }
       """
-    When I successfully run `hub issue update 1337 -l bug,important`
-    Then the output should contain exactly:
-      """
-      https://github.com/github/hub/issues/1337\n
-      """
+    Then I successfully run `hub issue update 1337 -l bug,important`
 
   Scenario: Update an issue's milestone
     Given the GitHub API server:
@@ -666,11 +658,7 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue update 1337 -M 42`
-    Then the output should contain exactly:
-      """
-      https://github.com/github/hub/issues/1337\n
-      """
+    Then I successfully run `hub issue update 1337 -M 42`
 
   Scenario: Upate an issue's milestone by name
     Given the GitHub API server:
@@ -699,11 +687,7 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue update 1337 -M "hello world!"`
-    Then the output should contain exactly:
-      """
-      https://github.com/github/hub/issues/1337\n
-      """
+    Then I successfully run `hub issue update 1337 -M "hello world!"`
 
   Scenario: Update an issue's assignees
     Given the GitHub API server:
@@ -725,11 +709,7 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue update 1337 -a Cornwe19`
-    Then the output should contain exactly:
-      """
-      https://github.com/github/hub/issues/1337\n
-      """
+    Then I successfully run `hub issue update 1337 -a Cornwe19`
 
   Scenario: Update an issue's title, labels, milestone, and assignees
     Given the GitHub API server:
@@ -751,29 +731,7 @@ Feature: hub issue
                :labels => ["bug", "important"]
       }
       """
-    When I successfully run `hub issue update 1337  -m "Not workie, pls fix" -M 42 -l bug,important -a Cornwe19`
-    Then the output should contain exactly:
-      """
-      https://github.com/github/hub/issues/1337\n
-      """
-
-  Scenario: Update an issue and open in browser
-    Given the GitHub API server:
-      """
-      get('/repos/github/hub/issues/1337') {
-        json \
-          :number => 1337,
-          :state => "open",
-          :body => "",
-          :title => "Not workie!",
-          :created_at => "2017-04-14T16:00:49Z",
-          :html_url => "https://github.com/github/hub/issues/1337"
-      }
-      patch('/repos/github/hub/issues/1337') {}
-      """
-    When I successfully run `hub issue update 1337 -m "Not workie, pls fix" -o`
-    Then the output should contain exactly ""
-    Then "open https://github.com/github/hub/issues/1337" should be run
+    Then I successfully run `hub issue update 1337  -m "Not workie, pls fix" -M 42 -l bug,important -a Cornwe19`
 
   Scenario: Update an issue's title and body manually
     Given the git commit editor is "vim"
@@ -800,11 +758,7 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue update 1337 --edit`
-    Then the output should contain exactly:
-      """
-      https://github.com/github/hub/issues/1337\n
-      """
+    Then I successfully run `hub issue update 1337 --edit`
 
   Scenario: Update an issue's title and body via a file
     Given a file named "my-issue.md" with:
@@ -832,11 +786,7 @@ Feature: hub issue
                :labels => :no
       }
       """
-    When I successfully run `hub issue update 1337 -F my-issue.md`
-    Then the output should contain exactly:
-      """
-      https://github.com/github/hub/issues/1337\n
-      """
+    Then I successfully run `hub issue update 1337 -F my-issue.md`
 
   Scenario: Update an issue without specifying fields to update
     When I run `hub issue update 1337`

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -597,15 +597,6 @@ Feature: hub issue
   Scenario: Update an issue's title
     Given the GitHub API server:
       """
-      get('/repos/github/hub/issues/1337') {
-        json \
-          :number => 1337,
-          :state => "open",
-          :body => "I want this feature",
-          :title => "Not workie!",
-          :created_at => "2017-04-14T16:00:49Z",
-          :html_url => "https://github.com/github/hub/issues/1337"
-      }
       patch('/repos/github/hub/issues/1337') {
         assert :title => "Not workie, pls fix",
                :body => "",
@@ -619,15 +610,6 @@ Feature: hub issue
   Scenario: Update an issue's labels
     Given the GitHub API server:
       """
-      get('/repos/github/hub/issues/1337') {
-        json \
-          :number => 1337,
-          :state => "open",
-          :body => "I want this feature",
-          :title => "Not workie!",
-          :created_at => "2017-04-14T16:00:49Z",
-          :html_url => "https://github.com/github/hub/issues/1337"
-      }
       patch('/repos/github/hub/issues/1337') {
         assert :title => :no,
                :body => :no,
@@ -641,15 +623,6 @@ Feature: hub issue
   Scenario: Update an issue's milestone
     Given the GitHub API server:
       """
-      get('/repos/github/hub/issues/1337') {
-        json \
-          :number => 1337,
-          :state => "open",
-          :body => "I want this feature",
-          :title => "Not workie!",
-          :created_at => "2017-04-14T16:00:49Z",
-          :html_url => "https://github.com/github/hub/issues/1337"
-      }
       patch('/repos/github/hub/issues/1337') {
         assert :title => :no,
                :body => :no,
@@ -670,15 +643,6 @@ Feature: hub issue
           { :number => 42, :title => "Hello World!" }
         ]
       }
-      get('/repos/github/hub/issues/1337') {
-        json \
-          :number => 1337,
-          :state => "open",
-          :body => "I want this feature",
-          :title => "Not workie!",
-          :created_at => "2017-04-14T16:00:49Z",
-          :html_url => "https://github.com/github/hub/issues/1337"
-      }
       patch('/repos/github/hub/issues/1337') {
         assert :title => :no,
                :body => :no,
@@ -692,15 +656,6 @@ Feature: hub issue
   Scenario: Update an issue's assignees
     Given the GitHub API server:
       """
-      get('/repos/github/hub/issues/1337') {
-        json \
-          :number => 1337,
-          :state => "open",
-          :body => "I want this feature",
-          :title => "Not workie!",
-          :created_at => "2017-04-14T16:00:49Z",
-          :html_url => "https://github.com/github/hub/issues/1337"
-      }
       patch('/repos/github/hub/issues/1337') {
         assert :title => :no,
                :body => :no,
@@ -714,15 +669,6 @@ Feature: hub issue
   Scenario: Update an issue's title, labels, milestone, and assignees
     Given the GitHub API server:
       """
-      get('/repos/github/hub/issues/1337') {
-        json \
-          :number => 1337,
-          :state => "open",
-          :body => "I want this feature",
-          :title => "Not workie!",
-          :created_at => "2017-04-14T16:00:49Z",
-          :html_url => "https://github.com/github/hub/issues/1337"
-      }
       patch('/repos/github/hub/issues/1337') {
         assert :title => "Not workie, pls fix",
                :body => "",
@@ -744,11 +690,8 @@ Feature: hub issue
       get('/repos/github/hub/issues/1337') {
         json \
           :number => 1337,
-          :state => "open",
           :title => "My old title",
-          :body => "My old body",
-          :created_at => "2017-04-14T16:00:49Z",
-          :html_url => "https://github.com/github/hub/issues/1337"
+          :body => "My old body"
       }
       patch('/repos/github/hub/issues/1337') {
         assert :title => "My new title",
@@ -769,15 +712,6 @@ Feature: hub issue
       """
     Given the GitHub API server:
       """
-      get('/repos/github/hub/issues/1337') {
-        json \
-          :number => 1337,
-          :state => "open",
-          :title => "My old title",
-          :body => "My old body",
-          :created_at => "2017-04-14T16:00:49Z",
-          :html_url => "https://github.com/github/hub/issues/1337"
-      }
       patch('/repos/github/hub/issues/1337') {
         assert :title => "My new title",
                :body => "My new body",

--- a/features/issue.feature
+++ b/features/issue.feature
@@ -612,8 +612,6 @@ Feature: hub issue
                :milestone => :no,
                :assignees => :no,
                :labels => :no
-        json ""
-        status 200
       }
       """
     When I successfully run `hub issue edit 1337 -m "Not workie, pls fix"`
@@ -640,8 +638,6 @@ Feature: hub issue
                :milestone => :no,
                :assignees => :no,
                :labels => ["bug", "important"]
-        json ""
-        status 200
       }
       """
     When I successfully run `hub issue edit 1337 -l bug,important`
@@ -668,8 +664,6 @@ Feature: hub issue
                :milestone => 42,
                :assignees => :no,
                :labels => :no
-        json ""
-        status 200
       }
       """
     When I successfully run `hub issue edit 1337 -M 42`
@@ -678,7 +672,7 @@ Feature: hub issue
       https://github.com/github/hub/issues/1337\n
       """
 
-  Scenario: Create an issue with milestone by name
+  Scenario: Edit an issue with milestone by name
     Given the GitHub API server:
       """
       get('/repos/github/hub/milestones') {
@@ -703,8 +697,6 @@ Feature: hub issue
                :milestone => 42,
                :assignees => :no,
                :labels => :no
-        json ""
-        status 200
       }
       """
     When I successfully run `hub issue edit 1337 -M "hello world!"`
@@ -731,8 +723,6 @@ Feature: hub issue
                :milestone => :no,
                :assignees => ["Cornwe19"],
                :labels => :no
-        json ""
-        status 200
       }
       """
     When I successfully run `hub issue edit 1337 -a Cornwe19`
@@ -759,8 +749,6 @@ Feature: hub issue
                :milestone => 42,
                :assignees => ["Cornwe19"],
                :labels => ["bug", "important"]
-        json ""
-        status 200
       }
       """
     When I successfully run `hub issue edit 1337  -m "Not workie, pls fix" -M 42 -l bug,important -a Cornwe19`
@@ -781,10 +769,7 @@ Feature: hub issue
           :created_at => "2017-04-14T16:00:49Z",
           :html_url => "https://github.com/github/hub/issues/1337"
       }
-      patch('/repos/github/hub/issues/1337') {
-        json ""
-        status 200
-      }
+      patch('/repos/github/hub/issues/1337') {}
       """
     When I successfully run `hub issue edit 1337 -m "Not workie, pls fix" -o`
     Then the output should contain exactly ""
@@ -813,8 +798,6 @@ Feature: hub issue
                :milestone => :no,
                :assignees => :no,
                :labels => :no
-        json ""
-        status 200
       }
       """
     When I successfully run `hub issue edit 1337 --edit`
@@ -847,8 +830,6 @@ Feature: hub issue
                :milestone => :no,
                :assignees => :no,
                :labels => :no
-        json ""
-        status 200
       }
       """
     When I successfully run `hub issue edit 1337 -F my-issue.md`

--- a/utils/args_parser.go
+++ b/utils/args_parser.go
@@ -183,15 +183,6 @@ func (p *ArgsParser) HasReceived(name string) bool {
 	return found && len(f.values) > 0
 }
 
-func (p *ArgsParser) HasReceivedOneOf(names []string) bool {
-	for _, name := range names {
-		if p.HasReceived(name) {
-			return true
-		}
-	}
-	return false
-}
-
 func NewArgsParser() *ArgsParser {
 	return &ArgsParser{
 		flagMap:     make(map[string]*argsFlag),

--- a/utils/args_parser.go
+++ b/utils/args_parser.go
@@ -183,6 +183,15 @@ func (p *ArgsParser) HasReceived(name string) bool {
 	return found && len(f.values) > 0
 }
 
+func (p *ArgsParser) HasReceivedOneOf(names []string) bool {
+	for _, name := range names {
+		if p.HasReceived(name) {
+			return true
+		}
+	}
+	return false
+}
+
 func NewArgsParser() *ArgsParser {
 	return &ArgsParser{
 		flagMap:     make(map[string]*argsFlag),


### PR DESCRIPTION
This PR adds the ability to edit existing issues using the same interface as `hub issue create`. 

There is a little duplication between creating and editing issues that could be removed. I'm not convinced that removing the duplication would increase clarity and readability.