### PR TITLE
Ask for a token, not a password

### DIFF
--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -31,7 +31,7 @@ Feature: OAuth authentication
     When I type "mislav"
     And I type "kitty"
     Then the output should contain "github.com username:"
-    And the output should contain "github.com password for mislav (never stored):"
+    And the output should contain "github.com access token with scope 'repo' for mislav (generate one at https://github.com/settings/tokens):"
     And the exit status should be 0
     And the file "~/.config/hub" should contain "user: MiSlAv"
     And the file "~/.config/hub" should contain "oauth_token: OTOKEN"
@@ -168,7 +168,7 @@ Feature: OAuth authentication
     Given $GITHUB_USER is "mislav"
     And $GITHUB_PASSWORD is "kitty"
     When I successfully run `hub create`
-    Then the output should not contain "github.com password for mislav"
+    Then the output should not contain "github.com access token with scope 'repo' for mislav"
     And the file "../home/.config/hub" should contain "oauth_token: OTOKEN"
 
   Scenario: XDG: legacy config found, credentials from GITHUB_USER & GITHUB_PASSWORD
@@ -380,7 +380,7 @@ Feature: OAuth authentication
     When I type "mislav"
     And I type "kitty"
     And I type "112233"
-    Then the output should contain "github.com password for mislav (never stored):"
+    Then the output should contain "github.com access token with scope 'repo' for mislav (generate one at https://github.com/settings/tokens):"
     Then the output should contain "two-factor authentication code:"
     And the output should not contain "warning: invalid two-factor code"
     And the exit status should be 0
@@ -438,7 +438,7 @@ Feature: OAuth authentication
     When I run `hub create` interactively
     When I type "mislav@example.com"
     And I type "my pass@phrase ok?"
-    Then the output should contain "github.com password for mislav@example.com (never stored):"
+    Then the output should contain "github.com access token with scope 'repo' for mislav@example.com (generate one at https://github.com/settings/tokens):"
     And the exit status should be 0
     And the file "../home/.config/hub" should contain "user: mislav"
     And the file "../home/.config/hub" should contain "oauth_token: OTOKEN"
@@ -466,7 +466,7 @@ Feature: OAuth authentication
     When I run `hub fork` interactively
     And I type "mislav"
     And I type "kitty"
-    Then the output should contain "git.my.org password for mislav (never stored):"
+    Then the output should contain "git.my.org access token with scope 'repo' for mislav (generate one at https://git.my.org/settings/tokens):"
     And the exit status should be 0
     And the file "../home/.config/hub" should contain "git.my.org"
     And the file "../home/.config/hub" should contain "user: mislav"

--- a/github/config.go
+++ b/github/config.go
@@ -163,7 +163,7 @@ func (c *Config) PromptForPassword(host, user string) (pass string) {
 		return
 	}
 
-	ui.Printf("%s password for %s (never stored): ", host, user)
+	ui.Printf("%s access token with scope 'repo' for %s (generate one at https://%s/settings/tokens): ", host, user, host)
 	if ui.IsTerminal(os.Stdin) {
 		if password, err := getPassword(); err == nil {
 			pass = password


### PR DESCRIPTION
According to [this comment][ref], the usage of a password is currently broken but it is possible to pass an access token instead.

This access token is then stored in the configuration file, so adjust the message to ask for an access token, tell the user where then can generate a new one, provide the required scope, and do not tell that the vqlue is not stored.

[ref]: https://github.com/github/hub/issues/2655#issuecomment-735836048

This would help people who are configuring a new account figure out what is going on more quickly :wink: 