### PR TITLE
Upgrade aruba to stable release ~v1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'aruba', '~> 1.0.0.pre.alpha.4'
+gem 'aruba', '~> 1.0.0'
 gem 'cucumber', '~> 3.1.2'
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aruba (1.0.0.pre.alpha.4)
-      childprocess (~> 1.0)
-      contracts (~> 0.13)
-      cucumber (>= 2.4, < 4.0)
-      ffi (~> 1.9)
+    aruba (1.0.4)
+      childprocess (>= 2.0, < 5.0)
+      contracts (~> 0.16.0)
+      cucumber (>= 2.4, < 6.0)
       rspec-expectations (~> 3.4)
-      thor (~> 0.19)
-    backports (3.15.0)
-    builder (3.2.3)
-    childprocess (1.0.1)
-      rake (< 13.0)
+      thor (~> 1.0)
+    backports (3.20.2)
+    builder (3.2.4)
+    childprocess (4.0.0)
     contracts (0.16.0)
     cucumber (3.1.2)
       builder (>= 2.1.2)
@@ -29,27 +27,30 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
+<<<<<<< Updated upstream
     diff-lcs (1.3)
     ffi (1.11.1)
     ffi (1.11.1-java)
+=======
+    diff-lcs (1.4.4)
+>>>>>>> Stashed changes
     gherkin (5.1.0)
-    multi_json (1.13.1)
+    multi_json (1.15.0)
     multi_test (0.1.2)
     mustermann (1.0.3)
     rack (2.0.7)
     rack-protection (2.0.5)
       rack
-    rake (12.3.3)
-    rspec-expectations (3.8.4)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.2)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
     sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
       rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    thor (0.20.3)
+    thor (1.1.0)
     tilt (2.0.9)
 
 PLATFORMS
@@ -57,7 +58,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aruba (~> 1.0.0.pre.alpha.4)
+  aruba (~> 1.0.0)
   cucumber (~> 3.1.2)
   sinatra
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,13 +27,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-<<<<<<< Updated upstream
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     ffi (1.11.1)
     ffi (1.11.1-java)
-=======
-    diff-lcs (1.4.4)
->>>>>>> Stashed changes
     gherkin (5.1.0)
     multi_json (1.15.0)
     multi_test (0.1.2)


### PR DESCRIPTION
The alpha release was firing warnings under Ruby 3.0.0 because
it was doing something deprecated with Pathname.