### PR TITLE
Add instructions for GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ Ubuntu | [Snap](https://snapcraft.io) | `snap install hub --classic`
 [compiled binaries](https://github.com/github/hub/releases) and put it anywhere
 in your executable path.
 
+#### GitHub Actions
+
+hub can be used for automation through [GitHub Actions][] workflows:
+```yaml
+steps:
+- uses: actions/checkout@v2
+
+- name: hub example
+  shell: bash
+  run: |
+    curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+    bin/hub pr list  # list pull requests in the current repo
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Note that the default GITHUB_TOKEN will only work for API operations within _the
+same repo that runs this workflow_. If you need to access or write to other
+repositories, [generate a Personal Access Token][pat] with `repo` scope and add
+it to your [repository secrets][].
+
+
+[github actions]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions
+[pat]: https://github.com/settings/tokens
+[repository secrets]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets
+
 #### Source
 
 Prerequisites for building from source are:

--- a/script/get
+++ b/script/get
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Usage: curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s <HUB_VERSION>
+#
+# Downloads the hub binary into `bin/hub` within the current directory.
+
+set -e
+
+latest-version() {
+  curl -fsi https://github.com/github/hub/releases/latest | awk -F/ '/^Location:/ {print $(NF)}'
+}
+
+HUB_VERSION="${1#v}"
+if [ -z "$HUB_VERSION" ]; then
+  latest=$(latest-version) || true
+  [ -n "$latest" ] || latest="v2.14.1"
+  cat <<MSG >&2
+Error: You must specify a version of hub via the first argument. Example:
+  curl -L <script> | bash -s ${latest#v}
+MSG
+  exit 1
+fi
+
+ARCH="amd64"
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+[[ $OS != mingw* ]] || OS="windows"
+
+download() {
+  if [ "$OS" = windows ]; then
+    zip="${1%.tgz}.zip"
+    curl -fsSLO "$zip"
+    unzip "$(basename "$zip")" bin/hub.exe
+    rm -f "$zip"
+  elif [ "$OS" = darwin ]; then
+    curl -fsSL "$1" | tar xz --strip-components=1 '*/bin/hub'
+  else
+    curl -fsSL "$1" | tar xz --strip-components=1 --wildcards '*/bin/hub'
+  fi
+}
+
+download "https://github.com/github/hub/releases/download/v$HUB_VERSION/hub-$OS-$ARCH-$HUB_VERSION.tgz"
+
+bin/hub version
+if [ -z "$GITHUB_TOKEN" ]; then
+  cat <<MSG >&2
+Warning: We recommend supplying the GITHUB_TOKEN environment variable to avoid
+being prompted for authentication.
+MSG
+fi


### PR DESCRIPTION
Also adds a simple cross-platform download script that works across all Actions environments: Ubuntu, macOS, and Windows.

Fixes #2249, closes #2259, fixes #987, closes #1585