### PR TITLE
create token with different scope

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -966,8 +966,14 @@ func (client *Client) FindOrCreateToken(user, password, twoFactorCode string) (t
 		return password, nil
 	}
 
+	return client.FindOrCreateTokenWithScope(user, password, twoFactorCode, []string{"repo", "gist"})
+}
+
+func (client *Client) FindOrCreateTokenWithScope(user, password, twoFactorCode string, scope []string) (token string, err error) {
+	api := client.apiClient()
+
 	params := map[string]interface{}{
-		"scopes":   []string{"repo", "gist"},
+		"scopes":   scope,
 		"note_url": OAuthAppURL,
 	}
 


### PR DESCRIPTION
I've added a function that allows users to create tokens with different scopes.

Use case:
Im building an cmd utility that requires github api calls and to avoid being throttled, i'd like to use hubs existing code to create a token without any scope (ie public access)