### PR TITLE
Make pull request 404s print a less useless message.

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -135,7 +135,7 @@ func (client *Client) CreatePullRequest(project *Project, params map[string]inte
 	if err = checkStatus(201, "creating pull request", res, err); err != nil {
 		if res != nil && res.StatusCode == 404 {
 			projectURL := strings.SplitN(project.WebURL("", "", ""), "://", 2)[1]
-			err = fmt.Errorf("%s\nAre you sure that %s exists?", err, projectURL)
+			err = fmt.Errorf("%s\nAre you sure that %s/%s at %s exists?", err, project.Owner, project.Name, projectURL)
 		}
 		return
 	}


### PR DESCRIPTION
```
Error creating pull request: Not Found (HTTP 404)
Not Found
Are you sure that github.com/tgstation/tgstation exists?
```

![image](https://user-images.githubusercontent.com/7069733/155861096-7dbc886e-453a-4b85-ab11-cc46762638bb.png)

(from: https://github.com/tgstation/tgstation/runs/5346803418?check_suite_focus=true#step:8:50 )
yes, i very much am sure it exists.

Without knowing the details of the url it tried, nobody can try to figure out this message, and projectURL is not the url that 404ed, its the api url, so any error message has to print the same info the api url is constructed from to make fixing it possible.

(This won't help us in time, we only use hub to make pull requests and this experience has reminded us about how impossible it is to debug bad code in 3rd party libraries and tools since any changes with extra debug info won't bubble downstream in time to be useful. We'll likely end up making a batch script to do this instead.)



> Ya, no, i'm not playing this game.
> 
> The info the pr adds is needed *to diagnose the bug*.
> 
> I need to see what the script is seeing, it runs in a github action triggered by another github action, without an error message that prints the inputs and computed values its erroring on, I can't even begin to figure out why it says it 404s
> 
> I'm gonna re-open this pr.