### PR TITLE
Replace references to "master" branch with "main"

### DIFF
--- a/commands/browse.go
+++ b/commands/browse.go
@@ -76,15 +76,15 @@ func browse(command *Command, args *Args) {
 	localRepo, _ := github.LocalRepo()
 	if dest != "" {
 		project = github.NewProject("", dest, "")
-		branch = localRepo.MasterBranch()
+		branch = localRepo.MainBranch()
 	} else if subpage != "" && subpage != "commits" && subpage != "tree" && subpage != "blob" && subpage != "settings" {
 		project, err = localRepo.MainProject()
-		branch = localRepo.MasterBranch()
+		branch = localRepo.MainBranch()
 		utils.Check(err)
 	} else {
 		currentBranch, err := localRepo.CurrentBranch()
 		if err != nil {
-			currentBranch = localRepo.MasterBranch()
+			currentBranch = localRepo.MainBranch()
 		}
 
 		var owner string
@@ -98,9 +98,9 @@ func browse(command *Command, args *Args) {
 			}
 		}
 
-		branch, project, _ = localRepo.RemoteBranchAndProject(owner, currentBranch.IsMaster())
+		branch, project, _ = localRepo.RemoteBranchAndProject(owner, currentBranch.IsMain())
 		if branch == nil {
-			branch = localRepo.MasterBranch()
+			branch = localRepo.MainBranch()
 		}
 	}
 
@@ -111,7 +111,7 @@ func browse(command *Command, args *Args) {
 	if subpage == "commits" {
 		path = fmt.Sprintf("commits/%s", branchInURL(branch))
 	} else if subpage == "tree" || subpage == "" {
-		if !branch.IsMaster() {
+		if !branch.IsMain() {
 			path = fmt.Sprintf("tree/%s", branchInURL(branch))
 		}
 	} else {

--- a/commands/compare.go
+++ b/commands/compare.go
@@ -33,7 +33,7 @@ compare [-uc] [<OWNER>] [<BASE>...]<HEAD>
 		If a range with two dots (''A..B'') is given, it will be transformed into a
 		range with three dots.
 
-		The <BASE> portion defaults to the default branch of the repository.
+		The <BASE> portion defaults to the main branch of the repository.
 
 		The <HEAD> argument defaults to the current branch. If the current branch
 		is not pushed to a remote, the command will error.
@@ -97,8 +97,8 @@ func compare(command *Command, args *Args) {
 
 		r = remoteBranch.ShortName()
 		if remoteProject.SameAs(mainProject) {
-			if flagCompareBase == "" && remoteBranch.IsMaster() {
-				utils.Check(fmt.Errorf("the branch to compare '%s' is the default branch", remoteBranch.ShortName()))
+			if flagCompareBase == "" && remoteBranch.IsMain() {
+				utils.Check(fmt.Errorf("the branch to compare '%s' is the main branch", remoteBranch.ShortName()))
 			}
 		} else {
 			r = fmt.Sprintf("%s:%s", remoteProject.Owner, r)

--- a/commands/merge.go
+++ b/commands/merge.go
@@ -17,7 +17,7 @@ var cmdMerge = &Command{
 This creates a local merge commit in the current branch, but does not actually
 change the state of the pull request. However, the pull request will get
 auto-closed and marked as "merged" as soon as the newly created merge commit is
-pushed to the default branch of the remote repository.
+pushed to the main branch of the remote repository.
 
 To merge a pull request remotely, use ''hub pr merge''.
 

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -68,8 +68,8 @@ pull-request -i <ISSUE>
 		Push the current branch to <HEAD> before creating the pull request.
 
 	-b, --base <BASE>
-		The base branch in the "[<OWNER>:]<BRANCH>" format. Defaults to the default
-		branch of the upstream repository (usually "master").
+		The base branch in the "[<OWNER>:]<BRANCH>" format. Defaults to the main
+		branch of the upstream repository.
 
 		See the "CONVENTIONS" section of hub(1) for more information on how hub
 		selects the defaults in case of multiple git remotes.
@@ -107,7 +107,7 @@ pull-request -i <ISSUE>
 		[ opens a text editor for writing title and message ]
 		[ creates a pull request for the current branch ]
 
-		$ hub pull-request --base OWNER:master --head MYUSER:my-branch
+		$ hub pull-request --base OWNER:main --head MYUSER:my-branch
 		[ creates a pull request with explicit base and head branches ]
 
 		$ hub pull-request --browse -m "My title"

--- a/github/branch.go
+++ b/github/branch.go
@@ -43,9 +43,9 @@ func (b *Branch) Upstream() (u *Branch, err error) {
 	return
 }
 
-func (b *Branch) IsMaster() bool {
-	masterName := b.Repo.MasterBranch().ShortName()
-	return b.ShortName() == masterName
+func (b *Branch) IsMain() bool {
+	mainName := b.Repo.MainBranch().ShortName()
+	return b.ShortName() == mainName
 }
 
 func (b *Branch) IsRemote() bool {

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -104,7 +104,7 @@ func (r *GitHubRepo) CurrentBranch() (branch *Branch, err error) {
 	return
 }
 
-func (r *GitHubRepo) MasterBranch() *Branch {
+func (r *GitHubRepo) MainBranch() *Branch {
 	if remote, err := r.MainRemote(); err == nil {
 		return r.DefaultBranch(remote)
 	}

--- a/share/man/man1/hub.1.md
+++ b/share/man/man1/hub.1.md
@@ -110,8 +110,7 @@ When working with forks, it's recommended that the git remote for your own fork
 is named "origin" and that the git remote for the upstream repository is named
 "upstream". See <https://help.github.com/articles/configuring-a-remote-for-a-fork/>
 
-The default branch (usually "master") for the current repository is detected
-like so:
+The main branch for the current repository is detected like so:
 
     git symbolic-ref refs/remotes/origin/HEAD
 


### PR DESCRIPTION
The main branch of a repository isn't "usually master" anymore, at least not on GitHub.
https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/