### PR TITLE
Use stable release names

### DIFF
--- a/script/package
+++ b/script/package
@@ -8,7 +8,7 @@ os="${1?}"
 arch="${2?}"
 version="${3?}"
 
-if [ $CI ]; then
+if [ ! -z "$CI" ]; then
   # Allows for stable references to latest release bin after publish, for example:
   # https://github.com/github/hub/releases/latest/download/hub-${os}-${arch}.tgz
   release="hub-${os}-${arch}"

--- a/script/package
+++ b/script/package
@@ -8,7 +8,13 @@ os="${1?}"
 arch="${2?}"
 version="${3?}"
 
-release="hub-${os}-${arch}-${version}"
+if [ $CI ]; then
+  # Allows for stable references to latest release bin after publish, for example:
+  # https://github.com/github/hub/releases/latest/download/hub-${os}-${arch}.tgz
+  release="hub-${os}-${arch}"
+else
+  release="hub-${os}-${arch}-${version}"
+fi
 
 case "$os" in
   darwin | freebsd | linux | netbsd | openbsd | solaris | windows ) ;;


### PR DESCRIPTION
Release using a stable name on an os-arch basis, so that scripts can easily target latest release without API tokens / requests / jq-jit-su.

This seemed more clear to discuss as a PR than as an issue.  Feel free to implement in a different way!

Thanks for hub.