### PR TITLE
Enhance `hub api` to recognise an empty array field

### DIFF
--- a/commands/api.go
+++ b/commands/api.go
@@ -40,6 +40,8 @@ var cmdAPI = &Command{
 		If <VALUE> is "true", "false", "null", or looks like a number, an
 		appropriate JSON type is used instead of a string.
 
+		If <VALUE> is "[]", an empty JSON array is used instead of a string.
+
 		It is not possible to serialize <VALUE> as a nested JSON array or hash.
 		Instead, construct the request payload externally and pass it via
 		''--input''.
@@ -334,9 +336,10 @@ func pauseUntil(timestamp int) {
 }
 
 const (
-	trueVal  = "true"
-	falseVal = "false"
-	nilVal   = "null"
+	trueVal       = "true"
+	falseVal      = "false"
+	nilVal        = "null"
+	emptyArrayVal = "[]"
 )
 
 func magicValue(value string) interface{} {
@@ -347,6 +350,8 @@ func magicValue(value string) interface{} {
 		return false
 	case nilVal:
 		return nil
+	case emptyArrayVal:
+		return []interface{}{}
 	default:
 		if strings.HasPrefix(value, "@") {
 			return string(readFile(value[1:]))


### PR DESCRIPTION
Hey, thanks for hub!

I made this tiny tweak to allow me to bypass `required_contexts` when doing staging deployments. The endpoint requires an empty array:

  <img width="658" alt="image" src="https://user-images.githubusercontent.com/14410/88570541-22dce480-d034-11ea-9ebe-acd9b03907d8.png">

But hub currently sends the JSON string `"[]"`. This change will send the empty array instead.

Changing the behaviour might not be desirable in the main repository! 😄 If nothing else, hopefully this has a bunch of useful keywords for anyone else with the same problem.

Let me know if you want me to do any additional work on it or feel free to close it if it's too niche.

Cheers,
~ Si