### PR TITLE
Use go -trimpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ export GO111MODULE=on
 unexport GOPATH
 
 export LDFLAGS := -extldflags '$(LDFLAGS)'
-export GCFLAGS := all=-trimpath '$(PWD)'
-export ASMFLAGS := all=-trimpath '$(PWD)'
+export GCFLAGS :=
+export ASMFLAGS :=
 
 MIN_COVERAGE = 90.2
 

--- a/script/build
+++ b/script/build
@@ -17,6 +17,7 @@ build_hub() {
 	  -ldflags "-X github.com/github/hub/v2/version.Version=`./script/version` $LDFLAGS" \
 	  -gcflags "$GCFLAGS" \
 	  -asmflags "$ASMFLAGS" \
+	  -trimpath \
 	  -o "$1"
 }
 


### PR DESCRIPTION
Use `go -trimpath`

per golang/go#63851 this is the recommended way to achieve reproducible builds.

This patch was done while working on reproducible builds for openSUSE.