### PR TITLE
Print more user-friendly HTTP 40x errors

### DIFF
--- a/commands/api.go
+++ b/commands/api.go
@@ -285,6 +285,10 @@ func apiCommand(_ *Command, args *Args) {
 		response.Body.Close()
 
 		if !success {
+			if ssoErr := github.ValidateGitHubSSO(response.Response); ssoErr != nil {
+				ui.Errorln()
+				ui.Errorln(ssoErr)
+			}
 			if scopeErr := github.ValidateSufficientOAuthScopes(response.Response); scopeErr != nil {
 				ui.Errorln()
 				ui.Errorln(scopeErr)

--- a/commands/api.go
+++ b/commands/api.go
@@ -285,6 +285,10 @@ func apiCommand(_ *Command, args *Args) {
 		response.Body.Close()
 
 		if !success {
+			if scopeErr := github.ValidateSufficientOAuthScopes(response.Response); scopeErr != nil {
+				ui.Errorln()
+				ui.Errorln(scopeErr)
+			}
 			os.Exit(22)
 		}
 

--- a/features/api.feature
+++ b/features/api.feature
@@ -491,3 +491,22 @@ Feature: hub api
     When I run `hub api --obey-ratelimit hello`
     Then the exit status should be 22
     Then the stderr should not contain "API rate limit exceeded"
+
+  Scenario: Warn about insufficient OAuth scopes
+    Given the GitHub API server:
+      """
+      get('/hello') {
+        response.headers['X-Accepted-Oauth-Scopes'] = 'repo, admin'
+        response.headers['X-Oauth-Scopes'] = 'public_repo'
+        status 403
+        json({})
+      }
+      """
+    When I run `hub api hello`
+    Then the exit status should be 22
+    And the output should contain exactly:
+      """
+      {}
+      Your access token may have insufficient scopes. Visit http://github.com/settings/tokens
+      to edit the 'hub' token and enable one of the following scopes: admin, repo
+      """

--- a/features/api.feature
+++ b/features/api.feature
@@ -510,3 +510,21 @@ Feature: hub api
       Your access token may have insufficient scopes. Visit http://github.com/settings/tokens
       to edit the 'hub' token and enable one of the following scopes: admin, repo
       """
+
+  Scenario: Print the SSO challenge to stderr
+    Given the GitHub API server:
+      """
+      get('/orgs/acme') {
+        response.headers['X-GitHub-SSO'] = 'required; url=http://example.com?auth=HASH'
+        status 403
+        json({})
+      }
+      """
+    When I run `hub api orgs/acme`
+    Then the exit status should be 22
+    And the stderr should contain exactly:
+      """
+      
+      You must authorize your token to access this organization:
+      http://example.com?auth=HASH
+      """

--- a/features/api.feature
+++ b/features/api.feature
@@ -524,7 +524,7 @@ Feature: hub api
     Then the exit status should be 22
     And the stderr should contain exactly:
       """
-      
+
       You must authorize your token to access this organization:
       http://example.com?auth=HASH
       """

--- a/features/gist.feature
+++ b/features/gist.feature
@@ -157,6 +157,7 @@ Feature: hub gist
       """
       post('/gists') {
         status 404
+        response.headers['x-accepted-oauth-scopes'] = 'gist'
         response.headers['x-oauth-scopes'] = 'repos'
         json({})
       }
@@ -170,7 +171,30 @@ Feature: hub gist
     And the stderr should contain exactly:
       """
       Error creating gist: Not Found (HTTP 404)
-      Go to https://github.com/settings/tokens and enable the 'gist' scope for hub\n
+      Your access token may have insufficient scopes. Visit http://github.com/settings/tokens
+      to edit the 'hub' token and enable one of the following scopes: gist
+      """
+
+  Scenario: Infer correct OAuth scopes for gist
+    Given the GitHub API server:
+      """
+      post('/gists') {
+        status 404
+        response.headers['x-oauth-scopes'] = 'repos'
+        json({})
+      }
+      """
+    Given a file named "testfile.txt" with:
+      """
+      this is a test file
+      """
+    When I run `hub gist create testfile.txt`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      Error creating gist: Not Found (HTTP 404)
+      Your access token may have insufficient scopes. Visit http://github.com/settings/tokens
+      to edit the 'hub' token and enable one of the following scopes: gist
       """
 
   Scenario: Create error
@@ -178,6 +202,7 @@ Feature: hub gist
       """
       post('/gists') {
         status 404
+        response.headers['x-accepted-oauth-scopes'] = 'gist'
         response.headers['x-oauth-scopes'] = 'repos, gist'
         json({})
       }

--- a/github/http.go
+++ b/github/http.go
@@ -41,6 +41,11 @@ const (
 var inspectHeaders = []string{
 	"Authorization",
 	"X-GitHub-OTP",
+	"X-GitHub-SSO",
+	"X-Oauth-Scopes",
+	"X-Accepted-Oauth-Scopes",
+	"X-Oauth-Client-Id",
+	"X-GitHub-Enterprise-Version",
 	"Location",
 	"Link",
 	"Accept",

--- a/github/http.go
+++ b/github/http.go
@@ -341,8 +341,9 @@ func (c *simpleClient) cacheRead(key string, req *http.Request) (res *http.Respo
 		}
 
 		res = &http.Response{
-			Body:   ioutil.NopCloser(bytes.NewBufferString(parts[1])),
-			Header: http.Header{},
+			Body:    ioutil.NopCloser(bytes.NewBufferString(parts[1])),
+			Header:  http.Header{},
+			Request: req,
 		}
 		headerLines := strings.Split(parts[0], "\r\n")
 		if len(headerLines) < 1 {


### PR DESCRIPTION
- If a 403 is due to SSO challenge, display the URL to authorize the token
- If a 403/404 is due to insufficient OAuth tokens, display the notice

Fixes #2147