### PR TITLE
Note XDG completion convention

### DIFF
--- a/etc/README.md
+++ b/etc/README.md
@@ -14,8 +14,8 @@ Homebrew programs](https://docs.brew.sh/Shell-Completion).
 Open your `.bashrc` file if you're on Linux, or your `.bash_profile` if you're on macOS and add:
 
 ```sh
-if [ -f /path/to/hub.bash_completion ]; then
-  . /path/to/hub.bash_completion
+if [ -f /path/to/hub.bash_completion.sh ]; then
+  . /path/to/hub.bash_completion.sh
 fi
 ```
 

--- a/etc/README.md
+++ b/etc/README.md
@@ -19,6 +19,14 @@ if [ -f /path/to/hub.bash_completion.sh ]; then
 fi
 ```
 
+Alternatively, to have completions dynamically loaded 
+(see the [bash-completion FAQ](https://github.com/scop/bash-completion#faq)):
+
+```sh
+cd ~/.local/share/bash-completion/completions/
+ln -s /path/to/hub.bash_completion.sh hub.bash
+```
+
 ## zsh
 
 Copy the file `etc/hub.zsh_completion` from the location where you downloaded


### PR DESCRIPTION
This enables dynamic loading of `hub` completions.

It might also make sense to move the file so that it "just works" with `stow`:

13:39 jean@X1:~/.local/stow/hub-linux-amd64-2.14.2$ mkdir -p share/bash-completion/completions
13:39 jean@X1:~/.local/stow/hub-linux-amd64-2.14.2$ mv etc/hub.bash_completion.sh share/bash-completion/completions/hub.bash
13:41 jean@X1:~/.local/stow$ stow -v hub-linux-amd64-2.14.2
LINK: share/bash-completion => ../stow/hub-linux-amd64-2.14.2/share/bash-completion
13:41 jean@X1:~/.local/stow$ ls ../share/bash-completion/completions/
hub.bash