### PR TITLE
hub-apply docs: Add -L option to curl examples

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -22,7 +22,7 @@ var cmdApply = &Command{
 
 ## Examples:
 		$ hub apply https://github.com/jingweno/gh/pull/55
-		> curl https://github.com/jingweno/gh/pull/55.patch -o /tmp/55.patch
+		> curl https://github.com/jingweno/gh/pull/55.patch -o /tmp/55.patch -L
 		> git apply /tmp/55.patch
 
 ## See also:
@@ -46,7 +46,7 @@ var cmdAm = &Command{
 
 ## Examples:
 		$ hub am -3 https://github.com/jingweno/gh/pull/55
-		> curl https://github.com/jingweno/gh/pull/55.patch -o /tmp/55.patch
+		> curl https://github.com/jingweno/gh/pull/55.patch -o /tmp/55.patch -L
 		> git am -3 /tmp/55.patch
 
 ## See also:


### PR DESCRIPTION
The request to
`https://github.com/jingweno/gh/pull/55.patch`
is redirected to
`https://patch-diff.githubusercontent.com/raw/jingweno/gh/pull/55.patch`
but cURL doesn't follow redirects by default, letting the download fail silently