### PR TITLE
Adding a note about cli/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This repository and its issue tracker is **not for reporting problems with
 GitHub.com** web interface. If you have a problem with GitHub itself, please
 [contact Support](https://github.com/contact).
 
+>**Interested in GitHub on CLIs?** <br>
+> GitHub is trialing a new, official CLI tool over at [cli/cli](https://github.com/cli/cli).
+
 Usage
 -----
 


### PR DESCRIPTION
Hey! 

This Pull Request simply adds a notice in the README about [cli/cli](https://github.com/cli/cli), a new alpha-stage official GitHub CLI. There are no changes to any non-documentation code.

Cheers,
Tim