### PR TITLE
Add openSUSE and zypper to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Arch Linux | [pacman](https://wiki.archlinux.org/index.php/pacman) | `sudo pacma
 FreeBSD | [pkg(8)](http://man.freebsd.org/pkg/8) | `pkg install hub`
 Debian | [apt(8)](https://manpages.debian.org/buster/apt/apt.8.en.html) | `sudo apt install hub`
 Ubuntu | [Snap](https://snapcraft.io) | `sudo snap install hub --classic`
+openSUSE | [Zypper](https://en.opensuse.org/SDB:Zypper_manual) | `sudo zypper install hub`
 
 Packages other than Homebrew are community-maintained (thank you!) and they
 are not guaranteed to match the [latest hub release][latest]. Check `hub


### PR DESCRIPTION
`hub` is packaged by openSUSE. This PR adds openSUSE and the coresponding
package manager to the installation instructions.