### PR TITLE
Add support for determining default branch when calling hub pull-request form worktree

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -84,7 +84,9 @@ func CommondirName() (string, error) {
 	dirCmd.Stderr = nil
 	output, err := dirCmd.Output()
 	dir := firstLine(output)
-	if dir == "--git-common-dir" {
+	if err != nil {
+		return "", fmt.Errorf("Not a git repository (or any of the parent directories): .git")
+	} else if dir == "--git-common-dir" {
 		return "", fmt.Errorf("unable to determine git commondir directory")
 	}
 	return dir, err


### PR DESCRIPTION
Fixes #2484 . 

When ```hub pull-request```  is called from a worktree, hub does not correctly find the default branch for the repo. 

~This code is a bit of a hack; it attempts to check for `worktree` in the path pointed to by ```$GIT_DIR/.git``` of the worktree.~

~This should work for the default cause; however, I am not sure if it will work in all scenarios, specifically when users decide to set ```git config extensions.worktreeConfig true```~