### PR TITLE
[Enhancement] git configs for hub-fork

### DIFF
--- a/commands/fork.go
+++ b/commands/fork.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/github/hub/v2/github"
+	"github.com/github/hub/v2/git"
 	"github.com/github/hub/v2/ui"
 	"github.com/github/hub/v2/utils"
 )
@@ -67,6 +68,8 @@ func fork(cmd *Command, args *Args) {
 	var newRemoteName string
 	if flagForkRemoteName := args.Flag.Value("--remote-name"); flagForkRemoteName != "" {
 		newRemoteName = flagForkRemoteName
+	} else if forkRemoteDefaultName, _ := git.GlobalConfig("hub.forkRemote"); forkRemoteDefaultName != "" {
+		newRemoteName = forkRemoteDefaultName
 	} else {
 		newRemoteName = forkProject.Owner
 	}

--- a/commands/fork.go
+++ b/commands/fork.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"fmt"
 
-	"github.com/github/hub/v2/github"
 	"github.com/github/hub/v2/git"
+	"github.com/github/hub/v2/github"
 	"github.com/github/hub/v2/ui"
 	"github.com/github/hub/v2/utils"
 )
@@ -133,16 +133,16 @@ func fork(cmd *Command, args *Args) {
 		args.Before("git", "remote", "add", "-f", newRemoteName, originURL)
 		args.Before("git", "remote", "set-url", newRemoteName, url)
 
-		if func(args *Args)bool {
+		if func(args *Args) bool {
 			config, _ := git.GlobalConfig("hub.fork.setDefault")
 			switch config {
-				case
-					"yes",
-					"true",
-					"always":
-						return !args.Flag.Bool("--no-set-push-default")
-					}
-					return args.Flag.Bool("--set-push-default")
+			case
+				"yes",
+				"true",
+				"always":
+				return !args.Flag.Bool("--no-set-push-default")
+			}
+			return args.Flag.Bool("--set-push-default")
 		}(args) {
 			args.Before("git", "config", "remote.pushDefault", newRemoteName)
 		}


### PR DESCRIPTION
Changes
========
  * get fork remote name from `git config`
  * set `remote.pushDefault` from `git config` or `args`

### git-config keys
  `hub.fork.remote`: remote name of fork
  `hub.fork.setDefault`: set remote.pushDefault if true

Similar: #2457

previous: #2647