### PR TITLE
Provide fork option to set remote.pushDefault

### DIFF
--- a/commands/fork.go
+++ b/commands/fork.go
@@ -23,6 +23,9 @@ var cmdFork = &Command{
 	--org <ORGANIZATION>
 		Fork the repository within this organization.
 
+	-d, --set-push-default
+		Set remote.pushDefault to the name of the new git remote.
+
 ## Examples:
 		$ hub fork
 		[ repo forked on GitHub ]
@@ -123,6 +126,9 @@ func fork(cmd *Command, args *Args) {
 
 		args.Before("git", "remote", "add", "-f", newRemoteName, originURL)
 		args.Before("git", "remote", "set-url", newRemoteName, url)
+		if args.Flag.Bool("--set-push-default") {
+			args.Before("git", "config", "remote.pushDefault", newRemoteName)
+		}
 
 		args.AfterFn(func() error {
 			ui.Printf("new remote: %s\n", newRemoteName)

--- a/features/fork.feature
+++ b/features/fork.feature
@@ -96,6 +96,17 @@ Feature: hub fork
     Then the output should not contain anything
     And there should be no "mislav" remote
 
+  Scenario: --set-push-default
+    Given the GitHub API server:
+      """
+      post('/repos/evilchelu/dotfiles/forks') {
+        status 202
+        json :name => 'dotfiles', :owner => { :login => 'mislav' }
+      }
+      """
+    When I successfully run `hub fork --set-push-default`
+    Then the "remote.pushDefault" config option should be "mislav"
+
   Scenario: Fork failed
     Given the GitHub API server:
       """

--- a/features/steps.rb
+++ b/features/steps.rb
@@ -184,6 +184,11 @@ Then(/^the git command should be unchanged$/) do
   assert_command_run @commands.last.sub(/^hub\b/, 'git')
 end
 
+Then(/^the "([^"]*)" config option should be "([^"]*)"$/) do |name, value|
+  run_command_and_stop %(git config --get-all "#{name}")
+  expect(last_command_started).to have_output(value)
+end
+
 Then(/^the url for "([^"]*)" should be "([^"]*)"$/) do |name, url|
   run_command_and_stop %(git config --get-all remote.#{name}.url)
   expect(last_command_started).to have_output(url)


### PR DESCRIPTION
I've only recently discovered this, but `remote.pushDefault` pairs really well with the typical GitHub open source workflow. All my pushes go to my fork, but my pulls come from the upstream. It's the missing piece of a puzzle I've been trying to solve for years. I think this excellent pairing, coupled with the fact Git itself doesn't provide a good high level way to set this option, make it an good candidate for inclusion in Hub itself. (It's also difficult to implement externally, as figuring out the name of the remote `hub fork` created is nontrivial.)

See also #2139, which attempted to add this as the *default* `fork` behavior, and was (rightfully, imo) rejected for being too disruptive.  Mentioned in the rejection is `push -u` as a possible alternative workflow. This sets the *upstream*, which is great for a branch that one intends to collaborate on with others, but for a typical forked repository, doesn't really have much value as a default `git pull` target, as nobody but you will be pushing to it.