### PR TITLE
Fix private data leak

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"sort"
@@ -1302,31 +1301,17 @@ func newScopeSet(s string) scopeSet {
 }
 
 func authTokenNote(num int) (string, error) {
-	n := os.Getenv("USER")
+	m := os.Getenv("HUB_MACHINE")
 
-	if n == "" {
-		n = os.Getenv("USERNAME")
-	}
-
-	if n == "" {
-		whoami := exec.Command("whoami")
-		whoamiOut, err := whoami.Output()
-		if err != nil {
-			return "", err
-		}
-		n = strings.TrimSpace(string(whoamiOut))
-	}
-
-	h, err := os.Hostname()
-	if err != nil {
-		return "", err
+	if m == "" {
+		m = "<unidentified machine>"
 	}
 
 	if num > 1 {
-		return fmt.Sprintf("hub for %s@%s %d", n, h, num), nil
+		return fmt.Sprintf("hub for %s %d", m, num), nil
 	}
 
-	return fmt.Sprintf("hub for %s@%s", n, h), nil
+	return fmt.Sprintf("hub for %s", m), nil
 }
 
 func perPage(limit, max int) int {

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -3,7 +3,7 @@ package github
 import (
 	"fmt"
 	"net/http"
-	"regexp"
+	"os"
 	"testing"
 
 	"github.com/github/hub/v2/internal/assert"
@@ -35,13 +35,19 @@ func TestAuthTokenNote(t *testing.T) {
 	note, err := authTokenNote(1)
 	assert.Equal(t, nil, err)
 
-	reg := regexp.MustCompile("hub for (.+)@(.+)")
-	assert.T(t, reg.MatchString(note))
+	assert.Equal(t, "hub for <unidentified machine>", note)
 
 	note, err = authTokenNote(2)
 	assert.Equal(t, nil, err)
+	assert.Equal(t, "hub for <unidentified machine> 2", note)
 
-	reg = regexp.MustCompile("hub for (.+)@(.+) 2")
-	assert.T(t, reg.MatchString(note))
+	os.Setenv("HUB_MACHINE", "mydevmachine")
 
+	note, err = authTokenNote(1)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "hub for mydevmachine", note)
+
+	note, err = authTokenNote(2)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "hub for mydevmachine 2", note)
 }


### PR DESCRIPTION
fix #2222
Don't read the user or hostname.
Use the value of env var HUB_MACHINE or a default value "`<unidentified machine>`".

Here is the result in my security log:
Created authorization for Personal access token (hub for `<unidentified machine>`) with gist, repo scope(s) 